### PR TITLE
Tolerate zero-version packages in the filter pipeline

### DIFF
--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -2,14 +2,19 @@ function filter_pkg_info!(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
 ) where {P,V}
-    # redundancy elimination first — it needs no reachability marks and
-    # does most of the shrinking — then alternate reachability and
-    # redundancy until neither deletes anything: each deleted version can
-    # expose more of both kinds of pruning, and every round preserves the
-    # resolved answer (see the theory docs on iterating the filter).
-    # requirement packages always survive filtering, so the requirements
-    # remain valid across rounds. rounds strictly shrink the total
-    # version count, so the loop terminates
+    # arc consistency first: it needs no marks and it is what makes the
+    # deletions safe — dropping a package while a kept version still
+    # depends on it would leave a dangling name. then redundancy
+    # elimination — it needs no reachability marks and does most of the
+    # shrinking — then alternate reachability and redundancy until neither
+    # deletes anything: each deleted version can expose more of both kinds
+    # of pruning, and every round preserves the resolved answer (see the
+    # theory docs on iterating the filter). requirement packages survive
+    # filtering unless they have no installable version at all — nothing
+    # can satisfy those — so the requirements remain valid across rounds.
+    # rounds strictly shrink the total version count, so the loop
+    # terminates
+    mark_installable!(info)
     mark_necessary!(info)
     drop_unmarked!(info)
     while true
@@ -50,13 +55,15 @@ function find_reachable(
     ix = Dict{P,Int}(p => i for (i, p) in enumerate(pkgs))
     infos = Vector{PkgInfo{P,V}}(undef, N)
     nvers = Vector{Int}(undef, N)
-    deps = Vector{Vector{Int}}(undef, N)     # interned depends, same order
+    # interned depends, same order (id 0: dependency absent from info,
+    # i.e. a package with no installable version — see below)
+    deps = Vector{Vector{Int}}(undef, N)
     partners = Vector{Vector{Tuple{Int,Int}}}(undef, N)
     for p = 1:N
         info_p = info[pkgs[p]]
         infos[p] = info_p
         nvers[p] = length(info_p.versions)
-        deps[p] = Int[ix[q] for q in info_p.depends]
+        deps[p] = Int[get(ix, q, 0) for q in info_p.depends]
         # (partner id, offset of p's version block in the partner's matrix)
         prt = Tuple{Int,Int}[
             (ix[q], info[q].interacts[pkgs[p]])
@@ -100,7 +107,9 @@ function find_reachable(
     #   "k is latest reachable version of q that depends on p"
 
     for p in reqs
-        enqueue(ix[p], 1)
+        # a requirement with no installable version reaches nothing
+        i = get(ix, p, 0)
+        i == 0 || enqueue(i, 1)
     end
 
     # notation:
@@ -134,6 +143,12 @@ function find_reachable(
             for (k, q) in enumerate(deps[p])
                 info_p.conflicts[j, k] || continue
                 # p@j depends on q
+                if q == 0
+                    # q has no installable version at all, so neither has
+                    # p@j: p can only be installed past it
+                    next(p, j)
+                    continue
+                end
                 rdeps_q = rdeps[q]
                 rdeps_q[p] = max(get(rdeps_q, p, 0), j)
                 next(q, 0) # q can be required
@@ -177,6 +192,42 @@ function mark_reachable!(
         info_p.conflicts[r+1:end, end] .= false
     end
     return reach
+end
+
+function mark_installable!(
+    info :: Dict{P, <: PkgInfo{P}},
+) where {P}
+    # a package with no active versions cannot be installed, so no version
+    # depending on it can be either: deactivate those, to a fixpoint (each
+    # deactivation can empty another package's active set). this is the
+    # arc-consistency test — a sound approximation of deleting model-free
+    # versions (see the theory docs) — and it is also what keeps `depends`
+    # from naming a package that `drop_unmarked!` deletes as empty
+    empties = Set{P}()
+    while true
+        empty!(empties)
+        for (p, info_p) in info
+            X = info_p.conflicts
+            any(X[i, end] for i = 1:length(info_p.versions)) && continue
+            push!(empties, p)
+        end
+        isempty(empties) && return info
+        dirty = false
+        for info_p in values(info)
+            X = info_p.conflicts
+            for (k, q) in enumerate(info_p.depends)
+                q in empties || continue
+                # q is uninstallable, drop the p@i that depend on it
+                for i = 1:length(info_p.versions)
+                    X[i, end] || continue
+                    X[i, k] || continue
+                    X[i, end] = false
+                    dirty = true
+                end
+            end
+        end
+        dirty || return info
+    end
 end
 
 function mark_necessary!(
@@ -505,34 +556,13 @@ function drop_excluded!(
     drop :: SetOrVec{P},
 ) where {P,V}
     drop isa AbstractSet || (drop = Set{P}(drop))
-    dirty = false
     for (p, info_p) in info
         # deactivate all versions of dropped packages
-        if p ∈ drop
-            info_p.conflicts[:, end] .= false
-            dirty = true
-            continue
-        end
+        p ∈ drop || continue
+        info_p.conflicts[:, end] .= false
     end
-    while dirty
-        # deactivate versions that depend on dropped packages
-        dirty = false
-        for (p, info_p) in info
-            X = info_p.conflicts
-            for (k, q) in enumerate(info_p.depends)
-                Y = info[q].conflicts
-                any(Y[i, end] for i = 1:length(info[q].versions)) && continue
-                # no active versions of q, delete p@i that depend on it
-                for i = 1:length(info_p.versions)
-                    info_p.conflicts[i, end] || continue
-                    info_p.conflicts[i, k] || continue
-                    # p@i depends on q, so drop p@i too
-                    info_p.conflicts[i, end] = false
-                    dirty = true
-                end
-            end
-        end
-    end
+    # deactivate versions that depend on dropped packages
+    mark_installable!(info)
     drop_unmarked!(info)
 end
 

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -7,6 +7,9 @@ function resolve_core(
     by   :: Function = identity, # priority ordering
     restore :: Bool = true, # restore the SAT instance's state before returning
 ) where {P}
+    # a requirement the instance doesn't know has no installable version —
+    # the filter drops such packages — so it cannot be satisfied
+    all(p -> haskey(sat.info, p), reqs) || return nothing
     # a solution exists iff the requirements are jointly satisfiable; the
     # check only assumes, so an unsatisfiable resolve leaves no state behind
     is_satisfiable(sat, reqs) || return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,6 +196,68 @@ using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file
     end
 end
 
+@testset "zero-version packages" begin
+    # a package with no versions can never be installed: requiring it makes
+    # the problem unsatisfiable, versions depending on it are uninstallable,
+    # and the filter must not leave references to it behind
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Any}}()
+
+    # a zero-version package required directly
+    data = Dict(
+        :A => PkgData(Symbol[], nodeps, nocomp),
+        :B => PkgData([:v1], nodeps, nocomp),
+    )
+    @test resolve(data, [:A]) === nothing
+    @test resolve(data, [:A, :B]) === nothing
+    @test resolve(data, [:B]) == Dict(:B => :v1)
+    @test isempty(resolve(data, Symbol[]))
+    @test !haskey(pkg_info(data, [:A]), :A)
+    test_resolver(data, [:A])
+    test_resolver(data, [:B])
+
+    # A's only version depends on the zero-version package B
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
+        :B => PkgData(Symbol[], nodeps, nocomp),
+    )
+    @test resolve(data, [:A]) === nothing
+    @test isempty(resolve(data, Symbol[]))
+    @test isempty(pkg_info(data, [:A]))
+    @test isempty(pkg_info(data, Symbol[]))
+    # unfiltered info keeps the package (and its dependents) as they are
+    info = pkg_info(data, [:A]; filter = false)
+    @test isempty(info[:B].versions)
+    @test info[:A].depends == [:B]
+    test_resolver(data, [:A])
+
+    # uninstallability propagates transitively
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
+        :B => PkgData(Symbol[], nodeps, nocomp),
+        :C => PkgData([:v1], Dict(:v1 => [:A]), nocomp),
+    )
+    @test resolve(data, [:C]) === nothing
+    @test isempty(pkg_info(data, [:C]))
+    test_resolver(data, [:C])
+
+    # A@v2 depends on the zero-version package B, A@v1 doesn't: degrade
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B]), nocomp),
+        :B => PkgData(Symbol[], nodeps, nocomp),
+        :C => PkgData([:v1], Dict(:v1 => [:A]), nocomp),
+    )
+    @test resolve(data, [:A]) == Dict(:A => :v1)
+    @test resolve(data, [:C]) == Dict(:C => :v1, :A => :v1)
+    @test isempty(resolve(data, Symbol[]))
+    info = pkg_info(data, [:A])
+    @test !haskey(info, :B)
+    @test info[:A].versions == [:v1]
+    @test isempty(info[:A].depends)
+    test_resolver(data, [:A])
+    test_resolver(data, [:C])
+end
+
 @testset "registry resolve" begin
     rp = registry.provider()
     test_resolver(rp, ["JSON"])


### PR DESCRIPTION
## What

`resolve` (and `pkg_info` with `filter=true`) threw `KeyError` when the dependency graph contains a **zero-version package** — a package present in `data` with an empty version list, e.g. because a caller pre-filtered all its versions away. Now such packages are treated as what they are: uninstallable.

- requiring one (directly or transitively) → `nothing` (unsatisfiable)
- a version depending on one is skipped, and resolution degrades past it to versions that don't
- empty requirements with a zero-version package present → empty solution
- `pkg_info(data, reqs)` never throws; filtered info simply drops the uninstallable parts

## Why it crashed

Two spots, one root cause: `filter_pkg_info!` runs `mark_necessary!`/`drop_unmarked!` before reachability, and `drop_unmarked!` deletes a zero-version package while other packages' `depends` still name it. `find_reachable`'s interning lookup `ix[q]` then throws; even made tolerant, the dangling name next crashes `SAT()`'s `vars[q]`. So the fix maintains the structural invariant (every `depends` name resolves in `keys(info)`) rather than papering over lookups.

## How

- **`mark_installable!` (new, factored not invented):** deactivates versions whose dependency has no active versions, to a fixpoint, running first in `filter_pkg_info!`. This is exactly the arc-consistency test the theory docs already bless as a sound approximation of deleting model-free versions, so it changes no answers — and it is `drop_excluded!`'s existing inline dirty-loop factored out (`drop_excluded!` now calls it; net −36 lines there). It only needs to run once: after round 1, a package can only empty via reachability, which implies no active dependents remain.
- **`find_reachable` tolerance:** dependencies absent from `info` intern as id 0 and are treated as permanently saturated (the depending version must be degraded past); requirements absent from `info` seed nothing.
- **`resolve_core`:** a requirement the SAT instance doesn't know returns `nothing`. Note the small behavioral change: `resolve(::Dict{P,PkgInfo}, reqs)` / `resolve(::SAT, reqs)` with a bogus package name now returns `nothing` instead of throwing; the data-level entry points still throw the informative `ArgumentError` from `pkg_info` validation.

## Verification

- New `zero-version packages` testset (44 assertions), each case cross-checked against the brute-force reference via `test_resolver`.
- Full suite green (~1.3M randomized assertions + brute-force reference + registry + bin tooling).
- Scratch fuzz (not committed): 3000 random instances with ~30% zero-version packages — `resolve` matched the reference resolver and no dangling names in filtered info, 6000/6000.
- Perf: `mark_installable!` costs ~60 µs of `filter_pkg_info!`'s ~56 ms on registry-scale data (764 packages / 26k versions), ~0.1%.

## Co-author

Implemented with [Claude Code](https://claude.com/claude-code): fix and tests by Claude, directed and reviewed by @StefanKarpinski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7
