### PR TITLE
Descent optimizations: probe-first version optimization and false default phase

### DIFF
--- a/src/PicoSAT.jl
+++ b/src/PicoSAT.jl
@@ -18,6 +18,9 @@ add(p::Ptr{Cvoid}, v::Integer) =
     ccall((:picosat_add, lib), Cint, (Ptr{Cvoid}, Cint), p, v)
 assume(p::Ptr{Cvoid}, v::Integer) =
     ccall((:picosat_assume, lib), Cint, (Ptr{Cvoid}, Cint), p, v)
+set_global_default_phase(p::Ptr{Cvoid}, phase::Integer) =
+    ccall((:picosat_set_global_default_phase, lib), Cvoid,
+          (Ptr{Cvoid}, Cint), p, phase)
 sat(p::Ptr{Cvoid}, limit::Integer = -1) =
     ccall((:picosat_sat, lib), Cint, (Ptr{Cvoid}, Cint), p, limit)
 deref(p::Ptr{Cvoid}, v::Integer) =

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -203,6 +203,16 @@ function optimize_version!(
     sol :: Dict{P,Int},
     p   :: P,
 ) where {P}
+    # cheap first try: after filtering, the best version is feasible more
+    # often than not, and probing it by assumption needs no temp clauses
+    # at all — one solve replaces the whole improvement loop
+    if sol[p] > 1
+        sat_assume(sat, p, 1)
+        if is_satisfiable(sat)
+            extract_solution!(sat, sol)
+            @assert sol[p] == 1
+        end
+    end
     # sol[p] == 1 is already optimal: the improvement clause below would be
     # empty, forcing a guaranteed-UNSAT solve
     while sol[p] > 1

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -39,6 +39,10 @@ function SAT(
     pico = PicoSAT.init() # TODO: use jl_malloc?
     try # free memory on error
         PicoSAT.adjust(pico, N)
+        # default unconstrained variables to false: models then carry
+        # fewer spuriously-true packages ("junk"), which makes solves
+        # faster and improvement steps land on better versions
+        PicoSAT.set_global_default_phase(pico, 0)
 
         # generate SAT problem
         for p in names


### PR DESCRIPTION
Two measured wins for the SAT-side descent, found while evaluating #33 (which measurement says to close instead — see the issue for numbers). All variants verified to return identical solutions, and the brute-force reference testsets pin the semantics.

1. **Default unconstrained variables to false** (`picosat_set_global_default_phase(pico, 0)` at SAT construction). The encoding admits junk — packages set true that nothing requires — and picosat's default phase heuristic wanders into plenty of it. Defaulting to false yields near-minimal models: solves get individually faster, and the improvement loops take fewer rounds because intermediate models stop carrying arbitrary versions of untouched packages. Phase choice cannot affect the answer (the layered solution is solver-independent, Theorem 1 in the theory docs).

2. **Probe the best version by assumption before the improvement loop.** After filtering, a package's best version is feasible more often than not — so `optimize_version!` now assumes `p@1` and solves once before entering the "some strictly better version" loop. The probe needs no temp clauses and no retraction; when it holds (the common case) one solve replaces the entire improvement chain (e.g. OrdinaryDiffEq's 10-round crawl becomes a single solve). When it fails, the loop proceeds as before at the cost of one extra solve.

Descent benchmark on the DifferentialEquations closure (best of 3 runs each, identical solutions):

| scheme | descent | in-solver | solves |
|---|---|---|---|
| current (push/pop) | 197ms | 100ms | 92 |
| + phase=0 | 162ms | 69ms | 87 |
| + phase=0 + probe-first | **120ms** | **49ms** | **57** |
| activation literals (#33) | 211–215ms | 128ms | 92 |

End-to-end `resolve` on the closure, interleaved best-of-10 against main: **425ms → 343ms**.

Remaining SAT-side headroom, for the record: the 65ms SAT build is dominated by 535k pairwise conflict clauses which measure as highly compressible (51,784 version×interval clauses, or 11,226 rectangle clauses with linear-size interval-variable definitions — 48×); that's the next candidate if the build matters enough to warrant the encoding complexity.

Co-authored with [Claude Code](https://claude.com/claude-code) ([session](https://claude.ai/code/session_01TvDUmiXi4YDt5mkE2JB9BB)).
