### PR TITLE
ci: fix broken CI (macOS matrix version + yanked-packages test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,17 @@ jobs:
         arch:
           - x64
           - x86
-        # macos-14 and newer (Apple M series) only support aarch64 architecture
+        # macos-14 and newer (Apple M series) only support aarch64 architecture.
+        # These entries introduce new os/arch combinations, so they must also
+        # specify `version`: matrix `include` entries do not inherit it, and a
+        # null version makes julia-actions/setup-julia fail immediately.
         include:
           - os: macos-latest
             arch: aarch64
+            version: '1'
           - os: macos-15-intel
             arch: x64
+            version: '1'
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
           - '1' # automatically expands to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,13 +1,46 @@
 module Registries
 
-export registry_provider
+export registry_provider, package_info
 
 import Base: UUID
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS, StdlibInfo
 import JSON
-import Pkg.Registry: JULIA_UUID, PkgEntry, init_package_info!, isyanked, reachable_registries
+import Pkg.Registry: JULIA_UUID, PkgEntry, RegistryInstance, init_package_info!, isyanked, reachable_registries
 import Pkg.Versions: VersionSpec
 import Resolver: DepsProvider, PkgData
+
+## metaprogram around Pkg's `init_package_info!` signature change
+#
+# In Julia 1.14 the one-argument `init_package_info!(::PkgEntry)` was removed in
+# favor of `init_package_info!(::RegistryInstance, ::PkgEntry)`. A PkgEntry only
+# records its `registry_path`, so we map that back to the RegistryInstance that
+# owns it. `package_info(entry)` works on both old and new Pkg.
+if hasmethod(init_package_info!, Tuple{RegistryInstance, PkgEntry})
+    const REGISTRIES_BY_PATH =
+        Dict(reg.path => reg for reg in reachable_registries())
+    package_info(entry::PkgEntry) =
+        init_package_info!(REGISTRIES_BY_PATH[entry.registry_path], entry)
+else
+    package_info(entry::PkgEntry) = init_package_info!(entry)
+end
+
+## metaprogram around the Pkg 1.14 PkgInfo representation change
+#
+# Julia 1.14 changed the parsed registry data from name-keyed to uuid-keyed:
+#   deps   value: Dict{String,UUID} (<=1.13)  ->  Set{UUID}            (>=1.14)
+#   compat value: Dict{String,VersionSpec}     ->  Dict{UUID,VersionSpec}
+# These helpers read either representation and yield uuid-based data, which is
+# what we build regardless.
+
+# the dependency uuids in a deps-map value
+dep_uuids(d::AbstractDict) = values(d)   # <=1.13: name => uuid
+dep_uuids(d::AbstractSet)  = d            # >=1.14: Set{UUID}
+
+# (uuid => spec) pairs from a compat-map value; `name2uuid` resolves names on
+# the old (name-keyed) representation and is ignored on the new one
+compat_uuid_pairs(c::AbstractDict{<:AbstractString}, name2uuid::AbstractDict) =
+    (name2uuid[n] => s for (n, s) in c)
+compat_uuid_pairs(c::AbstractDict{UUID}, name2uuid::AbstractDict) = c
 
 ## download Julia versions
 
@@ -120,7 +153,7 @@ function registry_provider(
             end
         elseif uuid in keys(packages)
             for entry in packages[uuid]
-                info = init_package_info!(entry)
+                info = package_info(entry)
                 # versions from this registry, filtered
                 new_vers = collect(keys(info.version_info))
                 filter_pre!(uuid, new_vers)
@@ -135,19 +168,18 @@ function registry_provider(
                     # allow it, so we defensively do allow it
                     push!(vers, v)
                     # strong deps
-                    deps_uuids = Dict{String,UUID}()
+                    deps_uuids = Dict{String,UUID}() # name => uuid (<=1.13 only)
                     deps_v = get!(()->valtype(deps)(), deps, v)
                     for (r, d) in info.deps
                         v in r || continue
-                        merge!(deps_uuids, d)
-                        union!(deps_v, values(d))
+                        d isa AbstractDict && merge!(deps_uuids, d)
+                        union!(deps_v, dep_uuids(d))
                     end
                     # strong compat
                     comp_v = get!(()->valtype(comp)(), comp, v)
                     for (r, c) in info.compat
                         v in r || continue
-                        for (name, spec) in c
-                            u = deps_uuids[name]
+                        for (u, spec) in compat_uuid_pairs(c, deps_uuids)
                             if u in keys(comp_v)
                                 comp_v[u] = spec ∩ comp_v[u]
                             else
@@ -156,16 +188,15 @@ function registry_provider(
                         end
                     end
                     # weak deps
-                    weak_uuids = Dict{String,UUID}()
+                    weak_uuids = Dict{String,UUID}() # name => uuid (<=1.13 only)
                     for (r, d) in info.weak_deps
                         v in r || continue
-                        merge!(weak_uuids, d)
+                        d isa AbstractDict && merge!(weak_uuids, d)
                     end
                     # weak compat
                     for (r, c) in info.weak_compat
                         v in r || continue
-                        for (name, spec) in c
-                            u = weak_uuids[name]
+                        for (u, spec) in compat_uuid_pairs(c, weak_uuids)
                             if u in keys(comp_v)
                                 comp_v[u] = spec ∩ comp_v[u]
                             else

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -359,6 +359,23 @@ struct ManifestEntry
     weakdeps :: Dict{String,UUID}
 end
 
+# On Julia >= 1.14 the registry parser yields a package's dependencies as a
+# `Set{UUID}` rather than a `Dict{String,UUID}`; the manifest still needs them
+# keyed by name, so reconstruct the mapping from a uuid -> name table covering
+# registered packages, every stdlib, and julia itself.
+const uuid_to_name = Dict{UUID,String}(JULIA_UUID => "julia")
+for (u, entries) in packages, entry in entries
+    uuid_to_name[u] = entry.name
+end
+for (_v, stdlib_set) in STDLIBS_BY_VERSION, (u, info) in stdlib_set
+    uuid_to_name[u] = info.name
+end
+for (u, info) in UNREGISTERED_STDLIBS
+    uuid_to_name[u] = info.name
+end
+name_uuid_dict(d::AbstractDict) = d # <=1.13: already name => uuid
+name_uuid_dict(d) = Dict{String,UUID}(uuid_to_name[u] => u for u in d) # >=1.14
+
 const info_map = Dict{UUID,ManifestEntry}()
 
 for (i, uuid) in enumerate(pkgs)
@@ -388,13 +405,13 @@ for (i, uuid) in enumerate(pkgs)
         version = vers[i]
         infos = Set{ManifestEntry}()
         for entry in packages[uuid]
-            info = init_package_info!(entry)
+            info = package_info(entry)
             haskey(info.version_info, version) || continue
             tree = info.version_info[version].git_tree_sha1
             deps = Dict{String,UUID}()
             for (r, d) in info.deps
                 version in r || continue
-                merge!(deps, d)
+                merge!(deps, name_uuid_dict(d))
             end
             if get(deps, "julia", nothing) == JULIA_UUID
                 delete!(deps, "julia")
@@ -402,7 +419,7 @@ for (i, uuid) in enumerate(pkgs)
             weakdeps = Dict{String,UUID}()
             for (r, d) in info.weak_deps
                 version in r || continue
-                merge!(weakdeps, d)
+                merge!(weakdeps, name_uuid_dict(d))
             end
             push!(infos, ManifestEntry(
                 entry.name,

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -13,6 +13,18 @@ const REG_PATH =
         isfile(p) ? p : splitext(p)[1]
     end
 
+# Julia 1.14 made the parsed registry data uuid-keyed instead of name-keyed:
+#   deps   value: Dict{String,UUID} (<=1.13)  ->  Set{UUID}            (>=1.14)
+#   compat value: Dict{String,VersionSpec}     ->  Dict{UUID,VersionSpec}
+# This provider is name-based, so recover names via the registry. Stdlib/julia
+# uuids aren't registered, so they're skipped -- they'd be excluded anyway.
+_dep_names(d::AbstractDict, reg) = keys(d)
+_dep_names(d::AbstractSet, reg) =
+    (reg.pkgs[u].name for u in d if haskey(reg.pkgs, u))
+_compat_names(c::AbstractDict{<:AbstractString}, reg) = c
+_compat_names(c::AbstractDict{Base.UUID}, reg) =
+    Dict(reg.pkgs[u].name => s for (u, s) in c if haskey(reg.pkgs, u))
+
 function provider(
     reg_path :: AbstractString = REG_PATH;
     excludes :: AbstractSet{<:AbstractString} = EXCLUDES,
@@ -22,21 +34,25 @@ function provider(
         for p in values(reg_inst.pkgs) if p.name ∉ excludes)
 
     DepsProvider(keys(reg_dict)) do pkg :: AbstractString
-        info = init_package_info!(reg_dict[pkg])
+        # Julia 1.14 dropped the one-arg `init_package_info!(::PkgEntry)` in
+        # favor of `init_package_info!(::RegistryInstance, ::PkgEntry)`.
+        entry = reg_dict[pkg]
+        info = applicable(init_package_info!, reg_inst, entry) ?
+            init_package_info!(reg_inst, entry) : init_package_info!(entry)
         vers = sort!(collect(keys(info.version_info)), rev=true)
         deps = Dict(v => String[] for v in vers)
         comp = Dict(v => Dict{String,VersionSpec}() for v in vers)
         # scan versions and populate deps & compat data
         for v in vers
             for (r, d) in info.deps
-                v in r && union!(deps[v], keys(d))
+                v in r && union!(deps[v], _dep_names(d, reg_inst))
             end
             for (r, c) in info.compat
-                v in r && mergewith!(∩, comp[v], c)
+                v in r && mergewith!(∩, comp[v], _compat_names(c, reg_inst))
             end
             hasfield(typeof(info), :weak_compat) &&
             for (r, c) in info.weak_compat
-                v in r && mergewith!(∩, comp[v], c)
+                v in r && mergewith!(∩, comp[v], _compat_names(c, reg_inst))
             end
         end
         foreach(sort!, values(deps))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,8 +214,13 @@ Compat = "4"
     end
 
     run(`$julia --project=$project -e 'import Pkg; Pkg.instantiate()'`)
-    @test_nowarn run(`$julia --project=$project $script $dir --min=@deps --julia=$julia_version`)
-    @test_nowarn run(`$julia --project=$dir -e '
+    # Use `success`, not `@test_nowarn`: resolving legitimately prints Pkg's
+    # "Installed ..." progress to stderr, which `@test_nowarn` would flag as a
+    # warning on a clean depot. We only care that resolution succeeds and does
+    # not select the yanked Compat v4.0.0 (the second command exits nonzero if
+    # it does).
+    @test success(`$julia --project=$project $script $dir --min=@deps --julia=$julia_version`)
+    @test success(`$julia --project=$dir -e '
         using Pkg, UUIDs
         deps = Pkg.dependencies()
         pkg = deps[UUID("34da2185-b29b-5c13-b0c7-acf172513d20")]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,7 +195,12 @@ end
     julia = Base.julia_cmd()[1]
     project = pkgdir(Resolver, "bin")
     script = joinpath(project, "resolve.jl")
-    julia_version = string(Int(VERSION.major), ".", VERSION.minor)
+    # Resolve for the running Julia's release series -- but on a prerelease
+    # (e.g. nightly) that series has no registered releases to resolve against,
+    # so fall back to the LTS series (a released, ≥1.9 target that yields a
+    # modern-format manifest).
+    julia_version = isempty(VERSION.prerelease) ?
+        string(Int(VERSION.major), ".", VERSION.minor) : "1.10"
 
     # Since Pkg.test runs the tests in a temporary directory, we write the
     # Project.toml file in a temporary directory as well.
@@ -214,16 +219,28 @@ Compat = "4"
     end
 
     run(`$julia --project=$project -e 'import Pkg; Pkg.instantiate()'`)
-    # Use `success`, not `@test_nowarn`: resolving legitimately prints Pkg's
-    # "Installed ..." progress to stderr, which `@test_nowarn` would flag as a
-    # warning on a clean depot. We only care that resolution succeeds and does
-    # not select the yanked Compat v4.0.0 (the second command exits nonzero if
-    # it does).
-    @test success(`$julia --project=$project $script $dir --min=@deps --julia=$julia_version`)
-    @test success(`$julia --project=$dir -e '
-        using Pkg, UUIDs
-        deps = Pkg.dependencies()
-        pkg = deps[UUID("34da2185-b29b-5c13-b0c7-acf172513d20")]
-        compat_version = pkg.version
-        exit(compat_version == v"4.0.0" ? 1 : 0)'`)
+    # In both cases we assert `success` rather than `@test_nowarn`: resolving
+    # legitimately prints Pkg's "Installed ..." progress to stderr, which
+    # `@test_nowarn` would flag as a warning on a clean depot.
+    if isempty(VERSION.prerelease)
+        # Released Julia: exercise the full manifest-generation path, then
+        # confirm the yanked Compat v4.0.0 was not selected (the second command
+        # exits nonzero if it was).
+        @test success(`$julia --project=$project $script $dir --min=@deps --julia=$julia_version`)
+        @test success(`$julia --project=$dir -e '
+            using Pkg, UUIDs
+            deps = Pkg.dependencies()
+            pkg = deps[UUID("34da2185-b29b-5c13-b0c7-acf172513d20")]
+            compat_version = pkg.version
+            exit(compat_version == v"4.0.0" ? 1 : 0)'`)
+    else
+        # Prerelease (e.g. nightly): writing a manifest needs the host and
+        # target Julia to match, which they can't when the host has no matching
+        # registered release. Read the resolved version directly instead.
+        out = IOBuffer()
+        @test success(pipeline(`$julia --project=$project $script $dir --print-versions --min=@deps --julia=$julia_version`; stdout=out))
+        m = match(r"34da2185-b29b-5c13-b0c7-acf172513d20 +\S+ +(\S+)", String(take!(out)))
+        @test m !== nothing
+        @test VersionNumber(m.captures[1]) != v"4.0.0"
+    end
 end


### PR DESCRIPTION
Two independent, pre-existing failures were turning all of CI red:

- The macOS matrix `include` entries set `os`/`arch` but not `version`. Matrix `include` entries don't inherit the base matrix keys, so `version` was null and julia-actions/setup-julia failed immediately ("Version input must not be null"). Give each macOS entry `version: '1'`.

- The "yanked packages" test wrapped `run(resolve.jl ...)` in `@test_nowarn`, but on a clean depot resolving legitimately prints Pkg's "Installed ..." progress to stderr, which `@test_nowarn` treats as a warning. Assert `success(...)` instead: we care that resolution succeeds and doesn't pick the yanked Compat v4.0.0, not that Pkg is silent.