### PR TITLE
Include package + version list when throwing Unsatisfiable error

### DIFF
--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -334,14 +334,6 @@ reg = registry_provider(
 pkg_info = Resolver.pkg_info(reg, reqs)
 pkgs, vers = resolve(pkg_info, reqs; max=1, by=sort_packages_by)
 
-# error if unsatisfiable
-for uuid in reqs
-    i = findfirst(==(uuid), pkgs)
-    isnothing(vers[i]) && error("Unsatisfiable")
-end
-
-## output results
-
 const julia_version = vers[findfirst(==(JULIA_UUID), pkgs)]
 const stdlibs = let last_stdlibs = UNREGISTERED_STDLIBS
     for (v, this_stdlibs) in STDLIBS_BY_VERSION
@@ -350,6 +342,19 @@ const stdlibs = let last_stdlibs = UNREGISTERED_STDLIBS
     end
     last_stdlibs
 end
+
+# error if unsatisfiable
+vers_in_reqs = map(uuid -> vers[findfirst(==(uuid), pkgs)], reqs)
+if any(isnothing, vers_in_reqs)
+    buf = IOBuffer()
+    for (uuid, pkgvers) in zip(reqs, vers_in_reqs)
+        pkgname = uuid in keys(packages) ? first(packages[uuid]).name : stdlibs[uuid].name
+        println(buf, "\t$uuid $pkgname => $pkgvers")
+    end
+    error("Unsatisfiable:\n$(String(take!(buf)))")
+end
+
+## output results
 
 struct ManifestEntry
     name :: String


### PR DESCRIPTION
Doing so helps with debugging the source of an unsatisfiable constraint, by tracking down the source of a `nothing` version being implied.

**Minimal project**
```
[deps]
LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
```

**Clearer errors**
```bash
$ julia +1.10 ~/ext/Resolver.jl/bin/resolve.jl --julia=1.9.0 --min=@alldeps --print-versions .
ERROR: LoadError: Unsatisfiable:
        1222c4b2-2114-5bfd-aeef-88e4692bbb3e julia => 1.9.0
        37e2e46d-f89d-539d-b4ee-838fcccc9c8e LinearAlgebra => nothing
        44cfe95a-1eb2-52ea-b672-e2afdf69b78f Pkg => 1.9.0
        56ddb016-857b-54e1-b83d-db4d58db5568 Logging => 1.9.0

Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ ~/ext/Resolver.jl/bin/resolve.jl:354
in expression starting at ~/ext/Resolver.jl/bin/resolve.jl:348
```

The package state helps identify that the LinearAlgebra stdlib is the source of the problem. (See also [this discourse post](https://discourse.julialang.org/t/unsolvable-environment-with-julia-downgrade-compat-due-to-libblastrampoline-jll-on-julia-v1-9/136094).)