### PR TITLE
fix: always include pinned stdlib versions in Julia's compat

### DIFF
--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -96,6 +96,10 @@ function registry_provider(
     filter_pre!(JULIA_UUID, julia_vers)
 
     stdlibs = Dict{UUID,Dict{VersionNumber,StdlibInfo}}()
+    # For each stdlib package: the (Julia version, pinned-version spec) pairs.
+    # Recorded so we can later widen the stdlib's own `julia` compat to include
+    # the Julia versions that bundle each of its versions (see the closure).
+    stdlib_pins = Dict{UUID,Vector{Tuple{VersionNumber,VersionSpec}}}()
     for julia_ver in julia_vers
         last_stdlibs = UNREGISTERED_STDLIBS
         for (v, this_stdlibs) in STDLIBS_BY_VERSION
@@ -104,6 +108,9 @@ function registry_provider(
         end
         for (uuid, stdlib_info) in last_stdlibs
             stdlib_ver = something(stdlib_info.version, julia_ver)
+            # matches the pin the JULIA_UUID branch emits below
+            push!(get!(()->valtype(stdlib_pins)(), stdlib_pins, uuid),
+                  (julia_ver, VersionSpec(stdlib_ver)))
             deps_u = get!(()->valtype(stdlibs)(), stdlibs, uuid)
             # Sometimes HistoricalStdlibVersions gives the same
             # version number to stdlib entries with different deps.
@@ -215,6 +222,36 @@ function registry_provider(
                 v in vers && continue # prefer real registry data
                 push!(vers, v)
                 deps[v] = info.deps
+            end
+        end
+        # widen a stdlib package's `julia` compat to admit the Julias that bundle it
+        #
+        # For a package that is also a stdlib, the Julia <-> stdlib version
+        # coupling is expressed authoritatively by Julia's own compat pins (see
+        # the JULIA_UUID branch above, where each Julia version pins every one
+        # of its stdlibs to an exact version). A registry entry's own `julia`
+        # compat for such a package can *disagree* with a Julia that actually
+        # bundles a given version -- e.g. CompilerSupportLibraries_jll 1.1.1
+        # ships with Julia 1.10.8+, yet the General registry marks 1.1.x as
+        # requiring `julia = "1.11.0-1"`. Left as-is, that bound makes the
+        # pinned stdlib version conflict with the very Julia that pins it, so
+        # anything pulling in the BLAS stack (LinearAlgebra -> OpenBLAS_jll ->
+        # CompilerSupportLibraries_jll) is unsatisfiable there.
+        #
+        # We *widen* rather than drop the bound: each version keeps its registry
+        # `julia` compat and additionally admits every Julia that bundles it.
+        # This is important because the same version can be a bundled stdlib for
+        # one Julia yet a resolvable dependency for another; for the latter the
+        # registry bound must still govern, so dropping it outright would wrongly
+        # make the version installable on Julias it isn't compatible with.
+        if uuid in keys(stdlib_pins)
+            for (julia_ver, ver_spec) in stdlib_pins[uuid]
+                for v in vers
+                    v in ver_spec || continue # julia_ver bundles this version
+                    comp_v = get!(()->valtype(comp)(), comp, v)
+                    comp_v[JULIA_UUID] =
+                        get(comp_v, JULIA_UUID, VersionSpec("*")) ∪ VersionSpec(julia_ver)
+                end
             end
         end
         # insert dependency on julia itself

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -1,0 +1,81 @@
+#!/usr/bin/env julia
+#
+# Regression tests for the `bin/` resolver tooling (bin/Registries.jl).
+#
+# Run from the repo root with the bin/ environment:
+#
+#     julia --project=bin bin/test/runtests.jl
+#
+# These are integration tests: they need the General registry installed and,
+# on a cold cache, network access to fetch the list of released Julia versions
+# (bin/julia_versions.json). They are intentionally *not* part of the package
+# test suite (test/runtests.jl), which is offline and exercises only src/.
+
+using Test
+import Base: UUID
+import Pkg.Registry: JULIA_UUID, PkgEntry, reachable_registries
+import Pkg.Versions: VersionSpec
+import Resolver
+
+include(joinpath(@__DIR__, "..", "Registries.jl"))
+
+# UUIDs of the packages involved in issue #24.
+const COMPILER_SUPPORT_LIBRARIES_JLL = UUID("e66e0078-7015-5450-92f7-15fbd957f2ae")
+const LINEAR_ALGEBRA = UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e")
+
+# Load packages from the installed registries (mirrors bin/resolve.jl).
+const packages = Dict{UUID,Vector{PkgEntry}}()
+for reg in reachable_registries()
+    for (uuid, entry) in reg.pkgs
+        push!(get!(()->PkgEntry[], packages, uuid), entry)
+    end
+end
+
+make_provider(julia::VersionSpec) = registry_provider(
+    packages;
+    julia_versions = julia,
+    allow_pre = Dict(UUID(0) => false),
+)
+
+# Does every requirement get a concrete version for the given Julia spec?
+function resolves(reqs::Vector{UUID}; julia::VersionSpec)
+    reg = make_provider(julia)
+    info = Resolver.pkg_info(reg, reqs)
+    pkgs, vers = Resolver.resolve(info, reqs; max = 1)
+    size(vers, 2) ≥ 1 || return false
+    all(!isnothing(vers[findfirst(==(u), pkgs), 1]) for u in reqs)
+end
+
+@testset "bin/Registries.jl" begin
+    # Issue #24: Julia 1.10.8 bundles CompilerSupportLibraries_jll 1.1.1, but the
+    # General registry's entry for 1.1.x declares `julia = "1.11.0-1"`. The
+    # provider must widen 1.1.1's `julia` compat to admit the Julia that bundles
+    # it -- while *keeping* the registry bound on versions that aren't bundled by
+    # 1.10.8, so those stay correctly incompatible (a bundled stdlib version can
+    # also be a plain resolvable dependency on another Julia, where the registry
+    # bound must still govern). Julia 1.10.8 is a frozen release, so its bundled
+    # CompilerSupportLibraries_jll (1.1.1) never changes.
+    @testset "stdlib julia-compat is widened, not cleared" begin
+        reg = make_provider(VersionSpec("1.10.8"))
+        pd = Resolver.pkg_data(reg, [COMPILER_SUPPORT_LIBRARIES_JLL])[COMPILER_SUPPORT_LIBRARIES_JLL]
+        compatible(v) = (spec = get(pd.compat[v], JULIA_UUID, nothing);
+                         spec === nothing || v"1.10.8" ∈ spec)
+        # the bundled version (1.1.1) is admitted on 1.10.8 (this is the bug fix)
+        bundled = [v for v in keys(pd.compat) if (v.major, v.minor, v.patch) == (1, 1, 1)]
+        @test !isempty(bundled)
+        @test all(compatible, bundled)
+        # but the registry bound survives elsewhere: some later version, neither
+        # bundled by 1.10.8 nor registry-compatible with it, must stay excluded
+        # (guards against clearing the bound outright)
+        @test any(!compatible(v) for v in keys(pd.compat))
+    end
+
+    # End-to-end: the minimal reproducers from issue #24 must resolve.
+    @testset "BLAS stack resolves on Julia 1.10" begin
+        # Smallest reproducer: depend directly on the culprit stdlib jll.
+        @test resolves([COMPILER_SUPPORT_LIBRARIES_JLL, JULIA_UUID]; julia = VersionSpec("1.10.8"))
+        @test resolves([COMPILER_SUPPORT_LIBRARIES_JLL, JULIA_UUID]; julia = VersionSpec("1.10"))
+        # Realistic reproducer: LinearAlgebra pulls in the same stack transitively.
+        @test resolves([LINEAR_ALGEBRA, JULIA_UUID]; julia = VersionSpec("1.10.8"))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,3 +244,15 @@ Compat = "4"
         @test VersionNumber(m.captures[1]) != v"4.0.0"
     end
 end
+
+@testset "bin/ tooling regression tests" begin
+    # The bin/ resolver tooling has its own integration tests (they need the
+    # General registry, so they live in bin/test/ and run in the bin/
+    # environment rather than as part of this package's offline suite). Run
+    # them here as a subprocess so CI exercises them too.
+    julia = Base.julia_cmd()[1]
+    project = pkgdir(Resolver, "bin")
+    tests = joinpath(project, "test", "runtests.jl")
+    run(`$julia --project=$project -e 'import Pkg; Pkg.instantiate()'`)
+    @test success(`$julia --project=$project $tests`)
+end


### PR DESCRIPTION
CompilerSupportLibraries_jll 1.1.1 is bundled with Julia 1.10.8+, but the General registry marks 1.1.x as requiring `julia = "1.11.0-1"`. The registry provider applied that bound to the stdlib-pinned version, so it conflicted with the very Julia that pins it — making any project that pulls in the BLAS stack (LinearAlgebra -> OpenBLAS_jll -> CompilerSupportLibraries_jll) unsatisfiable on those Julia patch releases. That is what surfaced as the Mooncake `Unsatisfiable` in #24 (Mooncake 0.5.x requires julia ≥ 1.10.8, which forces the target into the broken patch range).

The Julia <-> stdlib version coupling is enforced authoritatively by Julia's own compat pins, so for a stdlib package we *widen* each version's `julia` compat to also admit the Julia versions that bundle it. We widen rather than drop the registry bound because the same version can be a bundled stdlib for one Julia yet a resolvable dependency for another, where the registry bound must still govern; dropping it outright would wrongly make the version installable on Julia versions it isn't compatible with.

Add an integration regression test under bin/test/ (needs the General registry; not part of the offline package suite). It checks that the bundled version is admitted on the Julia that pins it *and* that a non-bundled, registry-incompatible version stays excluded.

Fixes #24.