### PR TITLE
add consistency check on input

### DIFF
--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -29,6 +29,30 @@ function pkg_data(
     return data
 end
 
+function validate_pkg_data_consistency(data::AbstractDict{P,<:PkgData{P}}, reqs::SetOrVec{P}) where {P}
+    available_packages = keys(data)
+
+    # Check that all required packages exist
+    for p in reqs
+        if p ∉ available_packages
+            throw(ArgumentError("Required package $p is not available in the package data"))
+        end
+    end
+
+    # Check that all dependencies exist
+    for (p, data_p) in data
+        for deps_pv in values(data_p.depends)
+            for q in deps_pv
+                if q ∉ available_packages
+                    throw(ArgumentError("Package $p depends on $q, but $q is not available in the package data"))
+                end
+            end
+        end
+
+        # Note: Compatibility constraints on unknown packages are allowed
+    end
+end
+
 function pkg_info(
     deps :: DepsProvider{P},
     reqs :: SetOrVec{P} = deps.packages;
@@ -44,6 +68,7 @@ function pkg_info(
     reqs :: SetOrVec{P} = keys(data);
     filter :: Bool = true,
 ) where {P,V}
+    validate_pkg_data_consistency(data, reqs)
     # compute interactions between packages
     interacts = Dict{P,Vector{P}}(p => P[] for p in keys(data))
     for (p, data_p) in data


### PR DESCRIPTION
ensures that we get a good error message in case we give bad input data to the resolver.

Fixes #8 

I originally also checked that all constrainted packages are known but this does not work for weak dependencies since they might never end up in the full "dependency graph":

```
registry resolve: Error During Test at /Users/kc/JuliaPkgs/Pkg.jl/Resolver.jl/test/runtests.jl:164
  Got exception outside of a @test
  ArgumentError: Package Polynomials has compatibility constraints with Makie, but Makie is not available in the package data
```

We would need to add some "dummy entry" for the weak deps (basically a package that is not required, has no versions and no deps/compat) if we want to have that stronger check of only having constraints on known packages. 

Edit: Maybe these weak dep entries are added in https://github.com/StefanKarpinski/Resolver.jl/blob/main/bin/Registries.jl?