### PR TITLE
Documenter docs with a theory section: layered semantics, filtering proofs, and the Pareto-front analysis

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,28 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+    branches:
+      - main
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - name: Install dependencies
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia --project=docs docs/make.jl

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Resolver = "ecd60e94-5748-11e9-04dc-1fe0f95e4121"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,26 @@
+using Documenter
+using Resolver
+
+makedocs(
+    sitename = "Resolver.jl",
+    modules = [Resolver],
+    format = Documenter.HTML(
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        canonical = "https://stefankarpinski.github.io/Resolver.jl",
+    ),
+    pages = [
+        "Home" => "index.md",
+        "API" => "api.md",
+        "Theory" => [
+            "Setting" => "theory/setting.md",
+            "The layered solution & filtering" => "theory/layered.md",
+            "Pareto front optimality" => "theory/front.md",
+        ],
+    ],
+)
+
+deploydocs(
+    repo = "github.com/StefanKarpinski/Resolver.jl",
+    devbranch = "main",
+    push_preview = true,
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,11 @@
+# API
+
+```@docs
+resolve
+```
+
+## Internals
+
+```@docs
+Resolver.find_reachable
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,24 @@
+# Resolver.jl
+
+A package version resolver built on a real SAT solver (PicoSAT). Given
+package data — versions, dependencies, and compatibility constraints — and a
+set of required packages, [`resolve`](@ref) returns a single optimal solution
+mapping each needed package to a version, or `nothing` when the requirements
+cannot be satisfied.
+
+What "optimal" means, precisely, and why the resolver's aggressive problem
+filtering provably does not change the answer, is worked out in the Theory
+section:
+
+- [Setting](theory/setting.md) — the resolution problem, solutions,
+  tightness, and the SAT encoding.
+- [The layered solution & filtering](theory/layered.md) — the semantics the
+  resolver implements, and proofs that filtering preserves both
+  satisfiability and the answer.
+- [Pareto front optimality](theory/front.md) — an alternative, purely
+  declarative notion of optimality that was fully worked out and ultimately
+  set aside; its theorems and counterexamples illuminate why the layered
+  semantics and its filter fit together as well as they do.
+
+For the package's motivation and project status, see the
+[README](https://github.com/StefanKarpinski/Resolver.jl).

--- a/docs/src/theory/front.md
+++ b/docs/src/theory/front.md
@@ -1,0 +1,271 @@
+# Pareto front optimality
+
+This page documents a fully worked-out *alternative* semantics for the
+resolver — necessity on the Pareto front — including its theorems, its
+pure-SAT implementation, and the reasons it was ultimately set aside. It is
+a digression from what the package implements, but a productive one: its
+impossibility results explain *why* the layered semantics and the filter
+fit together, its proof techniques power the theorems on the
+[previous page](layered.md), and it closes the question of a purely
+declarative optimality criterion rather than leaving it open. A reference
+implementation lives on the `front-necessity` branch.
+
+## Motivation
+
+The layered solution is defined by a procedure. One can ask for something
+more declarative: a criterion picking out *the* optimal solution using only
+the solution set — no layers, no reference to the dependency walk, ideally
+nothing but satisfiability queries. The natural candidate is a *necessity*
+descent: repeatedly pin the highest-priority package that is **necessary**
+— present in every remaining solution — at the best version available.
+Necessity, however, is a *universal* property of a solution set, so its
+meaning depends on which set is quantified over:
+
+- **All tight solutions** (raw necessity): too weak — a package needed by
+  every *sensible* solution counts as avoidable if one strictly-dominated
+  solution technically avoids it, e.g. by taking a requirement's worst
+  version merely because that version happens to drop a dependency edge.
+  This distorts the descent, and it also forbids problem reduction
+  entirely, which is ruinous at registry scale.
+- **Models of the filtered problem**: fast, but then the *answer* depends
+  on filtering details — sharpening or dulling the filter changes the
+  result, which is unacceptable as a semantics.
+
+The canonical middle ground is necessity over the **Pareto front**: quantify
+over the solutions that are not strictly worse than others.
+
+## The dominance order
+
+For tight solutions ``s, t``:
+
+```math
+t \trianglerighteq s \quad\iff\quad
+\mathrm{supp}(t) \supseteq \mathrm{supp}(s), \quad
+\mathrm{rank}_t(p) \le \mathrm{rank}_s(p) \;\; \forall p \in \mathrm{supp}(s),
+```
+
+with strict improvement at some ``p \in \mathrm{supp}(s)`` (*coverage-
+monotone version dominance*). This is a strict partial order on the finite
+set ``R^*`` of tight solutions, so every solution is either maximal or
+strictly dominated by a maximal one. The **front** ``F`` is the set of
+maximal elements.
+
+Both design choices in ``\trianglerighteq`` are forced:
+
+- **Orientation.** An order in which *leaner* solutions dominate cannot
+  work: the solutions that falsely break necessity are support-minimal
+  (a requirement alone at a bad version), and a support-minimal solution
+  has no leaner competitor, so no leaner-dominates order can remove one.
+  Also, since a tight solution's support is a function of its versions,
+  "leaner at equal quality" never occurs — leanness always trades against
+  version quality, and the order must price the trade. ``\trianglerighteq``
+  prices it as: a bigger solution wins only by covering everything at
+  least as well and strictly better somewhere.
+- **Junk is excluded by the space, not the order.** With the ``\supseteq``
+  orientation, unjustified packages would ride along for free, so the
+  candidate space must be the *tight* solutions. Tightness (well-founded
+  justification, the same notion as stable models in answer-set
+  programming) is not expressible by any dominance relation over versions
+  — it is not monotone in the version lattice. Empirically, defining the
+  front over junk-tolerant solutions changes answers on 92 of 7,464 small
+  instances.
+
+**The front-necessity semantics** is the forced descent over ``F``:
+repeatedly pin the highest-priority package present in *every* front member
+consistent with the pins so far, at the best version among them, until no
+unpinned package is common.
+
+## Theorem A: pin exactness
+
+The linchpin of everything that follows.
+
+!!! note "Theorem A"
+    Let `pins` be the pin state after any number of descent rounds. If
+    ``f \in F`` contains every pinned package at rank ≤ its pinned rank,
+    then ``f`` agrees *exactly* with the pins.
+
+    *Proof.* Suppose not; among pinned packages where ``f`` is strictly
+    better, let ``\hat q`` be the one pinned earliest, at rank ``\hat r``.
+    On packages pinned before ``\hat q``, ``f`` is ≤ with no strict
+    improvement, hence equal — so ``f`` was in the remaining front set when
+    ``\hat q`` was pinned. But then
+    ``\hat r = \min\{\mathrm{rank}_g(\hat q)\} \le \mathrm{rank}_f(\hat q)
+    < \hat r``. ∎
+
+!!! note "Corollary A1"
+    If ``t \in F`` and ``t \trianglerighteq s`` (or ``t = s``) for any
+    ``s`` agreeing with the pins, then ``t`` agrees exactly with the pins:
+    *dominating a pin-consistent solution can never buy pin-violating
+    quality.*
+
+## Theorem B: the answer is a front member
+
+!!! note "Theorem B"
+    The descent terminates with the remaining front set equal to exactly
+    ``\{\mathrm{pins}\}``; in particular the answer is itself a valid,
+    tight, undominated solution.
+
+    *Proof.* Requirements are in every front member, so they get pinned.
+    If ``q`` is pinned, every remaining ``f`` has ``q`` at the pinned
+    version, so ``\mathrm{deps}(q, \mathrm{pins}(q))`` is common and gets
+    pinned — the pins are dependency-closed. Now take any final survivor
+    ``f`` and walk its closure: it starts at requirements (pinned), and
+    whenever a closure node ``u`` is pinned, ``f(u) = \mathrm{pins}(u)``,
+    so the next closure nodes are pinned too. Hence
+    ``C(f) \subseteq \mathrm{dom}(\mathrm{pins})``, and by tightness
+    ``\mathrm{supp}(f) = C(f) \subseteq \mathrm{dom}(\mathrm{pins})
+    \subseteq \mathrm{supp}(f)`` — so ``f = \mathrm{pins}``. ∎
+
+The same argument shape, one level down, shows the *layered* answer is
+``\trianglerighteq``-undominated: a dominator would have to agree with
+every layered pin before its earliest strict improvement, contradicting
+that pin's optimality. So the layered solution always lies *on* the front;
+front-necessity differs only in *which* front point it selects (230 of
+7,464 small instances) — front-necessity makes priority the only ordering
+principle among necessary packages, where the layered order lets
+requirements outrank higher-priority dependencies.
+
+## Theorem C: a pure-SAT implementation exists
+
+Front-necessity is implementable against a SAT instance that encodes
+validity only — no tightness encoding, which matters because eager
+tightness encodings blow up (rooted-chain/level constructions), the naive
+support encoding admits unrooted cycles, and lazily this is exactly
+answer-set programming's unfounded-set problem. Instead, two cheap
+operations run *outside* the solver: pruning ``\pi`` (a closure
+computation) and support comparison. The key sub-results:
+
+- **Witness transfer.** A model lacking ``p`` prunes to a tight solution
+  lacking ``p``; conversely every tight solution is a model. So junk never
+  distorts the existential side of a necessity query.
+- **Dominator transfer.** A tight solution ``s`` has a tight strict
+  dominator iff some model ``d`` covers ``\mathrm{supp}(s)`` at ranks ≤
+  with a strict improvement *and* passes the **prune-check**
+  ``\pi(d) \supseteq \mathrm{supp}(s)`` — junk can fake domination whose
+  tight core doesn't actually cover ``s``, and the prune-check filters
+  exactly those fakes.
+- **Chain-top admissibility.** Climbing dominators terminates at a front
+  member, which by Corollary A1 agrees exactly with the pins even though
+  intermediate steps may not.
+- **Cone blocking.** When a chain-top ``t`` contains ``p``, everything
+  ``\trianglelefteq t`` is either dominated or is ``t`` itself, so one
+  clause excludes the entire cone without losing any witness.
+- **Greedy construction.** In the implementation, candidates are
+  *constructed* rather than searched for: the layered greedy runs under
+  per-query assumptions, and a junk-free greedy answer is provably
+  Pareto-maximal within its query space (the Theorem A argument again).
+  Restricting all queries to *supported* models — one clause per package:
+  present implies depended-upon — loses no tight solution and reduces junk
+  to dependency cycles.
+
+With these, the descent's two oracle types (is ``p`` in every pin-exact
+front member? what is the best rank among them?) are decided exactly, by
+sequences of ordinary SAT solves. Correctness of the composed pipeline was
+additionally verified against a brute-force implementation of the
+definition on roughly 19,500 instance/order pairs with zero deviations.
+
+## Theorem D: no version-level reduction is faithful
+
+Here is the decisive negative result. One would like to run the necessity
+descent on a *reduced* problem — that is how the layered semantics gets its
+speed. For front-necessity this fails not just for the actual filter but
+**in principle**:
+
+!!! note "Theorem D"
+    There is a problem on which the forced descent over models of the
+    *exact front-support reduction* — keep a version iff some front member
+    uses it, the strongest version-level reduction that could possibly be
+    faithful — differs from the forced descent over the front itself.
+
+    *Proof.* Requirements ``\{a\}``, priority ``p > a > d > b``, version 1
+    best:
+
+    | package | dependencies | conflicts |
+    |---|---|---|
+    | ``a`` | ``a@1 \to \{d\}``, ``a@2 \to \{b\}`` | |
+    | ``b`` | ``b@1 \to \{p\}`` | |
+    | ``d`` | ``d@1 \to \{p\}``, ``d@2 \to \{\}`` | ``d@1 \otimes p@1`` |
+    | ``p`` | ``p@1 \to \{d\}``, ``p@2 \to \{\}`` | |
+
+    ``R^*`` has four members and the front is
+    ``F = \{f_1, f_2\}`` with ``f_1 = \{a@2, b@1, p@1, d@2\}`` and
+    ``f_2 = \{a@1, d@1, p@2\}`` — both contain ``p``, so the front descent
+    pins ``p`` first at rank 1 and lands on ``f_1``. But every version
+    above appears in some front member, so the exact front-support
+    reduction keeps everything — including the **recombinant**
+    ``c = \{a@1, d@2\}`` (``f_2``'s ``a`` with ``f_1``'s ``d``), a tight
+    solution missing ``p``. In the reduced problem ``p`` is no longer
+    common; the descent pins ``a`` first, and rank-minimization at ``a``
+    eliminates ``f_1``: the reduced answer is ``f_2 \ne f_1``. (Verified
+    computationally.) ∎
+
+The moral: necessity is a property of the solution *set*, and a version
+universe only bounds that set from above — recombinations of individually
+front-supported versions can erase necessity. Universal queries survive
+only when asked against the front itself. Note the contrast with
+Theorem 4 of the [layered page](layered.md): the layered semantics needs a
+reduction to preserve *one solution*; front-necessity would need it to
+preserve the *entire front and nothing that changes commonality* — and
+even the latter is unattainable at the version level. Such counterexamples
+require engineered structure (two dependency routes, a recombination
+orphaning the necessity package, a conflict pinching the diagonal): none
+arose in 12,000 random 4-package instances, which is also why smaller
+empirical sweeps had suggested the reduction was safe.
+
+## Why the filter cannot serve the front
+
+The actual reachability filter fails front-preservation in an even more
+basic way: it **drops front members outright**. On the Theorem D instance
+it keeps only ``\{a@1, d@1, d@2, p@1, p@2\}`` — never reaching ``a@2``,
+deleting ``b`` — yet ``f_1`` uses both. The filter's designed invariant is
+*"a worse version is only chosen under conflict pressure against the
+better version,"* and ``a@1`` is never conflicted. But ``f_1`` takes
+``a@2`` for a different kind of reason: under ``a@1``, the only dependency
+edge that can justify ``p`` is ``d@1 \to p``, and ``p@1 \otimes d@1`` — so
+on the ``a@1`` route the better ``p@1`` is unreachable-as-justified.
+Switching to ``a@2`` reroutes justification through ``b`` and frees
+``p@1``. The downgrade at ``a`` is paid for by an upgrade at ``p`` — an
+*opportunity-cost trade*, mediated not by any conflict against ``a`` but by
+**version-varying dependency sets** rewiring the justification topology.
+
+That is precisely the boundary of the filter's intuition:
+
+!!! note "Fragment lemma"
+    If every version of each package has the same dependency set, then on
+    the front every non-best version is blocked by a conflict with a
+    co-installed package — the filter's invariant, as a theorem.
+
+    *Proof (one step).* Let ``s \in F`` with ``q`` at a non-best version
+    and ``v'`` better. The in-place upgrade ``s' = s[q \mapsto v']`` has
+    the same support, and — dependency sets being version-independent —
+    the same justification edges, hence remains tight. If ``s'`` were
+    conflict-free it would strictly dominate ``s``. So some conflict
+    between ``q@v'`` and a member of ``s`` blocks it. ∎
+
+Pointwise (layered) optimality never makes opportunity-cost trades, which
+is why conflict-driven degradation covers everything it can ever choose
+(Theorem 5 of the layered page); the front additionally contains the
+trade-mediated points, and front-*necessity* quantifies over exactly those.
+
+## Why it was set aside
+
+| | layered | front-necessity |
+|---|---|---|
+| canonical, filter-free definition | yes (Theorems 4–6) | yes (by construction) |
+| declarative (procedure-free) statement | no — defined by the trace | yes |
+| SAT query character | existential, answer-witnessed | universal (necessity, dominance) |
+| admissible reductions | any preserving *one* solution | none at the version level (Theorem D) |
+| registry performance | milliseconds–seconds | small: ms; `DataFrames`: ~85 ms; `DifferentialEquations` (26k versions, unreduced): intractable |
+
+The costs are intrinsic, not implementation slack: universal queries must
+run against the unreduced problem (Theorem D), every semantically-avoidable
+candidate needs a witness construction plus a dominance query, and witness
+certificates are invalidated by later pins. Even under optimistic
+assumptions the descent is an order of magnitude or more behind the layered
+implementation — and end users do not observe the difference between the
+two Pareto points the semantics select. What the exploration contributes is
+what this page records: the impossibility theorems that close the
+declarative route, the proof machinery reused for the layered guarantees,
+and a precise understanding of what the filter does and does not preserve —
+satisfiability (provably), the layered answer (provably), the front
+(provably not).

--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -1,0 +1,246 @@
+# The layered solution and filtering
+
+This page defines the semantics `resolve` implements — the *layered
+solution* — and proves the two guarantees that make the implementation
+trustworthy:
+
+1. **filtering preserves satisfiability** — a solvable problem never
+   becomes unsolvable by filtering; and
+2. **filtering preserves the answer** — the solution computed on the
+   filtered problem equals the layered solution of the *raw* problem, so
+   the semantics is independent of filtering details.
+
+The second result is the important one: it means the layered solution has a
+canonical, filter-free definition, and the filter is licensed by a theorem
+rather than trusted as part of the spec. It also yields a general contract
+under which *future, more aggressive* reductions are automatically safe.
+
+## The layered solution
+
+Fix a problem, requirements, and a strict total priority order ``\prec`` on
+packages (from the `by` argument). The **layered trace** is the following
+deterministic procedure over the problem's models (= valid solutions
+covering the requirements, junk allowed):
+
+1. If no model exists, the answer is *unsatisfiable* (`nothing`).
+2. Otherwise set the current layer ``L := \mathrm{reqs}`` and start with no
+   pins.
+3. For each ``q \in L`` in ``\prec``-order: pin ``q`` at the **best rank
+   feasible given the pins so far** — the minimum
+   ``\mathrm{rank}_M(q)`` over models ``M`` that extend all current pins.
+4. Let the next layer be the not-yet-visited dependencies of the versions
+   just pinned; if nonempty, go to 3.
+5. The answer ``\mathrm{Lay}(D, \mathrm{reqs}, \prec)`` is the set of pins.
+
+!!! note "Theorem 1 (well-definedness)"
+    The layered trace is deterministic — it depends only on the problem,
+    the requirements, and the priority order, not on which models a solver
+    happens to produce — and its answer is a tight solution.
+
+    *Proof.* Each step-3 choice is a minimum over a set determined by the
+    problem and the current pins; layers are determined by pinned versions'
+    dependency sets; so the trace is a deterministic recursion.
+    Feasibility is maintained at every pin (the minimizing model extends
+    the pins), so the final pin set extends to a model; the pins are
+    exactly the dependency closure of the requirements under the pinned
+    versions (layer construction), hence a tight solution. ∎
+
+The layered solution is *pointwise optimal*: each package, taken in layer
+order and priority order, is at the best version compatible with the
+choices already made. It is also Pareto-optimal in the sense made precise
+on the [next page](front.md) — no tight solution beats it on every package
+— though Pareto-optimality is a strictly weaker statement than the trace
+itself, which pins the unique answer.
+
+## Filtering
+
+Real problems are shrunk before solving by two passes (`pkg_info` with
+`filter=true`, the default):
+
+**Reachability** (`find_reachable`) computes, per package, a version
+*prefix* to keep, by a fixpoint of *conflict-driven degradation*:
+
+- requirements' first versions are reachable;
+- the first version of each dependency of a reachable version is reachable;
+- if a reachable version conflicts with a reachable version, both packages'
+  prefixes extend one further;
+- if every version of a package has been pushed past (the package
+  *saturates* — meaning conflicts could make it uninstallable), packages
+  depending on it have their prefixes pushed past the depending versions —
+  and a saturated package keeps **all** its versions.
+
+**Redundancy elimination** (`mark_necessary!`) then deletes any version
+``q@j`` for which some better version ``q@i`` (``i < j``) has a *subset* of
+its constraints — every dependency and every (surviving) conflict of
+``q@i`` is also one of ``q@j`` — iterated to a fixpoint.
+
+The intuition behind reachability is: *an optimal solution only settles for
+a worse version for a reason, and the reason is a conflict.* That intuition
+is exactly right for the layered (pointwise) semantics, and the theorems
+below make it precise. (It is *not* right for Pareto-front reasoning — see
+the [next page](front.md#Why-the-filter-cannot-serve-the-front) — which is
+one of the sharpest ways to see the difference between the two notions of
+optimality.)
+
+## Theorem 2: the reach fixpoint invariant
+
+Everything rests on one observation about what the reachability fixpoint
+guarantees. Call a kept version *last* if it is the highest-rank (worst)
+kept version of an unsaturated package.
+
+!!! note "Theorem 2 (fixpoint invariant)"
+    At the reachability fixpoint, the last kept version ``p@r(p)`` of every
+    unsaturated package ``p``:
+
+    1. conflicts with **no kept version of any package** (saturated
+       packages' versions included); and
+    2. depends on **no saturated package**.
+
+    *Proof.* If ``p@r(p)`` conflicted with a kept ``q@k``, then whichever
+    of the two was processed later scans the other (already reachable) and
+    fires the degradation rule, extending ``p``'s prefix past ``r(p)`` —
+    contradicting that ``r(p)`` is last. If ``p@r(p)`` depended on a
+    saturated package, the saturation rule pushes dependents past the
+    depending version, likewise extending the prefix. ∎
+
+In other words: **the cascade pushes prefixes exactly until the
+"all-worst-kept" assignment becomes self-consistent.** That immediately
+gives the first correctness result.
+
+## Theorem 3: filtering preserves satisfiability
+
+!!! note "Theorem 3"
+    If the raw problem has a solution covering the requirements, so does
+    the filtered problem. (The converse is trivial, since filtered models
+    are a subset of raw models.)
+
+    *Proof.* Let ``S`` be a raw solution. First suppose no requirement's
+    dependency chain touches a saturated package. Build ``T`` as the
+    dependency closure from the requirements choosing every package's
+    *last kept* version. By invariant (2) this closure never enters a
+    saturated package; by invariant (1) every chosen version conflicts
+    with nothing kept, so ``T`` is conflict-free; it is dependency-closed
+    by construction and covers the requirements. ``T`` is a filtered
+    solution.
+
+    In general, splice: for saturated packages use ``S``'s own versions —
+    all kept, since saturation drops nothing, and ``S`` is
+    dependency-closed so saturated dependencies of ``S``-members are
+    assigned in ``S`` — and for unsaturated packages use last kept
+    versions. Conflicts between an unsaturated choice and anything vanish
+    by invariant (1); conflicts among the saturated choices are absent
+    because they come from the valid ``S``. Dependency edges are satisfied
+    branch by branch: unsaturated members' dependencies are unsaturated by
+    invariant (2) and get last-kept versions; saturated members'
+    dependencies are resolved inside ``S`` or by last-kept substitutes
+    (dependency edges are package-level, so any assigned version satisfies
+    them). ∎
+
+For the redundancy pass, satisfiability is preserved by direct
+substitution: any solution using a deleted ``q@j`` maps to a solution using
+its dominating ``q@i`` (fewer dependencies to satisfy, fewer conflicts to
+avoid), and domination chains terminate at a surviving version because
+reachability keeps prefixes — a better version is never deleted while a
+worse one survives.
+
+## Theorem 4: reduction invariance — the optimization license
+
+The next theorem is the general principle; the filter's correctness is an
+instance of it.
+
+!!! note "Theorem 4 (reduction invariance)"
+    Let ``D'`` be obtained from ``D`` by deleting versions (so
+    ``\mathrm{models}(D') \subseteq \mathrm{models}(D)``), and suppose the
+    layered solution ``\mathrm{Lay}(D)`` survives in ``D'`` — every version
+    it uses is kept. Then
+    ``\mathrm{Lay}(D') = \mathrm{Lay}(D)``.
+
+    *Proof.* By induction along the trace, both runs make identical pins.
+    At each step the choice for ``q`` is the best rank feasible given the
+    (identical) pins. Deleting models can only make ranks *harder* to
+    achieve, so the ``D'``-best is no better than the ``D``-best. And the
+    ``D``-best is witnessed *in* ``D'`` by ``\mathrm{Lay}(D)`` itself: it
+    extends all current pins (its values on pinned packages are exactly
+    the pins, by induction), assigns ``q`` its ``D``-best rank (that is
+    what the raw trace pinned), and survives in ``D'`` by hypothesis. So
+    the choices agree; identical pins induce identical layers. The
+    satisfiable/unsatisfiable branch also agrees, since
+    ``\mathrm{Lay}(D)`` witnesses satisfiability in both. ∎
+
+This is the "decoupling" result: the layered semantics is defined once, on
+the raw problem, and *any* reduction whatsoever is licensed by exhibiting a
+single surviving solution — the answer. Two consequences:
+
+- **Certification.** Answer preservation can be checked *post hoc*,
+  cheaply: resolve the filtered problem, then verify each pin against the
+  raw problem — feasibility is free (the answer is itself a raw model), and
+  optimality of each pin is one unsatisfiable solve ("no raw model with
+  these pins and a better version of ``q``") per pinned package. A resolver
+  can offer machine-checked raw-canonical answers for the cost of building
+  the raw instance plus one probe per package.
+- **Headroom.** Future reductions can be far more aggressive than the
+  current filter — anything that keeps the answer is safe, and the
+  certification above detects violations per-resolve rather than trusting
+  the reduction globally.
+
+The deep reason a theorem this convenient is available is that every SAT
+query the layered trace makes is *existential* ("is a better version
+feasible?") and is witnessed by the final answer, which survives the
+reduction. Universal queries — "is this package in *every* solution?" — do
+not enjoy this: deleting models changes their truth value. That asymmetry
+is the fundamental obstruction explored on the [next page](front.md).
+
+## Theorem 5: the filter preserves the answer
+
+It remains to show the actual filter satisfies Theorem 4's hypothesis.
+
+!!! note "Theorem 5 (reach keeps the layered answer)"
+    Every version chosen by the raw layered trace is kept by reachability
+    filtering.
+
+    *Proof.* By induction along the trace; assume all pins so far are kept
+    versions. Consider the step for package ``q``, and suppose first ``q``
+    is unsaturated. We claim ``q``'s last kept version ``q@r(q)`` is
+    feasible given the pins, so the best feasible rank — the trace's choice
+    — is at most ``r(q)``, i.e. a kept version. To see feasibility,
+    construct a model: take the pins (jointly feasible by the trace's
+    invariant, and kept by induction), add ``q@r(q)``, and complete with
+    the last-kept dependency closure of everything present. By invariant
+    (1) of Theorem 2, ``q@r(q)`` and every last-kept version conflict with
+    nothing kept — in particular not with the pins or each other; by
+    invariant (2) the completion never needs a saturated package; pins'
+    dependencies are satisfied by pinned or last-kept packages. The result
+    is a model containing the pins and ``q@r(q)``. If instead ``q`` is
+    saturated, all its versions are kept and there is nothing to prove. ∎
+
+!!! note "Theorem 6 (redundancy keeps the layered answer)"
+    The layered trace never chooses a version deleted by redundancy
+    elimination.
+
+    *Proof.* Suppose the trace chose ``q@j`` and ``q@j`` is dominated by a
+    kept ``q@i`` with ``i < j``. Any model witnessing ``q@j``'s
+    feasibility given the pins converts to one witnessing ``q@i``'s: swap
+    the version; ``q@i``'s dependencies are a subset of ``q@j``'s (already
+    present) and its conflicts a subset (already avoided). So ``q@i`` was
+    feasible and better, contradicting that the trace chose ``j``.
+    Domination chains terminate at a kept version, and the argument
+    applies to whichever kept dominator terminates the chain. ∎
+
+Composing: the raw answer survives reachability (Theorem 5), so by
+Theorem 4 the reach-filtered problem has the same layered answer; that
+answer survives redundancy elimination (Theorem 6 applied on the
+reach-filtered problem), so by Theorem 4 again the fully filtered problem
+has the same layered answer. **The implementation's answer is the raw
+layered solution.**
+
+!!! warning "Formalization boundary"
+    Theorems 2, 3, 5, and 6 are proved against the rule set as stated
+    above, which is a faithful but hand-made reading of `find_reachable`
+    and `mark_necessary!`; the correspondence of code to rules is checked
+    by review and by the test suite, not mechanically. The package's tests
+    compare the implementation against a brute-force reference that
+    implements the layered trace *on raw data* across hundreds of
+    thousands of random instances — a direct, ongoing empirical check of
+    Theorems 4–6 — and, whenever the implementation reports
+    unsatisfiable, verify by enumeration that no raw solution covers the
+    requirements (Theorem 3).

--- a/docs/src/theory/setting.md
+++ b/docs/src/theory/setting.md
@@ -1,0 +1,97 @@
+# Setting
+
+This page fixes the objects and notation used throughout the theory
+section. Everything downstream — the semantics the resolver implements, the
+correctness proofs for its filtering, and the Pareto-front analysis — is
+stated in these terms.
+
+## The resolution problem
+
+A **resolution problem** consists of:
+
+- a finite set of **packages** ``\mathcal{P}``;
+- for each package ``p`` a finite, totally ordered list of **versions**,
+  written by **rank**: rank ``1`` is the best version, rank ``2`` the next,
+  and so on (the meaning of "best" is supplied by the caller — newest,
+  oldest, closest-to-installed — the theory only uses the order);
+- for each version ``p@v`` a **dependency set**
+  ``\mathrm{deps}(p, v) \subseteq \mathcal{P}`` — note that dependencies are
+  attached to *versions*, and different versions of the same package may
+  have different dependency sets, a fact that turns out to carry a lot of
+  weight;
+- a symmetric **conflict** relation on version pairs (in the package data
+  this arises from compatibility constraints: ``p@v`` conflicts with ``q@w``
+  when ``w`` is outside ``p@v``'s compatibility bound for ``q``, or vice
+  versa);
+- a set of **requirements** ``\mathrm{reqs} \subseteq \mathcal{P}``.
+
+A **solution** is a partial assignment ``s`` of versions to a support set
+``\mathrm{supp}(s) \subseteq \mathcal{P}`` such that:
+
+1. *coverage*: ``\mathrm{reqs} \subseteq \mathrm{supp}(s)``;
+2. *dependency closure*: for every ``p \in \mathrm{supp}(s)``,
+   ``\mathrm{deps}(p, s(p)) \subseteq \mathrm{supp}(s)``;
+3. *conflict freedom*: no two assigned versions conflict.
+
+Write ``\mathrm{rank}_s(p)`` for the rank of ``s(p)``.
+
+## Tightness and pruning
+
+The **closure** ``C(s)`` of a solution is the least set containing
+``\mathrm{reqs}`` and closed under following dependencies of ``s``'s chosen
+versions:
+
+```math
+C(s) \;=\; \bigcup_k L_k, \qquad
+L_0 = \mathrm{reqs}, \quad
+L_{k+1} = L_k \cup \bigcup_{q \in L_k} \mathrm{deps}(q, s(q)).
+```
+
+A solution is **tight** if ``\mathrm{supp}(s) = C(s)`` — it contains
+nothing that isn't reachable from the requirements along its own chosen
+dependency edges. ``R^*`` denotes the set of tight solutions. **Pruning**
+``\pi(s)`` restricts ``s`` to ``C(s)``.
+
+!!! note "Lemma (pruning)"
+    ``\pi(s)`` is a tight solution with ``s``'s versions, and
+    ``C(\pi(s)) = C(s)``.
+
+    *Proof.* Coverage and dependency closure hold because the closure
+    construction adds exactly the dependencies of its members; conflict
+    freedom is inherited from ``s``; and the closure computation only ever
+    inspects versions of packages already in the closure, which agree with
+    ``s``. ∎
+
+Two structural facts about tight solutions recur constantly:
+
+- **Support is a function of the versions.** For a tight solution, the
+  support is determined by the version assignment (it *is* the closure), so
+  two distinct tight solutions with nested supports must already differ on
+  a version within the smaller support.
+- **Junk.** A valid solution need not be tight — it may carry packages
+  ("junk") not justified from the requirements. Junk matters because the
+  resolver works with a SAT solver, and SAT models are exactly the valid
+  solutions, junk included.
+
+## The SAT encoding
+
+The resolver encodes a problem instance with one boolean variable per
+package and one per version:
+
+- package implies some version: ``p \Rightarrow \bigvee_i p@i``;
+- version implies its package: ``p@i \Rightarrow p``;
+- versions are mutually exclusive: ``\lnot p@i \lor \lnot p@j``;
+- dependencies: ``p@i \Rightarrow q`` for each ``q \in \mathrm{deps}(p,i)``;
+- conflicts: ``\lnot p@i \lor \lnot q@j`` for conflicting pairs.
+
+With requirement unit clauses added, the models of this formula are
+precisely the valid solutions covering the requirements (with junk
+allowed). All constraints are dependency edges (positive, from versions to
+packages) and *pairwise* version conflicts (negative) — a structural fact
+several proofs exploit: any infeasibility ultimately traces to pairwise
+conflicts, because dependencies alone can always be satisfied by including
+more packages.
+
+Before solving, the problem is shrunk by *filtering* —
+[reachability analysis and redundancy elimination](layered.md#Filtering) —
+whose correctness is the subject of the next page.

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -71,6 +71,27 @@ function resolve_core(
     return sol
 end
 
+"""
+    resolve(data, reqs; by = identity) -> Union{Dict{P,V}, Nothing}
+
+Resolve the requirements `reqs` against the package universe described by
+`data`, returning the optimal solution as a dict mapping each needed package
+to its chosen version, or `nothing` when the requirements are not jointly
+satisfiable. The solution covers every requirement and is exactly the
+dependency closure of the requirements under its own chosen versions.
+
+The returned solution is the *layered solution*: requirements are optimized
+first, in the priority order induced by `by` (each package maximized to its
+best feasible version given the choices already made), then the dependencies
+of the chosen versions, layer by layer along the dependency graph. See the
+manual's Theory section for the precise semantics and the guarantees it
+carries.
+
+`data` may be a `DepsProvider`, a dict of `PkgData`, a dict of `PkgInfo`, or
+a `SAT` instance. The `SAT` method also accepts `restore::Bool = true`: when
+true the instance's clauses are restored before returning so the instance
+can be reused; `restore = false` is faster for single-use instances.
+"""
 function resolve(
     sat  :: SAT{P,V},
     reqs :: SetOrVec{P} = keys(sat.info);


### PR DESCRIPTION
Enables standard Documenter docs (HTML, KaTeX math, GitHub Pages deployment workflow) and adds a **Theory** section recording everything we now know — proofs, counterexamples, and evidence — about what the resolver computes and why its filtering is safe.

## Contents

**Setting** — the resolution problem, solutions, closure/tightness, pruning, and the SAT encoding, fixing notation for the rest.

**The layered solution & filtering** — the semantics `resolve` implements, as theorems:
- the layered trace is deterministic and model-independent, and its answer is tight;
- the **reach fixpoint invariant**: every unsaturated package's last kept version conflicts with nothing kept and depends on nothing saturated — the cascade degrades exactly until the "all-worst-kept" assignment is self-consistent;
- **filtering preserves satisfiability** (constructive proof, including the saturated-requirement splice);
- **reduction invariance**: *any* version deletion that keeps the answer preserves the entire trace — the general license for aggressive filtering, with cheap post-hoc certification as a corollary;
- the actual reach and redundancy passes **keep the layered answer**, so the implementation provably computes the raw problem's canonical layered solution — the filter is licensed by a theorem, not trusted as part of the spec.

**Pareto front optimality** — the worked-out declarative alternative and why it was set aside, kept because its results illuminate the whole design space: coverage-monotone dominance and the forced descent over the front; pin exactness; the answer being a front member; pure-SAT implementability; **no version-level reduction is faithful to necessity** (explicit 4-package recombination counterexample, machine-verified); the reachability filter drops front members, and the exact fragment where the filter's design intuition ("only settle for worse under conflict pressure") is a theorem — version-independent dependency sets; and the cost analysis (universal vs existential queries) behind the decision. Reference implementation on the `front-necessity` branch.

Also gives `resolve` a docstring and surfaces `find_reachable`'s existing docstring on an internals page. The docs build clean locally; the workflow deploys to GitHub Pages on merge and builds previews on PRs.

## Co-author

Written with [Claude Code](https://claude.com/claude-code); proofs and counterexamples developed interactively with @StefanKarpinski (see session context in prior PRs #34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
