### PR TITLE
update CI: macos-latest is aarch64, not x64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         include:
           - os: macos-latest
             arch: aarch64
+          - os: macos-15-intel
+            arch: x64
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,14 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
         arch:
           - x64
           - x86
-        # 32-bit Julia binaries are not available on macOS
-        exclude:
-          - os: macOS-latest
-            arch: x86
+        # macos-14and newer (Apple M series) only support aarch64 architecture
+        include:
+          - os: macos-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         arch:
           - x64
           - x86
-        # macos-14and newer (Apple M series) only support aarch64 architecture
+        # macos-14 and newer (Apple M series) only support aarch64 architecture
         include:
           - os: macos-latest
             arch: aarch64


### PR DESCRIPTION
This is why macOS CI fails in https://github.com/StefanKarpinski/Resolver.jl/pull/17 