### PR TITLE
Run redundancy elimination first and iterate the filter to a fixpoint

### DIFF
--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -235,10 +235,10 @@ layered solution.**
 
 ## Iterating the filter
 
-The filter runs reachability once and redundancy elimination once, in
-that order. It is natural to ask whether iterating the two passes would
-prune more — and the answer illuminates what each pass can and cannot
-see.
+It is natural to ask whether a single reachability pass followed by a
+single redundancy pass leaves anything on the table — whether iterating
+the two would prune more. The answer illuminates what each pass can and
+cannot see.
 
 Reachability alone is a closure operation:
 
@@ -291,13 +291,17 @@ above.)
 
 None of this threatens correctness. By Theorem 4, *any* number of
 additional passes preserves the layered answer, so iterating the filter
-to a mutual fixpoint would be perfectly legal. It just isn't worth it:
-in deliberately conflict-dense random instances a second pass prunes
-anything at all in only about 0.007% of cases with version-independent
-dependencies and about 1% with version-varying ones — and what it prunes
-is marginal — while real registry problems are far sparser. Essentially
-all of the reduction is captured by running reachability once and
-redundancy elimination once, in that order.
+to a mutual fixpoint is perfectly legal — and since the passes are
+cheap, that is what the implementation does: redundancy elimination
+first (it needs no reachability marks, and on registry-scale problems
+it does most of the shrinking), then reachability and redundancy
+alternating until neither deletes anything. The returns diminish fast:
+a further round prunes anything at all in only about 0.007% of
+deliberately conflict-dense random instances with version-independent
+dependencies and about 1% with version-varying ones, and what it prunes
+is marginal. Essentially all of the reduction is captured by one
+reachability pass and one redundancy pass; the remaining rounds just
+collect the stragglers because they cost next to nothing.
 
 !!! warning "Formalization boundary"
     Theorems 2, 3, 5, and 6 are proved against the rule set as stated

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -2,9 +2,25 @@ function filter_pkg_info!(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
 ) where {P,V}
-    mark_reachable!(info, reqs)
+    # redundancy elimination first — it needs no reachability marks and
+    # does most of the shrinking — then alternate reachability and
+    # redundancy until neither deletes anything: each deleted version can
+    # expose more of both kinds of pruning, and every round preserves the
+    # resolved answer (see the theory docs on iterating the filter).
+    # requirement packages always survive filtering, so the requirements
+    # remain valid across rounds. rounds strictly shrink the total
+    # version count, so the loop terminates
     mark_necessary!(info)
     drop_unmarked!(info)
+    while true
+        total = sum(length(i.versions) for i in values(info); init = 0)
+        mark_reachable!(info, reqs)
+        mark_necessary!(info)
+        drop_unmarked!(info)
+        sum(length(i.versions) for i in values(info); init = 0) < total ||
+            break
+    end
+    return info
 end
 
 """


### PR DESCRIPTION
Follow-on to #38 (item 5 of the pre-SAT pipeline improvements): `filter_pkg_info!` now runs redundancy elimination *before* reachability — it needs no reachability marks, and on registry-scale problems it does most of the shrinking (the DifferentialEquations closure drops 26,361 → 5,857 versions before reach even runs) — and then alternates the two passes until neither deletes anything. Requirement packages always survive filtering, and each effective round strictly shrinks the total version count, so the loop terminates. Every round preserves the layered answer (Theorem 4); the theory docs' "Iterating the filter" section is updated to describe the new schedule.

This is the first output-changing commit of the series — kept sets can only shrink:

- Across the 200k-instance differential dump: answers and raw reach maps **byte-identical** to the previous implementation; kept sets strictly smaller in 1,763 cases, larger in none (subset-checked).
- DiffEq closure: keeps drop from 5,408 versions / 732 packages to **5,219 / 702**.
- The filter itself costs ~10ms more (the dominance pass sees the raw problem), but the smaller SAT encoding more than pays for it: resolve end-to-end 491ms vs 502ms (best of 10, measured back-to-back).

This ordering is also the split that future registry caching wants: the opening redundancy pass is requirement-independent and cacheable per registry state, leaving only the ~12ms iterate-to-fixpoint tail per resolve.

Full test suite passes; docs build clean.

Co-authored with [Claude Code](https://claude.com/claude-code) ([session](https://claude.ai/code/session_01TvDUmiXi4YDt5mkE2JB9BB)).