### PR TITLE
ci: update GitHub Actions to current versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
             arch: x64
             version: '1'
     steps:
-      - uses: actions/checkout@v5
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         env:
           cache-name: cache-artifacts
         with:
@@ -54,6 +54,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
-          file: lcov.info
+          files: lcov.info


### PR DESCRIPTION
## Summary

Brings the CI GitHub Actions up to their current latest majors. This supersedes the three stale dependabot PRs (#14/#17/#20, now closed) and goes a bit further, since some actions have released newer majors since those PRs were opened.

I checked the current latest release of every action used in the workflows:

| action | before | after | notes |
|---|---|---|---|
| `actions/checkout` | v5 | **v7** | |
| `julia-actions/setup-julia` | v2 | **v3** | |
| `actions/cache` | v4 | **v6** | |
| `codecov/codecov-action` | v4 | **v7** | also renames the deprecated `file:` input to `files:` (required since v5) |
| `julia-actions/julia-buildpkg` | v1 | v1 | latest is v1.7.0 — `@v1` already tracks it |
| `julia-actions/julia-runtest` | v1 | v1 | latest is v1.12.0 |
| `julia-actions/julia-processcoverage` | v1 | v1 | latest is v1.2.2 |
| `JuliaRegistries/TagBot` | v1 | v1 | latest is v1.25.9 |

## Notes

- **`setup-julia` v2 → v3** has breaking changes, but none affect this workflow: it doesn't use `version: min`, and the macOS matrix already pairs `macos-15-intel` with `x64` and `macos-latest` with `aarch64`, so there's no x86_64-on-Apple-Silicon request (which v3 now errors on).
- The newer majors of `checkout`/`cache` also move to Node 24, clearing the "Node 20 is deprecated" warnings that were showing in the logs.
- `codecov-action` is non-blocking (`fail_ci_if_error` defaults to `false`), and tokenless upload is supported for public repos, so the v7 bump won't gate the build.

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
