### PR TITLE
Do not delete required packages without versions 

### DIFF
--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -4,7 +4,7 @@ function filter_pkg_info!(
 ) where {P,V}
     mark_reachable!(info, reqs)
     mark_necessary!(info)
-    drop_unmarked!(info)
+    drop_unmarked!(info, reqs)
 end
 
 """
@@ -187,6 +187,7 @@ end
 
 function drop_unmarked!(
     info′ :: Dict{P, <: PkgInfo{P}},
+    reqs  :: SetOrVec{P} = keys(info′),
     info  :: Dict{P, <: PkgInfo{P}} = info′,
 ) where {P}
     # info[p].conflicts[:, end] bits definitive (row flags)
@@ -226,8 +227,8 @@ function drop_unmarked!(
         # active version masks
         I = X[1:end-1, end]
         K = X[end, 1:end-1]
-        # delete if no active versions
-        if !any(I)
+        # delete non-required if no active versions
+        if !any(I) && p ∉ reqs
             delete!(info′, p)
             continue
         end
@@ -296,7 +297,7 @@ function drop_excluded!(
             end
         end
     end
-    drop_unmarked!(info)
+    drop_unmarked!(info, P[])
 end
 
 function check_info_structure(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,16 @@ end
 end
 
 using Resolver: PkgData
+
+@testset "required packages with no version" begin
+    data = Dict(
+           :PkgA => PkgData(Symbol[], Dict{Symbol,Vector{Symbol}}(), Dict{Symbol,Dict{Symbol,Any}}()),
+           :PkgB => PkgData(Symbol[:v1], Dict{Symbol,Vector{Symbol}}(), Dict{Symbol,Dict{Symbol,Any}}()),
+       )
+    pkgs, vers = resolve(data, [:PkgA, :PkgB])
+    @test vers == [nothing; :v1;;]
+end
+
 @testset "consistency validation" begin
     # Test missing dependency
     data = Dict(


### PR DESCRIPTION
Required packages are assumed to exist later in the resolver process.

On the main branch the added test case fails with:

```julia
  Got exception outside of a @test
  KeyError: key :PkgA not found
  Stacktrace:
    [1] getindex(h::Dict{Symbol, Int64}, key::Symbol)
      @ Base ./dict.jl:478
    [2] sat_assume (repeats 2 times)
      @ ~/JuliaPkgs/Pkg.jl/Resolver.jl/src/SAT.jl:124 [inlined]
    [3] #sat_assume##0
      @ ~/JuliaPkgs/Pkg.jl/Resolver.jl/src/SAT.jl:127 [inlined]
    [4] foreach
      @ ./abstractarray.jl:3202 [inlined]
    [5] sat_assume
      @ ~/JuliaPkgs/Pkg.jl/Resolver.jl/src/SAT.jl:126 [inlined]
    [6] is_satisfiable(sat::Resolver.SAT{Symbol, Symbol}, reqs::Vector{Symbol})
```

This is a common source of errors in the Pkg test suite when running with the SAT solver since the previous resolver just said the problem was infeasible and threw a `ResolverError` while this resolver errors in its internals.