### PR TITLE
Filter machinery optimizations: 15× faster filtering, plus pkg info file fix

### DIFF
--- a/src/BitKernels.jl
+++ b/src/BitKernels.jl
@@ -24,18 +24,6 @@ function col_copy!(buf::Vector{UInt64}, X::BitMatrix, j::Int)
     return buf
 end
 
-# buf .&= column j of X; returns true if buf has any set bit left
-function col_and!(buf::Vector{UInt64}, X::BitMatrix, j::Int)
-    W = col_words(X)
-    base = (j - 1) * W
-    chunks = X.chunks
-    live = UInt64(0)
-    @inbounds for w = 1:W
-        live |= (buf[w] &= chunks[base + w])
-    end
-    return !iszero(live)
-end
-
 # does column j of X intersect the row set in buf?
 function col_intersects(X::BitMatrix, j::Int, buf::Vector{UInt64})
     W = col_words(X)
@@ -45,20 +33,6 @@ function col_intersects(X::BitMatrix, j::Int, buf::Vector{UInt64})
         iszero(chunks[base + w] & buf[w]) || return true
     end
     return false
-end
-
-# clear the bits of buf corresponding to rows 1:i
-function clear_rows_upto!(buf::Vector{UInt64}, i::Int)
-    i ≤ 0 && return buf
-    wt = i >> 6
-    @inbounds for w = 1:min(wt, length(buf))
-        buf[w] = 0
-    end
-    r = i & 63
-    if r != 0 && wt < length(buf)
-        @inbounds buf[wt + 1] &= ~((UInt64(1) << r) - 1)
-    end
-    return buf
 end
 
 # clear the bits of buf corresponding to rows above m (flag row & padding)
@@ -74,9 +48,30 @@ function clear_rows_above!(buf::Vector{UInt64}, m::Int)
     return buf
 end
 
-# is row i's bit set in buf?
-getbit(buf::Vector{UInt64}, i::Int) =
-    !iszero(buf[((i - 1) >> 6) + 1] & (UInt64(1) << ((i - 1) & 63)))
+# copy len bits from the (word-aligned) column j of X into dest,
+# starting at 0-based bit offset off
+function copy_col_bits!(dest::Vector{UInt64}, off::Int, X::BitMatrix, j::Int, len::Int)
+    W = col_words(X)
+    base = (j - 1) * W
+    src = X.chunks
+    wd = (off >> 6) + 1
+    sh = off & 63
+    s = 0
+    @inbounds while len > 0
+        s += 1
+        take = min(64, len)
+        mask = take == 64 ? ~UInt64(0) : (UInt64(1) << take) - 1
+        chunk = src[base + s] & mask
+        dest[wd] = (dest[wd] & ~(mask << sh)) | (chunk << sh)
+        hi = 64 - sh
+        if sh != 0 && take > hi
+            dest[wd + 1] = (dest[wd + 1] & ~(mask >> hi)) | (chunk >> hi)
+        end
+        len -= take
+        wd += 1
+    end
+    return dest
+end
 
 # highest set row ≤ hi in column j of X, or 0 if none
 function col_max_upto(X::BitMatrix, j::Int, hi::Int)

--- a/src/BitKernels.jl
+++ b/src/BitKernels.jl
@@ -1,0 +1,119 @@
+# Every PkgInfo conflicts matrix is allocated with its row dimension padded
+# to a whole number of 64-bit words (see padded_rows), so that column j
+# occupies exactly the aligned chunk words X.chunks[(j-1)*W .+ (1:W)] where
+# W = size(X, 1) >> 6. Version i of the package corresponds to bit i-1 of
+# that span; the row after the last version holds the column's active flag;
+# any rows beyond that are padding and must remain zero. The helpers below
+# are the word-parallel column primitives the filtering passes build on.
+
+# rows to allocate for a package with m versions:
+# m version rows plus the flag row, rounded up to whole words
+padded_rows(m::Int) = 64 * cld(m + 1, 64)
+
+# number of 64-bit words per column
+col_words(X::BitMatrix) = size(X, 1) >> 6
+
+# copy column j of X into buf[1:W]
+function col_copy!(buf::Vector{UInt64}, X::BitMatrix, j::Int)
+    W = col_words(X)
+    base = (j - 1) * W
+    chunks = X.chunks
+    @inbounds for w = 1:W
+        buf[w] = chunks[base + w]
+    end
+    return buf
+end
+
+# buf .&= column j of X; returns true if buf has any set bit left
+function col_and!(buf::Vector{UInt64}, X::BitMatrix, j::Int)
+    W = col_words(X)
+    base = (j - 1) * W
+    chunks = X.chunks
+    live = UInt64(0)
+    @inbounds for w = 1:W
+        live |= (buf[w] &= chunks[base + w])
+    end
+    return !iszero(live)
+end
+
+# does column j of X intersect the row set in buf?
+function col_intersects(X::BitMatrix, j::Int, buf::Vector{UInt64})
+    W = col_words(X)
+    base = (j - 1) * W
+    chunks = X.chunks
+    @inbounds for w = 1:W
+        iszero(chunks[base + w] & buf[w]) || return true
+    end
+    return false
+end
+
+# clear the bits of buf corresponding to rows 1:i
+function clear_rows_upto!(buf::Vector{UInt64}, i::Int)
+    i ≤ 0 && return buf
+    wt = i >> 6
+    @inbounds for w = 1:min(wt, length(buf))
+        buf[w] = 0
+    end
+    r = i & 63
+    if r != 0 && wt < length(buf)
+        @inbounds buf[wt + 1] &= ~((UInt64(1) << r) - 1)
+    end
+    return buf
+end
+
+# clear the bits of buf corresponding to rows above m (flag row & padding)
+function clear_rows_above!(buf::Vector{UInt64}, m::Int)
+    wt = (m + 63) >> 6
+    @inbounds for w = wt + 1:length(buf)
+        buf[w] = 0
+    end
+    r = m & 63
+    if r != 0 && 1 ≤ wt ≤ length(buf)
+        @inbounds buf[wt] &= (UInt64(1) << r) - 1
+    end
+    return buf
+end
+
+# is row i's bit set in buf?
+getbit(buf::Vector{UInt64}, i::Int) =
+    !iszero(buf[((i - 1) >> 6) + 1] & (UInt64(1) << ((i - 1) & 63)))
+
+# highest set row ≤ hi in column j of X, or 0 if none
+function col_max_upto(X::BitMatrix, j::Int, hi::Int)
+    hi ≤ 0 && return 0
+    W = col_words(X)
+    base = (j - 1) * W
+    chunks = X.chunks
+    w = (hi + 63) >> 6
+    @inbounds c = chunks[base + w]
+    r = hi & 63
+    r != 0 && (c &= (UInt64(1) << r) - 1)
+    while true
+        iszero(c) || return ((w - 1) << 6) + (64 - leading_zeros(c))
+        w -= 1
+        w == 0 && return 0
+        @inbounds c = chunks[base + w]
+    end
+end
+
+# lowest set row in lo:hi of column j of X, or 0 if none
+function col_min_from(X::BitMatrix, j::Int, lo::Int, hi::Int)
+    lo ≤ 0 && (lo = 1)
+    hi < lo && return 0
+    W = col_words(X)
+    base = (j - 1) * W
+    chunks = X.chunks
+    wh = (hi + 63) >> 6
+    w = ((lo - 1) >> 6) + 1
+    @inbounds c = chunks[base + w] & (~UInt64(0) << ((lo - 1) & 63))
+    while true
+        if w == wh
+            r = hi & 63
+            r != 0 && (c &= (UInt64(1) << r) - 1)
+        end
+        iszero(c) || return ((w - 1) << 6) + trailing_zeros(c) + 1
+        w == wh && return 0
+        w += 1
+        @inbounds c = chunks[base + w]
+    end
+end

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -337,35 +337,41 @@ function drop_unmarked!(
     info′ :: Dict{P, <: PkgInfo{P}},
     info  :: Dict{P, <: PkgInfo{P}} = info′,
 ) where {P}
-    # info[p].conflicts version-flag column bits definitive
-    # info[p].conflicts column-flag row bits made to match
+    # first pass: per package, compute the kept versions and kept columns
+    # from the (definitive) version flags — all of it before any package
+    # is rebuilt, since kept columns are read off the partners' matrices
+    masks = Dict{P, Tuple{BitVector, BitVector}}()
+    A = UInt64[] # active version mask buffer
     for (p, info_p) in info
         X = info_p.conflicts
         m = length(info_p.versions)
-        X[m+1, :] .= false
-        # dependency column is active if:
-        # - some active version has that dependency
-        for i = 1:m
-            X[i, end] || continue # skip inactive versions
-            for (k, q) in enumerate(info_p.depends)
-                X[m+1, k] |= X[i, k]
-            end
+        n = size(X, 2) - 1
+        W = col_words(X)
+        # active versions
+        I = X[1:m, end]
+        resize!(A, W)
+        col_copy!(A, X, n + 1)
+        clear_rows_above!(A, m)
+        # kept columns: dependency columns some active version depends
+        # on, and conflict columns of active partner versions — a
+        # partner's column block must stay aligned with its version list,
+        # so kept partner versions keep their columns even if empty
+        K = falses(n)
+        for k = 1:length(info_p.depends)
+            K[k] = col_intersects(X, k, A)
         end
-        # conflict column is active if:
-        # - the conflicting version is active
         for (q, b) in info_p.interacts
             Y = info[q].conflicts
-            for j = 1:length(info[q].versions)
-                X[m+1, b + j] = Y[j, end]
-            end
+            copy_col_bits!(K.chunks, b, Y, size(Y, 2), length(info[q].versions))
         end
+        masks[p] = (I, K)
     end
     # save original version counts (needed if info′ === info)
     N = Dict{P,Int}(
         p => length(info_p.versions)
         for (p, info_p) in info
     )
-    # go through again and shrink each PkgInfo
+    # second pass: shrink each PkgInfo
     for (p, info_p) in info
         # abbreviate components
         V = info_p.versions
@@ -374,16 +380,18 @@ function drop_unmarked!(
         X = info_p.conflicts
         m = length(V)
         n = size(X, 2) - 1
-        # active version & column masks
-        I = X[1:m, end]
-        K = X[m+1, 1:n]
+        W = col_words(X)
+        I, K = masks[p]
+        m′ = count(I)
         # delete if no active versions
-        if !any(I)
+        if m′ == 0
             delete!(info′, p)
             continue
         end
-        # copy if everything is active
-        if all(I) && all(K)
+        # keep as is if everything is active (with the column flags
+        # normalized, as rebuilding would leave them)
+        if m′ == m && all(K)
+            X[m+1, 1:n] .= true
             if info !== info′
                 V′ = copy(V)
                 D′ = copy(D)
@@ -405,15 +413,52 @@ function drop_unmarked!(
                 b′ += n′
             end
         end
-        m′ = length(V′)
-        X′ = falses(padded_rows(m′), b′ + 1)
-        rows = findall(I)
+        R′ = padded_rows(m′)
+        W′ = R′ >> 6
+        X′ = falses(R′, b′ + 1)
+        src = X.chunks
+        dst = X′.chunks
+        # kept-version mask words for the gather below
+        resize!(A, W)
+        col_copy!(A, X, n + 1)
+        clear_rows_above!(A, m)
+        prefix = findlast(I) == m′ # kept versions are 1:m′
         j′ = 0
         for j = 1:n
             K[j] || continue
             j′ += 1
-            for (i′, i) in enumerate(rows)
-                X′[i′, j′] = X[i, j]
+            sb = (j - 1) * W
+            db = (j′ - 1) * W′
+            if prefix
+                # kept versions are a prefix: straight word copy
+                nw = (m′ + 63) >> 6
+                @inbounds for w = 1:nw
+                    dst[db + w] = src[sb + w]
+                end
+                r = m′ & 63
+                r != 0 && @inbounds (dst[db + nw] &= (UInt64(1) << r) - 1)
+            else
+                # gather the kept versions' bits
+                acc = UInt64(0)
+                na = 0
+                dw = db + 1
+                @inbounds for w = 1:W
+                    avail = A[w]
+                    iszero(avail) && continue
+                    v = src[sb + w]
+                    while !iszero(avail)
+                        acc |= ((v >> trailing_zeros(avail)) & 1) << na
+                        avail &= avail - 1
+                        na += 1
+                        if na == 64
+                            dst[dw] = acc
+                            dw += 1
+                            acc = UInt64(0)
+                            na = 0
+                        end
+                    end
+                end
+                na > 0 && @inbounds (dst[dw] = acc)
             end
         end
         @assert j′ == b′

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -189,10 +189,9 @@ function mark_necessary!(
     end
     # some work buffers
     A = UInt64[]        # active version mask
-    C = UInt64[]        # domination candidates mask
-    J = Int[]           # active versions vector
+    D = UInt64[]        # per-version domination candidate masks
+    T = UInt64[]        # mask of versions still tracked by the sweep
     R = Int[]           # redundant indices vector
-    cols = Vector{Int}[] # per-version active constraint columns
     # initialize active column flags
     for p = 1:N
         info_p = infos[p]
@@ -235,75 +234,93 @@ function mark_necessary!(
         m > 1 || continue # unique version cannot be redundant
         n = size(X, 2) - 1
         W = col_words(X)
-        # active version mask & indices
+        # active version mask
         resize!(A, W)
         col_copy!(A, X, n + 1)
         clear_rows_above!(A, m)
-        empty!(J)
+        nact = 0
+        @inbounds for w = 1:W
+            nact += count_ones(A[w])
+        end
+        nact > 1 || continue # unique version cannot be redundant
+        # find redundant versions: i < j and X[i, k] => X[j, k] for all
+        # active k means an earlier version is strictly more compatible,
+        # therefore i will always be chosen instead of j. the candidates
+        # dominated by i are the active versions worse than i that have a
+        # constraint in every column i does. sweep the active columns
+        # once, restricting the candidates of every version with a bit in
+        # the column to the column's row set; versions whose candidate
+        # set empties drop out of the sweep. a version dominated only by
+        # dominated versions is also dominated by their (transitively
+        # live) dominators, so batching over the initial active set finds
+        # exactly the sequentially dominated versions.
+        resize!(D, m * W)
+        resize!(T, W)
+        copyto!(T, A)
         @inbounds for w = 1:W
             c = A[w]
             while !iszero(c)
-                push!(J, ((w - 1) << 6) + trailing_zeros(c) + 1)
+                i = ((w - 1) << 6) + trailing_zeros(c) + 1
                 c &= c - 1
+                # candidates of i: active versions worse than i
+                o = (i - 1) * W
+                for w′ = 1:W
+                    D[o + w′] = A[w′]
+                end
+                wt = i >> 6
+                for w′ = 1:min(wt, W)
+                    D[o + w′] = 0
+                end
+                r = i & 63
+                if r != 0 && wt < W
+                    D[o + wt + 1] &= ~((UInt64(1) << r) - 1)
+                end
+                live = UInt64(0)
+                for w′ = 1:W
+                    live |= D[o + w′]
+                end
+                iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
             end
-        end
-        length(J) > 1 || continue # unique version cannot be redundant
-        # collect every active version's active constraint columns in one
-        # sweep over the columns, each of which is a contiguous bit span
-        while length(cols) < m
-            push!(cols, Int[])
-        end
-        for j in J
-            empty!(cols[j])
         end
         for k = 1:n
             X[m+1, k] || continue # inactive column
             base = (k - 1) * W
             @inbounds for w = 1:W
-                c = X.chunks[base + w] & A[w]
+                c = X.chunks[base + w] & T[w]
                 while !iszero(c)
                     i = ((w - 1) << 6) + trailing_zeros(c) + 1
-                    push!(cols[i], k)
                     c &= c - 1
+                    o = (i - 1) * W
+                    live = UInt64(0)
+                    for w′ = 1:W
+                        live |= (D[o + w′] &= X.chunks[base + w′])
+                    end
+                    iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
                 end
             end
         end
-        # find redundant versions: i < j and X[i, k] => X[j, k] for all
-        # active k means an earlier version is strictly more compatible,
-        # therefore i will always be chosen instead of j. the candidates
-        # dominated by i are the active versions worse than i that have a
-        # constraint in every column i does — the word-parallel
-        # intersection of i's constraint columns
-        empty!(R)
-        resize!(C, W)
-        for i in J
-            getbit(A, i) || continue # dominated versions can't dominate
-            copyto!(C, A)
-            clear_rows_upto!(C, i)
-            live = false
-            @inbounds for w = 1:W
-                live |= !iszero(C[w])
-            end
-            live || continue
-            ok = true
-            for k in cols[i]
-                col_and!(C, X, k) && continue
-                ok = false
-                break
-            end
-            ok || continue
-            # remove dominated versions from the active set & record them
-            @inbounds for w = 1:W
-                c = C[w]
-                while !iszero(c)
-                    push!(R, ((w - 1) << 6) + trailing_zeros(c) + 1)
-                    c &= c - 1
+        # union of all candidate sets = the dominated versions
+        fill!(T, UInt64(0)) # reuse as the union accumulator
+        @inbounds for w = 1:W
+            c = A[w]
+            while !iszero(c)
+                i = ((w - 1) << 6) + trailing_zeros(c) + 1
+                c &= c - 1
+                o = (i - 1) * W
+                for w′ = 1:W
+                    T[w′] |= D[o + w′]
                 end
-                A[w] &= ~C[w]
+            end
+        end
+        empty!(R)
+        @inbounds for w = 1:W
+            c = T[w]
+            while !iszero(c)
+                push!(R, ((w - 1) << 6) + trailing_zeros(c) + 1)
+                c &= c - 1
             end
         end
         isempty(R) && continue
-        sort!(R)
         # deactivate redundant versions
         X[R, end] .= false
         for (q, b, c) in partners[p]

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -27,51 +27,85 @@ function find_reachable(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
 ) where {P,V}
+    # intern packages as integer indices so that the fixpoint loop below
+    # hashes no package names; all derived tables are indexed by pkg id
+    pkgs = sort!(collect(keys(info)))
+    N = length(pkgs)
+    ix = Dict{P,Int}(p => i for (i, p) in enumerate(pkgs))
+    infos = Vector{PkgInfo{P,V}}(undef, N)
+    nvers = Vector{Int}(undef, N)
+    deps = Vector{Vector{Int}}(undef, N)     # interned depends, same order
+    partners = Vector{Vector{Tuple{Int,Int}}}(undef, N)
+    for p = 1:N
+        info_p = info[pkgs[p]]
+        infos[p] = info_p
+        nvers[p] = length(info_p.versions)
+        deps[p] = Int[ix[q] for q in info_p.depends]
+        # (partner id, offset of p's version block in the partner's matrix)
+        prt = Tuple{Int,Int}[
+            (ix[q], info[q].interacts[pkgs[p]])
+            for q in keys(info_p.interacts)
+        ]
+        partners[p] = sort!(prt)
+    end
+
     # meaning (both map packages to version indices):
     #   - reach tracks fully processed reachable versions
     #   - queue tracks newly reachable versions not yet processed
-    reach = Dict{P,Int}(p => 0 for p in reqs)
-    queue = Dict{P,Int}(p => 1 for p in reqs)
+    reach = zeros(Int, N)
+    queue = zeros(Int, N)
+    stack = Int[] # packages with queued work
+    instack = falses(N)
+
+    function enqueue(p::Int, j::Int)
+        queue[p] = j
+        if !instack[p]
+            instack[p] = true
+            push!(stack, p)
+        end
+    end
 
     # add next active version of p *after* i to the queue
     # do nothing if there's already version > i in reach/queue
-    function next(p::P, i::Int)
-        get(reach, p, 0) > i && return false
-        get(queue, p, 0) > i && return false
-        info_p = info[p]
-        m = length(info_p.versions)
-        X = info_p.conflicts
+    function next(p::Int, i::Int)
+        reach[p] > i && return false
+        queue[p] > i && return false
+        m = nvers[p]
+        X = infos[p].conflicts
         # first active version after i (the flag column is the active set)
         j = col_min_from(X, size(X, 2), i + 1, m)
         # j == 0: we're out of versions (i.e. saturated; see below)
-        queue[p] = j == 0 ? m + 1 : j
+        enqueue(p, j == 0 ? m + 1 : j)
         return true
     end
 
-    rdeps = Dict{P,Dict{P,Int}}() # reverse dependency map
-    # p => q => k means
+    rdeps = [Dict{Int,Int}() for _ = 1:N] # reverse dependency map
+    # rdeps[p][q] == k means
     #   "k is latest reachable version of q that depends on p"
-    # add new reverse dependency:
-    function rdep(p::P, q::P, k::Int)
-        rdeps_p = get!(() -> valtype(rdeps)(), rdeps, p)
-        rdeps_p[q] = max(get(rdeps_p, q, 0), k)
+
+    for p in reqs
+        enqueue(ix[p], 1)
     end
 
     # notation:
     #   - p, q: packages
-    #   - info_p = info[p]
+    #   - info_p = infos[p]
     #   - indices of versions of package p: i, j
     #   - indices of versions of package q: k
-    while !isempty(queue)
+    while !isempty(stack)
         # get unprocessed package + version
-        p, i = pop!(queue)
-        info_p = info[p]
+        p = pop!(stack)
+        instack[p] = false
+        i = queue[p]
+        queue[p] = 0
+        info_p = infos[p]
+        m = nvers[p]
         # check for saturation
         #   p saturated means: conflicts can force p to be uninstallable
-        #   saturation represented by i > length(info_p.versions)
-        if i > length(info_p.versions)
+        #   saturation represented by i > nvers[p]
+        if i > m
             # p has become saturated
-            haskey(rdeps, p) && for (q, k) in rdeps[p]
+            for (q, k) in rdeps[p]
                 # q@k depends on p, therefore
                 # q@k conflicts with p being uninstallable
                 # p being saturated means that can happen
@@ -79,14 +113,16 @@ function find_reachable(
             end
         end
         # process each newly reachable version of p
-        for j = get(reach, p, 0)+1:min(i, length(info_p.versions))
+        for j = reach[p]+1:min(i, m)
             # dependencies
-            for (k, q) in enumerate(info_p.depends)
+            for (k, q) in enumerate(deps[p])
                 info_p.conflicts[j, k] || continue
-                rdep(q, p, j) # p@j depends on q
+                # p@j depends on q
+                rdeps_q = rdeps[q]
+                rdeps_q[p] = max(get(rdeps_q, p, 0), j)
                 next(q, 0) # q can be required
                 # check if q is saturated:
-                if get(reach, q, 0) > length(info[q].versions)
+                if reach[q] > nvers[q]
                     # p@j depends on q, therefore
                     # p@j conflicts with q being uninstallable
                     # q being saturated means that can happen
@@ -96,11 +132,10 @@ function find_reachable(
             # find p@j's conflicts with reached versions of each partner:
             # conflicts are stored symmetrically, so scan the partner-side
             # column Y[k, c+j] == X[j, b+k], which is contiguous
-            for q in keys(info_p.interacts)
-                r = min(get(reach, q, 0), length(info[q].versions))
+            for (q, c) in partners[p]
+                r = min(reach[q], nvers[q])
                 r > 0 || continue
-                info_q = info[q]
-                k = col_max_upto(info_q.conflicts, info_q.interacts[p] + j, r)
+                k = col_max_upto(infos[q].conflicts, c + j, r)
                 k == 0 && continue
                 # p@j conflicts with q@k (the highest such k; pushing past
                 # it subsumes pushing past any lower conflicting version)
@@ -112,7 +147,7 @@ function find_reachable(
         reach[p] = i
     end
 
-    return reach
+    return Dict{P,Int}(pkgs[p] => reach[p] for p = 1:N if reach[p] > 0)
 end
 
 function mark_reachable!(
@@ -131,8 +166,27 @@ end
 function mark_necessary!(
     info :: Dict{P, PkgInfo{P,V}},
 ) where {P,V}
-    work = copy(keys(info))
-    names = sort!(collect(work))
+    # intern packages as integer indices so that the work loop below
+    # hashes no package names (sorted so the processing order — and with
+    # it any order-dependent tie — is deterministic)
+    pkgs = sort!(collect(keys(info)))
+    N = length(pkgs)
+    ix = Dict{P,Int}(p => i for (i, p) in enumerate(pkgs))
+    infos = Vector{PkgInfo{P,V}}(undef, N)
+    nvers = Vector{Int}(undef, N)
+    partners = Vector{Vector{NTuple{3,Int}}}(undef, N)
+    for p = 1:N
+        info_p = info[pkgs[p]]
+        infos[p] = info_p
+        nvers[p] = length(info_p.versions)
+        # (partner id, partner's version block offset in p's matrix,
+        #  p's version block offset in the partner's matrix)
+        prt = NTuple{3,Int}[
+            (ix[q], b, info[q].interacts[pkgs[p]])
+            for (q, b) in info_p.interacts
+        ]
+        partners[p] = sort!(prt)
+    end
     # some work buffers
     A = UInt64[]        # active version mask
     C = UInt64[]        # domination candidates mask
@@ -140,9 +194,10 @@ function mark_necessary!(
     R = Int[]           # redundant indices vector
     cols = Vector{Int}[] # per-version active constraint columns
     # initialize active column flags
-    for (p, info_p) in info
+    for p = 1:N
+        info_p = infos[p]
         X = info_p.conflicts
-        m = length(info_p.versions)
+        m = nvers[p]
         n = size(X, 2) - 1
         resize!(A, col_words(X))
         col_copy!(A, X, n + 1)
@@ -155,22 +210,26 @@ function mark_necessary!(
         # conflict columns for inactive partner versions are also
         # irrelevant: no model over the active versions can include
         # the partner, so the conflict cannot constrain anything
-        for (q, b) in info_p.interacts
-            Y = info[q].conflicts
-            for k = 1:length(info[q].versions)
+        for (q, b, c) in partners[p]
+            Y = infos[q].conflicts
+            for k = 1:nvers[q]
                 X[m+1, b+k] &= Y[k, end]
             end
         end
     end
-    sort!(names, by = p -> length(info[p].interacts))
-    for p in Iterators.cycle(names)
-        isempty(work) && break
-        p in work || continue
-        delete!(work, p)
+    # cheapest packages first; stable sort breaks ties by name
+    order = sort!(collect(1:N), by = p -> length(partners[p]))
+    inwork = trues(N)
+    nwork = N
+    for p in Iterators.cycle(order)
+        nwork == 0 && break
+        inwork[p] || continue
+        inwork[p] = false
+        nwork -= 1
         # get conflicts & dimensions
-        info_p = info[p]
+        info_p = infos[p]
         X = info_p.conflicts
-        m = length(info_p.versions)
+        m = nvers[p]
         m > 1 || continue # unique version cannot be redundant
         n = size(X, 2) - 1
         W = col_words(X)
@@ -245,10 +304,12 @@ function mark_necessary!(
         sort!(R)
         # deactivate redundant versions
         X[R, end] .= false
-        for q in keys(info_p.interacts)
-            b = info[q].interacts[p]
-            info[q].conflicts[length(info[q].versions) + 1, b .+ R] .= false
-            push!(work, q) # can create new redundancies
+        for (q, b, c) in partners[p]
+            infos[q].conflicts[nvers[q] + 1, c .+ R] .= false
+            if !inwork[q] # can create new redundancies
+                inwork[q] = true
+                nwork += 1
+            end
         end
     end
 end

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -282,9 +282,23 @@ function mark_necessary!(
                 iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
             end
         end
+        prev = -1 # chunk base of the previous active column
         for k = 1:n
             X[m+1, k] || continue # inactive column
             base = (k - 1) * W
+            # compat bounds are ranges, so identical adjacent columns are
+            # common — and re-ANDing an identical column changes nothing
+            if prev ≥ 0
+                same = true
+                @inbounds for w = 1:W
+                    if X.chunks[base + w] != X.chunks[prev + w]
+                        same = false
+                        break
+                    end
+                end
+                same && continue
+            end
+            prev = base
             @inbounds for w = 1:W
                 c = X.chunks[base + w] & T[w]
                 while !iszero(c)

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -39,14 +39,12 @@ function find_reachable(
         get(reach, p, 0) > i && return false
         get(queue, p, 0) > i && return false
         info_p = info[p]
-        n = length(info_p.versions)
-        for j = i+1:n
-            info_p.conflicts[j, end] || continue # inactive
-            queue[p] = j
-            return true
-        end
-        # we're out of versions (i.e. saturated; see below)
-        queue[p] = n+1
+        m = length(info_p.versions)
+        X = info_p.conflicts
+        # first active version after i (the flag column is the active set)
+        j = col_min_from(X, size(X, 2), i + 1, m)
+        # j == 0: we're out of versions (i.e. saturated; see below)
+        queue[p] = j == 0 ? m + 1 : j
         return true
     end
 
@@ -95,14 +93,19 @@ function find_reachable(
                     next(p, j)
                 end
             end
-            # find all p@j's conflicts
-            for (q, b) in info_p.interacts
-                for k = 1:min(get(reach, q, 0), length(info[q].versions))
-                    info_p.conflicts[j, b+k] || continue
-                    # p@j conflicts with q@k
-                    next(p, j)
-                    next(q, k)
-                end
+            # find p@j's conflicts with reached versions of each partner:
+            # conflicts are stored symmetrically, so scan the partner-side
+            # column Y[k, c+j] == X[j, b+k], which is contiguous
+            for q in keys(info_p.interacts)
+                r = min(get(reach, q, 0), length(info[q].versions))
+                r > 0 || continue
+                info_q = info[q]
+                k = col_max_upto(info_q.conflicts, info_q.interacts[p] + j, r)
+                k == 0 && continue
+                # p@j conflicts with q@k (the highest such k; pushing past
+                # it subsumes pushing past any lower conflicting version)
+                next(p, j)
+                next(q, k)
             end
         end
         # update the reach map
@@ -118,7 +121,7 @@ function mark_reachable!(
 ) where {P,V}
     reach = find_reachable(info, reqs)
     for (p, info_p) in info
-        r = get(reach, p, 0)
+        r = min(get(reach, p, 0), length(info_p.versions))
         info_p.conflicts[1:r, end] .= true
         info_p.conflicts[r+1:end, end] .= false
     end
@@ -130,65 +133,121 @@ function mark_necessary!(
 ) where {P,V}
     work = copy(keys(info))
     names = sort!(collect(work))
+    # some work buffers
+    A = UInt64[]        # active version mask
+    C = UInt64[]        # domination candidates mask
+    J = Int[]           # active versions vector
+    R = Int[]           # redundant indices vector
+    cols = Vector{Int}[] # per-version active constraint columns
     # initialize active column flags
     for (p, info_p) in info
         X = info_p.conflicts
-        m = size(X, 1)-1
-        n = size(X, 2)-1
+        m = length(info_p.versions)
+        n = size(X, 2) - 1
+        resize!(A, col_words(X))
+        col_copy!(A, X, n + 1)
+        clear_rows_above!(A, m)
         for j = 1:n
             # we don't have to look at columns that have no
             # conflicts for any active versions of package
-            X[end, j] = any(X[i, j] for i = 1:m if X[i, end])
+            X[m+1, j] = col_intersects(X, j, A)
         end
         # conflict columns for inactive partner versions are also
         # irrelevant: no model over the active versions can include
         # the partner, so the conflict cannot constrain anything
         for (q, b) in info_p.interacts
             Y = info[q].conflicts
-            for k = 1:size(Y, 1)-1
-                X[end, b+k] &= Y[k, end]
+            for k = 1:length(info[q].versions)
+                X[m+1, b+k] &= Y[k, end]
             end
         end
     end
-    # some work vectors
-    J = Int[] # active versions vector
-    K = Int[] # active conflicts vector
-    R = Int[] # redundant indices vector
     sort!(names, by = p -> length(info[p].interacts))
     for p in Iterators.cycle(names)
         isempty(work) && break
         p in work || continue
         delete!(work, p)
         # get conflicts & dimensions
-        X = info[p].conflicts
-        m = size(X, 1) - 1
+        info_p = info[p]
+        X = info_p.conflicts
+        m = length(info_p.versions)
         m > 1 || continue # unique version cannot be redundant
         n = size(X, 2) - 1
-        # active indices
-        append!(empty!(J), (j for j = 1:m if X[j, end]))
+        W = col_words(X)
+        # active version mask & indices
+        resize!(A, W)
+        col_copy!(A, X, n + 1)
+        clear_rows_above!(A, m)
+        empty!(J)
+        @inbounds for w = 1:W
+            c = A[w]
+            while !iszero(c)
+                push!(J, ((w - 1) << 6) + trailing_zeros(c) + 1)
+                c &= c - 1
+            end
+        end
         length(J) > 1 || continue # unique version cannot be redundant
-        append!(empty!(K), (k for k = 1:n if X[end, k]))
-        # find redundant versions
-        empty!(R)
+        # collect every active version's active constraint columns in one
+        # sweep over the columns, each of which is a contiguous bit span
+        while length(cols) < m
+            push!(cols, Int[])
+        end
         for j in J
-            # don't combine loops--it changes what break & continue do
-            for i in J
-                i < j || break
-                i ∈ R && continue
-                all(!X[i, k] | X[j, k] for k in K) || continue
-                # an earlier version is strictly more compatible
-                # i.e. i < j and X[i, k] => X[j, k] for all k
-                # therefore i will always be chosen instead of j
-                push!(R, j)
+            empty!(cols[j])
+        end
+        for k = 1:n
+            X[m+1, k] || continue # inactive column
+            base = (k - 1) * W
+            @inbounds for w = 1:W
+                c = X.chunks[base + w] & A[w]
+                while !iszero(c)
+                    i = ((w - 1) << 6) + trailing_zeros(c) + 1
+                    push!(cols[i], k)
+                    c &= c - 1
+                end
+            end
+        end
+        # find redundant versions: i < j and X[i, k] => X[j, k] for all
+        # active k means an earlier version is strictly more compatible,
+        # therefore i will always be chosen instead of j. the candidates
+        # dominated by i are the active versions worse than i that have a
+        # constraint in every column i does — the word-parallel
+        # intersection of i's constraint columns
+        empty!(R)
+        resize!(C, W)
+        for i in J
+            getbit(A, i) || continue # dominated versions can't dominate
+            copyto!(C, A)
+            clear_rows_upto!(C, i)
+            live = false
+            @inbounds for w = 1:W
+                live |= !iszero(C[w])
+            end
+            live || continue
+            ok = true
+            for k in cols[i]
+                col_and!(C, X, k) && continue
+                ok = false
                 break
+            end
+            ok || continue
+            # remove dominated versions from the active set & record them
+            @inbounds for w = 1:W
+                c = C[w]
+                while !iszero(c)
+                    push!(R, ((w - 1) << 6) + trailing_zeros(c) + 1)
+                    c &= c - 1
+                end
+                A[w] &= ~C[w]
             end
         end
         isempty(R) && continue
+        sort!(R)
         # deactivate redundant versions
         X[R, end] .= false
-        for q in keys(info[p].interacts)
+        for q in keys(info_p.interacts)
             b = info[q].interacts[p]
-            info[q].conflicts[end, b .+ R] .= false
+            info[q].conflicts[length(info[q].versions) + 1, b .+ R] .= false
             push!(work, q) # can create new redundancies
         end
     end
@@ -198,25 +257,26 @@ function drop_unmarked!(
     info′ :: Dict{P, <: PkgInfo{P}},
     info  :: Dict{P, <: PkgInfo{P}} = info′,
 ) where {P}
-    # info[p].conflicts[:, end] bits definitive (row flags)
-    # info[p].conflicts[end, :] bits made to match (column flags)
+    # info[p].conflicts version-flag column bits definitive
+    # info[p].conflicts column-flag row bits made to match
     for (p, info_p) in info
         X = info_p.conflicts
-        X[end, :] .= false
+        m = length(info_p.versions)
+        X[m+1, :] .= false
         # dependency column is active if:
         # - some active version has that dependency
-        for i = 1:size(X,1)-1
+        for i = 1:m
             X[i, end] || continue # skip inactive versions
             for (k, q) in enumerate(info_p.depends)
-                X[end, k] |= X[i, k]
+                X[m+1, k] |= X[i, k]
             end
         end
         # conflict column is active if:
         # - the conflicting version is active
         for (q, b) in info_p.interacts
             Y = info[q].conflicts
-            for j = 1:size(Y,1)-1
-                X[end, b + j] = Y[j, end]
+            for j = 1:length(info[q].versions)
+                X[m+1, b + j] = Y[j, end]
             end
         end
     end
@@ -232,9 +292,11 @@ function drop_unmarked!(
         D = info_p.depends
         T = info_p.interacts
         X = info_p.conflicts
-        # active version masks
-        I = X[1:end-1, end]
-        K = X[end, 1:end-1]
+        m = length(V)
+        n = size(X, 2) - 1
+        # active version & column masks
+        I = X[1:m, end]
+        K = X[m+1, 1:n]
         # delete if no active versions
         if !any(I)
             delete!(info′, p)
@@ -263,9 +325,20 @@ function drop_unmarked!(
                 b′ += n′
             end
         end
-        X′ = X[[I; true], [K; true]]
-        @assert size(X′, 1) == length(V′) + 1
-        @assert size(X′, 2) == b′ + 1
+        m′ = length(V′)
+        X′ = falses(padded_rows(m′), b′ + 1)
+        rows = findall(I)
+        j′ = 0
+        for j = 1:n
+            K[j] || continue
+            j′ += 1
+            for (i′, i) in enumerate(rows)
+                X′[i′, j′] = X[i, j]
+            end
+        end
+        @assert j′ == b′
+        X′[1:m′, end] .= true  # kept versions are active
+        X′[m′+1, 1:b′] .= true # kept columns are active
         # assign new struct into info′
         info′[p] = PkgInfo(V′, D′, T′, X′)
     end
@@ -293,7 +366,7 @@ function drop_excluded!(
             X = info_p.conflicts
             for (k, q) in enumerate(info_p.depends)
                 Y = info[q].conflicts
-                any(Y[i, end] for i=1:size(Y,1)-1) && continue
+                any(Y[i, end] for i = 1:length(info[q].versions)) && continue
                 # no active versions of q, delete p@i that depend on it
                 for i = 1:length(info_p.versions)
                     info_p.conflicts[i, end] || continue

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -217,15 +217,17 @@ function mark_necessary!(
             end
         end
     end
-    # cheapest packages first; stable sort breaks ties by name
-    order = sort!(collect(1:N), by = p -> length(partners[p]))
+    # process every package once, cheapest first (stable sort breaks ties
+    # by name); packages woken by a partner's deletions are appended to
+    # the queue unless already pending
+    queue = sort!(collect(1:N), by = p -> length(partners[p]))
     inwork = trues(N)
-    nwork = N
-    for p in Iterators.cycle(order)
-        nwork == 0 && break
+    head = 1
+    while head ≤ length(queue)
+        p = queue[head]
+        head += 1
         inwork[p] || continue
         inwork[p] = false
-        nwork -= 1
         # get conflicts & dimensions
         info_p = infos[p]
         X = info_p.conflicts
@@ -308,7 +310,7 @@ function mark_necessary!(
             infos[q].conflicts[nvers[q] + 1, c .+ R] .= false
             if !inwork[q] # can create new redundancies
                 inwork[q] = true
-                nwork += 1
+                push!(queue, q)
             end
         end
     end

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -100,12 +100,15 @@ function pkg_info(
             T[q] = n
             n += length(data[q].versions)
         end
-        # conflicts matrix (m + 1) × (n + 1)
+        # conflicts matrix: n+1 columns of padded_rows(m) bits each — rows
+        # 1:m are versions, row m+1 holds column-active flags, the rest is
+        # word-alignment padding (always zero); column n+1 holds the
+        # version-active flags
         m = length(data_p.versions)
-        X = falses(m + 1, n + 1)
-        # mark all versions as active
+        X = falses(padded_rows(m), n + 1)
+        # mark all versions & columns as active
         X[1:m, end] .= true
-        X[end, 1:n] .= true
+        X[m+1, 1:n] .= true
         # add the PkgInfo struct to dict
         info[p] = PkgInfo{P,V}(data_p.versions, D, T, X)
     end

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -164,9 +164,17 @@ function pkg_info(
         # version-active flags
         m = length(data_p.versions)
         X = falses(padded_rows(m), n + 1)
-        # mark all versions & columns as active
+        # mark all versions & columns as active; the column flags live at
+        # a fixed bit of each column's chunk span, so set them directly
+        # rather than through one strided BitArray write per column
         X[1:m, end] .= true
-        X[m+1, 1:n] .= true
+        W = col_words(X)
+        wf = (m >> 6) + 1
+        bf = UInt64(1) << (m & 63)
+        ch = X.chunks
+        @inbounds for j = 1:n
+            ch[(j - 1) * W + wf] |= bf
+        end
         # add the PkgInfo struct to dict
         info[p] = PkgInfo{P,V}(data_p.versions, D, T, X)
     end
@@ -199,11 +207,18 @@ function pkg_info(
                 @inbounds for w = 1:length(mask)
                     Y.chunks[ybase + w] |= mask[w]
                 end
-                # own-side row: one bit per conflicting partner version
+                # own-side row: one bit per conflicting partner version,
+                # written straight into the chunks (the row bit sits at a
+                # fixed offset of each column's span)
+                Wx = col_words(X)
+                wx = ((i - 1) >> 6) + 1
+                bx = UInt64(1) << ((i - 1) & 63)
+                xch = X.chunks
                 @inbounds for w = 1:length(mask)
                     z = mask[w]
                     while !iszero(z)
-                        X[i, b + ((w - 1) << 6) + trailing_zeros(z) + 1] = true
+                        j = ((w - 1) << 6) + trailing_zeros(z) + 1
+                        xch[(b + j - 1) * Wx + wx] |= bx
                         z &= z - 1
                     end
                 end

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -69,22 +69,39 @@ function pkg_info(
     filter :: Bool = true,
 ) where {P,V}
     validate_pkg_data_consistency(data, reqs)
+    # conflict masks per distinct compat entry: for each partner q with a
+    # conflicting version, the bitmask of conflicting versions of q. data
+    # providers commonly share compat dicts across versions, so each
+    # distinct entry is scanned against the partners' versions only once
+    memo = IdDict{Any, Dict{P, Vector{UInt64}}}()
+    function conflict_masks(comp_pv)
+        get!(memo, comp_pv) do
+            masks = Dict{P, Vector{UInt64}}()
+            for (q, comp_pvq) in comp_pv
+                haskey(data, q) || continue # unreachable (weak dep)
+                vers = data[q].versions
+                mask = zeros(UInt64, (length(vers) + 63) >> 6)
+                found = false
+                for (j, w) in enumerate(vers)
+                    w in comp_pvq && continue
+                    mask[((j - 1) >> 6) + 1] |= UInt64(1) << ((j - 1) & 63)
+                    found = true
+                end
+                found && (masks[q] = mask)
+            end
+            masks
+        end
+    end
+
     # compute interactions between packages
     interacts = Dict{P,Vector{P}}(p => P[] for p in keys(data))
     for (p, data_p) in data
         interacts_p = interacts[p]
         for (v, comp_pv) in data_p.compat
-            # don't combine loops--it changes what continue does
-            for (q, comp_pvq) in comp_pv
-                # continue if q is unreachable (weak dep) or already processed
-                (q == p || q ∉ keys(data) || q in interacts_p) && continue
-                interacts_q = interacts[q]
-                for w in data[q].versions
-                    w in comp_pvq && continue
-                    push!(interacts_p, q)
-                    push!(interacts_q, p)
-                    break
-                end
+            for q in keys(conflict_masks(comp_pv))
+                (q == p || q in interacts_p) && continue
+                push!(interacts_p, q)
+                push!(interacts[q], p)
             end
         end
     end
@@ -130,16 +147,24 @@ function pkg_info(
         # set compatibility bits
         for (v, comp_pv) in data_p.compat
             i = V⁻¹[v]
-            for (q, comp_pvq) in comp_pv
-                haskey(info_p.interacts, q) || continue
+            for (q, mask) in conflict_masks(comp_pv)
+                q == p && continue
                 info_q = info[q]
                 Y = info_q.conflicts
                 b = info_p.interacts[q]
                 c = info_q.interacts[p]
-                for (j, w) in enumerate(info_q.versions)
-                    w in comp_pvq && continue
-                    X[i, b + j] = true
-                    Y[j, c + i] = true
+                # partner-side column is contiguous: blit the mask
+                ybase = (c + i - 1) * col_words(Y)
+                @inbounds for w = 1:length(mask)
+                    Y.chunks[ybase + w] |= mask[w]
+                end
+                # own-side row: one bit per conflicting partner version
+                @inbounds for w = 1:length(mask)
+                    z = mask[w]
+                    while !iszero(z)
+                        X[i, b + ((w - 1) << 6) + trailing_zeros(z) + 1] = true
+                        z &= z - 1
+                    end
                 end
             end
         end

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -93,17 +93,25 @@ function pkg_info(
         end
     end
 
-    # compute interactions between packages
+    # compute interactions between packages, keeping each version's
+    # masks around for the bit-setting pass below
+    MasksT = Dict{P, Vector{UInt64}}
+    vmasks = Dict{P, Vector{Tuple{V, MasksT}}}()
     interacts = Dict{P,Vector{P}}(p => P[] for p in keys(data))
     for (p, data_p) in data
         interacts_p = interacts[p]
+        vm = Tuple{V, MasksT}[]
         for (v, comp_pv) in data_p.compat
-            for q in keys(conflict_masks(comp_pv))
+            masks = conflict_masks(comp_pv)
+            isempty(masks) && continue
+            push!(vm, (v, masks))
+            for q in keys(masks)
                 (q == p || q in interacts_p) && continue
                 push!(interacts_p, q)
                 push!(interacts[q], p)
             end
         end
+        isempty(vm) || (vmasks[p] = vm)
     end
     foreach(sort!, values(interacts))
 
@@ -145,9 +153,9 @@ function pkg_info(
             end
         end
         # set compatibility bits
-        for (v, comp_pv) in data_p.compat
+        for (v, masks) in get(vmasks, p, Tuple{V, MasksT}[])
             i = V⁻¹[v]
-            for (q, mask) in conflict_masks(comp_pv)
+            for (q, mask) in masks
                 q == p && continue
                 info_q = info[q]
                 Y = info_q.conflicts

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -70,39 +70,53 @@ function pkg_info(
 ) where {P,V}
     validate_pkg_data_consistency(data, reqs)
     # conflict masks per distinct compat entry: for each partner q with a
-    # conflicting version, the bitmask of conflicting versions of q. data
-    # providers commonly share compat dicts across versions, so each
-    # distinct entry is scanned against the partners' versions only once
-    memo = IdDict{Any, Dict{P, Vector{UInt64}}}()
-    function conflict_masks(comp_pv)
-        get!(memo, comp_pv) do
-            masks = Dict{P, Vector{UInt64}}()
-            for (q, comp_pvq) in comp_pv
-                haskey(data, q) || continue # unreachable (weak dep)
-                vers = data[q].versions
-                mask = zeros(UInt64, (length(vers) + 63) >> 6)
-                found = false
-                for (j, w) in enumerate(vers)
-                    w in comp_pvq && continue
-                    mask[((j - 1) >> 6) + 1] |= UInt64(1) << ((j - 1) & 63)
-                    found = true
-                end
-                found && (masks[q] = mask)
+    # conflicting version, the bitmask of conflicting versions of q
+    MasksT = Dict{P, Vector{UInt64}}
+    function compute_masks(comp_pv)
+        masks = MasksT()
+        for (q, comp_pvq) in comp_pv
+            haskey(data, q) || continue # unreachable (weak dep)
+            vers = data[q].versions
+            mask = zeros(UInt64, (length(vers) + 63) >> 6)
+            found = false
+            for (j, w) in enumerate(vers)
+                w in comp_pvq && continue
+                mask[((j - 1) >> 6) + 1] |= UInt64(1) << ((j - 1) & 63)
+                found = true
             end
-            masks
+            found && (masks[q] = mask)
         end
+        return masks
     end
 
     # compute interactions between packages, keeping each version's
-    # masks around for the bit-setting pass below
-    MasksT = Dict{P, Vector{UInt64}}
+    # masks around for the bit-setting pass below. data providers share
+    # compat dicts across a package's versions, so each package has only
+    # a handful of distinct entries — a linear identity scan finds them
+    # far more cheaply than hashing every version's dict
     vmasks = Dict{P, Vector{Tuple{V, MasksT}}}()
     interacts = Dict{P,Vector{P}}(p => P[] for p in keys(data))
+    objs = Vector{Any}()
+    mvals = Vector{MasksT}()
     for (p, data_p) in data
         interacts_p = interacts[p]
         vm = Tuple{V, MasksT}[]
+        empty!(objs)
+        empty!(mvals)
         for (v, comp_pv) in data_p.compat
-            masks = conflict_masks(comp_pv)
+            idx = 0
+            for ci = 1:length(objs)
+                if objs[ci] === comp_pv
+                    idx = ci
+                    break
+                end
+            end
+            if idx == 0
+                push!(objs, comp_pv)
+                push!(mvals, compute_masks(comp_pv))
+                idx = length(objs)
+            end
+            masks = mvals[idx]
             isempty(masks) && continue
             push!(vm, (v, masks))
             for q in keys(masks)

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -132,7 +132,26 @@ function pkg_info(
     # construct dict of PkgInfo structs
     info = Dict{P,PkgInfo{P,V}}()
     for (p, data_p) in data
-        D = sort!(reduce(union!, values(data_p.depends), init=P[]))
+        # union the version's dependency sets; they are shared objects
+        # (provider deduplication), so skip repeats by identity first
+        empty!(objs)
+        for dv in values(data_p.depends)
+            repeat = false
+            for o in objs
+                if o === dv
+                    repeat = true
+                    break
+                end
+            end
+            repeat || push!(objs, dv)
+        end
+        D = P[]
+        for dv in objs
+            for q in dv
+                push!(D, q)
+            end
+        end
+        D = sort!(unique!(D))
         T = Dict{P,Int}(p => 0 for p in interacts[p])
         n = length(D)
         for q in interacts[p]

--- a/src/PkgInfoFiles.jl
+++ b/src/PkgInfoFiles.jl
@@ -115,7 +115,8 @@ function read_vals(io::IO, ::Type{T}) where {T}
     for i = 1:n
         l = read_int(io)
         s = String(read(io, l))
-        v[i] = T === String ? s : parse(T, s)
+        v[i] = T === String ? s :
+               T === Symbol ? Symbol(s) : parse(T, s)
     end
     return v
 end
@@ -123,8 +124,7 @@ end
 function write_vals(io::IO, inds::Dict{<:Any,<:Integer}, v::Vector)
     write_int(io, length(v))
     for x in v
-        s = x isa String ? x : string(x)
-        write_int(io, inds[s])
+        write_int(io, inds[x])
     end
 end
 

--- a/src/PkgInfoFiles.jl
+++ b/src/PkgInfoFiles.jl
@@ -42,7 +42,7 @@ function load_pkg_info_file(
             versions  = read_vals(io, V)
             depends   = read_vals(io, pv)
             interacts = read_vals(io, pv)
-            conflicts = read_bits(io, length(versions) + 1)
+            conflicts = read_bits(io, padded_rows(length(versions)))
             interacts = Dict{P, Int}(q => 0 for q in interacts)
             info[p] = PkgInfo(versions, depends, interacts, conflicts)
         end
@@ -60,7 +60,7 @@ end
 
 ## bespoke de/serialization functions ##
 
-const magic = "\xfa\x7d\xe1\0Resolver.jl PkgInfo File\0v1\0"
+const magic = "\xfa\x7d\xe1\0Resolver.jl PkgInfo File\0v2\0"
 
 function write_magic(io::IO)
     write(io, magic)

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -2,6 +2,7 @@ module Resolver
 
 export resolve
 
+include("BitKernels.jl")
 include("DepsProvider.jl")
 include("PkgInfo.jl")
 include("PkgInfoFiles.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,6 +166,36 @@ using Resolver: PkgData
     @test_throws ArgumentError("Required package MissingReq is not available in the package data") resolve(data, [:MissingReq])
 end
 
+using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file
+@testset "pkg info files" begin
+    # roundtrip with String package names & integer versions
+    sdata = Dict(
+        "A" => PkgData([2, 1], Dict(2 => ["B"], 1 => ["B"]),
+                       Dict(2 => Dict("B" => [1]))),
+        "B" => PkgData([2, 1], Dict{Int,Vector{String}}(),
+                       Dict{Int,Dict{String,Vector{Int}}}()),
+    )
+    for filter in (false, true)
+        info = pkg_info(sdata, ["A"]; filter)
+        path = save_pkg_info_file(info)
+        @test load_pkg_info_file(path) == info
+        rm(path)
+    end
+    # roundtrip with Symbol package names & Symbol versions
+    ydata = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]),
+                      Dict(:v2 => Dict(:B => [:v1]))),
+        :B => PkgData([:v2, :v1], Dict{Symbol,Vector{Symbol}}(),
+                      Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()),
+    )
+    for filter in (false, true)
+        info = pkg_info(ydata, [:A]; filter)
+        path = save_pkg_info_file(info)
+        @test load_pkg_info_file(path) == info
+        rm(path)
+    end
+end
+
 @testset "registry resolve" begin
     rp = registry.provider()
     test_resolver(rp, ["JSON"])


### PR DESCRIPTION
A sequence of single-fix performance commits to the filtering machinery (each one passes the full test suite on its own), plus one bug fix found along the way. End result on the DifferentialEquations registry closure (764 packages / 26,361 raw versions), best of 5:

| stage | before | after | speedup |
|---|---|---|---|
| reach | 557ms | 16ms | 35× |
| redundancy | 175ms | 23ms | 7.7× |
| drop | 14ms | 9ms | 1.6× |
| **filter total** | **747ms** | **48ms** | **15.6×** |
| unfiltered info build | 182ms | 105ms | 1.7× |
| resolve end-to-end | 1188ms | 411ms | 2.9× |

The requirement-independent dominance-first split lands at 34ms for the cacheable pass + 12.5ms per resolve. Small instances (JSON, DataFrames) stay at or under a millisecond.

### How

- **Word-aligned column layout**: every conflicts BitMatrix pads its row dimension to whole 64-bit words, so each column is an aligned chunk span. Since conflicts are stored symmetrically, every pairwise scan has an orientation in which it's a contiguous column read — reach scans the partner-side column with one masked word scan, and redundancy elimination becomes word-parallel column intersection instead of per-bit row subset tests. The pkg info file format inherits the padded geometry (magic bumped to v2).
- **Package→integer interning** in both fixpoints: no name hashing in inner loops; reach's queue becomes a stack + pending vectors, redundancy's work set becomes flag bits, and the `Iterators.cycle` rescan is replaced by a FIFO queue (O(1) wake-ups).
- **Batched dominance**: per-version candidate masks updated in one sweep over active columns, with versions dropping out as their candidates empty; identical adjacent columns (ubiquitous, since compat bounds are ranges) are skipped outright.
- **drop_unmarked!** computes kept-column masks directly (partner activity word-blitted via a new `copy_col_bits!` kernel) instead of round-tripping through strided flag-row writes, and rebuilds matrices by word copy (prefix fast path) or chunk gather.
- **Build**: conflict masks computed once per distinct compat entry (providers deduplicate compat dicts across versions) and reused by both build passes, with distinct entries found by identity scan; partner-side conflict columns blitted word-wise; shared dependency vectors deduplicated by identity before unioning; remaining strided single-bit writes lowered to direct chunk stores.
- **Fix**: `save_pkg_info_file`/`load_pkg_info_file` were broken for non-String package types (stringified index lookups, no Symbol reconstruction); fixed with roundtrip tests for String- and Symbol-keyed data.

### Verification

Every optimization is behavior-preserving and verified as such: reach maps, filtered versions, and answers are **byte-identical** to the pre-optimization implementation across a 200k-instance differential dump (fixed and version-varying dependency generators) and registry checksums. Where processing order changes (FIFO queue, batched dominance), the commit messages include the confluence argument for why the fixpoint is order-independent. Full test suite passes at every commit.

Co-authored with [Claude Code](https://claude.com/claude-code) ([session](https://claude.ai/code/session_01TvDUmiXi4YDt5mkE2JB9BB)).