### PR TITLE
Add constraints from weak deps to the registry tests

### DIFF
--- a/test/registry.jl
+++ b/test/registry.jl
@@ -34,6 +34,7 @@ function provider(
             for (r, c) in info.compat
                 v in r && mergewith!(∩, comp[v], c)
             end
+            hasfield(typeof(info), :weak_compat) &&
             for (r, c) in info.weak_compat
                 v in r && mergewith!(∩, comp[v], c)
             end

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -34,6 +34,9 @@ function provider(
             for (r, c) in info.compat
                 v in r && mergewith!(∩, comp[v], c)
             end
+            for (r, c) in info.weak_compat
+                v in r && mergewith!(∩, comp[v], c)
+            end
         end
         foreach(sort!, values(deps))
         # scrub out excluded deps (stdlibs, julia itself)


### PR DESCRIPTION
This ensures that weak compatibility also adds constraints so that we do not resolve package versions that are incompatible with our extensions

Not sure what the best way to add a test for this is.

Fixes https://github.com/StefanKarpinski/Resolver.jl/issues/7.