### PR TITLE
Problem type: user compat and pins as resolve-time constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,6 +1,6 @@
 module Registries
 
-export registry_provider, package_info
+export registry_provider, package_info, bundled_versions
 
 import Base: UUID
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS, StdlibInfo
@@ -92,34 +92,24 @@ function dedup_values!(d::AbstractDict, vers::Vector)
     return d
 end
 
-function registry_provider(
-    packages       :: Dict{UUID,Vector{PkgEntry}};
-    julia_versions :: VersionSpec = VersionSpec("1"),
-    project_compat :: Dict{UUID,VersionSpec} = Dict{UUID,VersionSpec}(),
-    sort_versions  :: Function = sort_versions_default,
-    allow_pre      :: Dict{UUID,Bool} = Dict{UUID,Bool}(),
-    workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
-                      Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
+# The Julia versions to resolve against, and what they bundle:
+#
+#   stdlibs[uuid][version] : the historical stdlib info for a bundled version
+#   stdlib_pins[uuid]      : the (Julia version, pinned-version spec) pairs.
+#     Recorded so `registry_provider` can widen a stdlib's own `julia` compat
+#     to include the Julia versions that bundle each of its versions.
+#
+# Split out of `registry_provider` because `bin/resolve.jl` needs the bundled
+# version sets too (see `bundled_versions`).
+function julia_and_stdlib_versions(
+    julia_versions :: VersionSpec,
+    allow_pre      :: Dict{UUID,Bool} = Dict(UUID(0) => false),
 )
-    function filter_pre!(uuid::UUID, vers::Vector{VersionNumber})
-        if !get(allow_pre, uuid, allow_pre[UUID(0)])
-            filter!(v->isempty(v.prerelease), vers)
-        end
-        return vers
-    end
-
-    function filter_yanked!(info, vers::Vector{VersionNumber})
-        filter!(v -> !isyanked(info, v), vers)
-        return vers
-    end
-
     julia_vers = filter(in(julia_versions), JULIA_VERSIONS)
-    filter_pre!(JULIA_UUID, julia_vers)
+    get(allow_pre, JULIA_UUID, allow_pre[UUID(0)]) ||
+        filter!(v -> isempty(v.prerelease), julia_vers)
 
     stdlibs = Dict{UUID,Dict{VersionNumber,StdlibInfo}}()
-    # For each stdlib package: the (Julia version, pinned-version spec) pairs.
-    # Recorded so we can later widen the stdlib's own `julia` compat to include
-    # the Julia versions that bundle each of its versions (see the closure).
     stdlib_pins = Dict{UUID,Vector{Tuple{VersionNumber,VersionSpec}}}()
     for julia_ver in julia_vers
         last_stdlibs = UNREGISTERED_STDLIBS
@@ -157,6 +147,46 @@ function registry_provider(
             deps_u[stdlib_ver] = stdlib_info
         end
     end
+    return julia_vers, stdlibs, stdlib_pins
+end
+
+# Per package, the versions the provider offers because a Julia in
+# `julia_versions` bundles them -- regardless of what the registries say, and
+# regardless of any user compat. `bin/resolve.jl` widens the project's compat
+# bounds with these so that moving compat out of the provider (where it was
+# applied to the registry versions *before* the bundled ones were patched in)
+# doesn't change any answers.
+function bundled_versions(
+    julia_versions :: VersionSpec,
+    allow_pre      :: Dict{UUID,Bool} = Dict(UUID(0) => false),
+)
+    _, stdlibs, _ = julia_and_stdlib_versions(julia_versions, allow_pre)
+    Dict{UUID,Vector{VersionNumber}}(
+        uuid => collect(keys(vers)) for (uuid, vers) in stdlibs)
+end
+
+function registry_provider(
+    packages       :: Dict{UUID,Vector{PkgEntry}};
+    julia_versions :: VersionSpec = VersionSpec("1"),
+    sort_versions  :: Function = sort_versions_default,
+    allow_pre      :: Dict{UUID,Bool} = Dict{UUID,Bool}(),
+    workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
+                      Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
+)
+    function filter_pre!(uuid::UUID, vers::Vector{VersionNumber})
+        if !get(allow_pre, uuid, allow_pre[UUID(0)])
+            filter!(v->isempty(v.prerelease), vers)
+        end
+        return vers
+    end
+
+    function filter_yanked!(info, vers::Vector{VersionNumber})
+        filter!(v -> !isyanked(info, v), vers)
+        return vers
+    end
+
+    julia_vers, stdlibs, stdlib_pins =
+        julia_and_stdlib_versions(julia_versions, allow_pre)
 
     return DepsProvider(keys(packages)) do uuid::UUID
         if uuid in keys(workspace_pkgs)
@@ -200,9 +230,10 @@ function registry_provider(
                 new_vers = collect(keys(info.version_info))
                 filter_pre!(uuid, new_vers)
                 filter_yanked!(info, new_vers)
-                if uuid in keys(project_compat)
-                    filter!(in(project_compat[uuid]), new_vers)
-                end
+                # the project's own compat is *not* applied here: it is a user
+                # constraint, and it reaches the resolver as part of the
+                # `Problem` (see bin/resolve.jl). the provider only decides
+                # which versions exist at all
                 # scan versions and populate deps & compat data
                 for v in new_vers
                     # NOTE: we probably won't support the same name meaning

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -14,7 +14,9 @@ usage: $PROGRAM_FILE [options] [<project path>]
   --print-manifest        print the new manifest to stdout
   --print-versions        print the resolved versions to stdout
 
-  --julia=<versions>      Julia versions to resolve for (default: 1+)
+  --julia=<versions>      Julia versions to resolve for; overrides the
+                          project's own [compat] julia bound, which is
+                          the default (and 1+ if it has none too)
                           use registry compat syntax, not semver
 
   --allow-pre[=<pkgs>]    allow prerelease versions
@@ -93,15 +95,6 @@ import Pkg.Versions: VersionSpec, semver_spec
 import Resolver: Resolver, DepsProvider, PkgData, Problem, resolve
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS
 import TOML
-
-## options: target Julia version
-
-const julia_versions = handle_opts(:julia, VersionSpec("1")) do val::String
-    try VersionSpec(split(val, r"\s*,\s*"))
-    catch
-        usage("Invalid compat version spec: --julia=$val")
-    end
-end
 
 ## load project & manifest
 
@@ -255,6 +248,33 @@ if in_workspace
         end
     end
 end
+
+## options: target Julia version
+#
+# The Julia versions to resolve for come from `--julia` if given, otherwise
+# from the project's own `[compat] julia` bound (intersected across the
+# workspace above), otherwise from the `1` default. `--julia` overrides the
+# project bound outright rather than intersecting with it, so the flag always
+# says exactly what will be resolved for.
+#
+# Whichever source wins feeds the one `julia_versions` spec that determines
+# both the `julia` package's version universe and, through it, which
+# historical stdlib versions are bundled and pinned (see Registries.jl) --
+# so a project bound and the equivalent `--julia` are indistinguishable
+# downstream. The bound is *consumed* here: it must not also constrain
+# `julia` as a user compat entry in the `Problem` below, or the two readings
+# of the same entry would compound.
+
+const julia_versions = something(
+    handle_opts(:julia) do val::String
+        try VersionSpec(split(val, r"\s*,\s*"))
+        catch
+            usage("Invalid compat version spec: --julia=$val")
+        end
+    end,
+    pop!(project_compat, JULIA_UUID, nothing),
+    VersionSpec("1"),
+)
 
 ## options: parsing packages specs
 
@@ -437,21 +457,16 @@ reg = registry_provider(
 
 # the project's compat bounds are user constraints, not part of the package
 # universe: they go into the `Problem`, which forbids the versions they exclude
-# by clause instead of deleting them from the provider's data. two entries are
-# deliberately widened or dropped so the answers stay exactly what they were
-# when the provider applied compat itself:
-#
-#   * `julia` is dropped -- its version universe is set by `--julia` (which
-#     also drives the historical-stdlib pinning), and the project's own
-#     `julia` compat has never constrained resolution here;
-#   * bounds on packages Julia bundles as stdlibs are widened to admit the
-#     bundled versions -- the provider applied compat to a package's registry
-#     versions and *then* patched the bundled ones back in, so those were
-#     never subject to it. (a bundled version is pinned by the Julia that
-#     bundles it, so excluding it just makes that Julia infeasible.)
+# by clause instead of deleting them from the provider's data. (the `julia`
+# bound is not among them: it was consumed above, as the Julia version
+# universe.) bounds on packages Julia bundles as stdlibs are widened to admit
+# the bundled versions, so that answers stay exactly what they were when the
+# provider applied compat itself: it applied compat to a package's registry
+# versions and *then* patched the bundled ones back in, so those were never
+# subject to it. (a bundled version is pinned by the Julia that bundles it, so
+# excluding it just makes that Julia infeasible.)
 let compat = Dict{UUID,VersionSpec}(), bundled = bundled_versions(julia_versions, allow_pre)
     for (uuid, spec) in project_compat
-        uuid ≠ JULIA_UUID || continue
         for v in get(bundled, uuid, ())
             spec = spec ∪ VersionSpec(v)
         end

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -90,7 +90,7 @@ end
 import Pkg.Registry: JULIA_UUID, PkgEntry, RegistryInstance,    init_package_info!, reachable_registries
 import Pkg.Types: Context, EnvCache, Manifest, PackageEntry, get_last_stdlibs, write_manifest
 import Pkg.Versions: VersionSpec, semver_spec
-import Resolver: Resolver, DepsProvider, PkgData, resolve
+import Resolver: Resolver, DepsProvider, PkgData, Problem, resolve
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS
 import TOML
 
@@ -430,13 +430,38 @@ end
 reg = registry_provider(
     packages;
     julia_versions,
-    project_compat,
     sort_versions,
     allow_pre,
     workspace_pkgs,
 )
-pkg_info = Resolver.pkg_info(reg, reqs)
-sol = resolve(pkg_info, reqs; by=sort_packages_by)
+
+# the project's compat bounds are user constraints, not part of the package
+# universe: they go into the `Problem`, which forbids the versions they exclude
+# by clause instead of deleting them from the provider's data. two entries are
+# deliberately widened or dropped so the answers stay exactly what they were
+# when the provider applied compat itself:
+#
+#   * `julia` is dropped -- its version universe is set by `--julia` (which
+#     also drives the historical-stdlib pinning), and the project's own
+#     `julia` compat has never constrained resolution here;
+#   * bounds on packages Julia bundles as stdlibs are widened to admit the
+#     bundled versions -- the provider applied compat to a package's registry
+#     versions and *then* patched the bundled ones back in, so those were
+#     never subject to it. (a bundled version is pinned by the Julia that
+#     bundles it, so excluding it just makes that Julia infeasible.)
+let compat = Dict{UUID,VersionSpec}(), bundled = bundled_versions(julia_versions, allow_pre)
+    for (uuid, spec) in project_compat
+        uuid ≠ JULIA_UUID || continue
+        for v in get(bundled, uuid, ())
+            spec = spec ∪ VersionSpec(v)
+        end
+        compat[uuid] = spec
+    end
+    global const problem = Problem(reqs; compat)
+end
+
+pkg_info = Resolver.pkg_info(reg, problem)
+sol = resolve(pkg_info, problem; by=sort_packages_by)
 sol === nothing && error("Unsatisfiable")
 
 ## output results
@@ -548,6 +573,14 @@ for (uuid, version) in sol
 end
 
 if output == :print_versions
+    # the best version of a package that the project's constraints admit: the
+    # info keeps the versions the Problem forbids (they are constrained away,
+    # not deleted), so they don't count as available here
+    function best_version(uuid::UUID)
+        vers = pkg_info[uuid].versions
+        i = findfirst(v -> !Resolver.is_excluded(problem, uuid, v), vers)
+        return isnothing(i) ? first(vers) : vers[i]
+    end
     # print packages and versions in priority order, required packages first
     pkgs = sort!(collect(keys(sol)), by = sort_packages_by)
     sort!(pkgs, by = !in(reqs))
@@ -568,7 +601,7 @@ if output == :print_versions
             version = something(info_map[uuid].version, julia_version)
         end
         optimal = uuid in keys(stdlibs) ||
-            version == first(pkg_info[uuid].versions)
+            version == best_version(uuid)
         try print(uuid, " ", rpad(name, width), " ", version)
             optimal || print(" ⊼")
             println()

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -1,6 +1,7 @@
 #!/usr/bin/env julia
 #
-# Regression tests for the `bin/` resolver tooling (bin/Registries.jl).
+# Regression tests for the `bin/` resolver tooling (bin/Registries.jl, plus
+# option handling exercised through bin/resolve.jl in a subprocess).
 #
 # Run from the repo root with the bin/ environment:
 #
@@ -44,6 +45,36 @@ function resolves(reqs::Vector{UUID}; julia::VersionSpec)
     reg = make_provider(julia)
     info = Resolver.pkg_info(reg, reqs)
     Resolver.resolve(info, reqs) !== nothing
+end
+
+# Resolve a one-dependency project with the given `[compat]` body and command
+# line flags, returning uuid => version. This drives the real `bin/resolve.jl`
+# in a subprocess, since that is where the project file is read and where the
+# option precedence lives. `--print-versions` (rather than manifest
+# generation) so it works on any host Julia, prerelease included.
+const RESOLVE_JL = normpath(joinpath(@__DIR__, "..", "resolve.jl"))
+const BIN_PROJECT = normpath(joinpath(@__DIR__, ".."))
+
+function resolve_versions(compat::AbstractString, flags::Vector{String} = String[])
+    dir = mktempdir()
+    open(joinpath(dir, "Project.toml"), "w") do io
+        println(io, "[deps]")
+        println(io, "JSON = \"$JSON\"")
+        isempty(compat) && return
+        println(io, "\n[compat]")
+        println(io, compat)
+    end
+    out = IOBuffer()
+    julia = Base.julia_cmd()[1]
+    cmd = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions $flags`
+    success(pipeline(cmd; stdout = out)) || error("failed: $cmd")
+    vers = Dict{UUID,VersionNumber}()
+    for line in eachline(seekstart(out))
+        m = match(r"^(\S{36})\s+\S+\s+(\S+)", line)
+        isnothing(m) && continue
+        vers[UUID(m[1])] = VersionNumber(m[2])
+    end
+    return vers
 end
 
 @testset "bin/Registries.jl" begin
@@ -105,5 +136,35 @@ end
         @test haskey(bundled, STATISTICS)
         @test v"1.10.0" in bundled[STATISTICS]
         @test !haskey(bundled, JSON) # not a stdlib
+    end
+
+    # The Julia versions to resolve for come from `--julia` if given, otherwise
+    # from the project's own `[compat] julia` bound, otherwise from the `1`
+    # default. Unlike every other compat entry, the `julia` bound selects a
+    # version *universe* rather than constraining one: it decides which Julias
+    # exist to be resolved among, and with them which stdlib versions are
+    # bundled and pinned.
+    @testset "julia compat as the default julia bound" begin
+        # the newest release the `1` default admits: what resolving with
+        # neither a flag nor a project bound has always picked
+        newest = maximum(v for v in Registries.JULIA_VERSIONS
+                         if isempty(v.prerelease) && v ∈ VersionSpec("1"))
+
+        # neither a flag nor a bound: unchanged
+        plain = resolve_versions("")
+        @test plain[JULIA_UUID] == newest
+
+        # the project's bound supplies the default, and here it changes the
+        # answer -- which it silently failed to do before
+        bound = resolve_versions("julia = \"~1.10\"")
+        @test bound[JULIA_UUID] ∈ VersionSpec("1.10")
+        @test bound[JULIA_UUID] ≠ plain[JULIA_UUID]
+
+        # `--julia` overrides the bound outright rather than intersecting with
+        # it: the answer is exactly the flag's answer on a project with no
+        # bound at all
+        flag = resolve_versions("julia = \"~1.10\"", ["--julia=1.9"])
+        @test flag[JULIA_UUID] ∈ VersionSpec("1.9")
+        @test flag == resolve_versions("", ["--julia=1.9"])
     end
 end

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -22,6 +22,8 @@ include(joinpath(@__DIR__, "..", "Registries.jl"))
 # UUIDs of the packages involved in issue #24.
 const COMPILER_SUPPORT_LIBRARIES_JLL = UUID("e66e0078-7015-5450-92f7-15fbd957f2ae")
 const LINEAR_ALGEBRA = UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e")
+const JSON = UUID("682c06a0-de6a-54ab-a142-c8b1cf79cde6")
+const STATISTICS = UUID("10745b16-79ce-11e8-11f9-7d13ad32a3b2")
 
 # Load packages from the installed registries (mirrors bin/resolve.jl).
 const packages = Dict{UUID,Vector{PkgEntry}}()
@@ -75,5 +77,33 @@ end
         @test resolves([COMPILER_SUPPORT_LIBRARIES_JLL, JULIA_UUID]; julia = VersionSpec("1.10"))
         # Realistic reproducer: LinearAlgebra pulls in the same stack transitively.
         @test resolves([LINEAR_ALGEBRA, JULIA_UUID]; julia = VersionSpec("1.10.8"))
+    end
+
+    # A project's compat bounds are user constraints, so the provider no longer
+    # applies them: they reach the resolver as part of a `Problem`, which
+    # forbids the excluded versions by clause rather than deleting them.
+    @testset "project compat travels in the Problem" begin
+        reg = make_provider(VersionSpec("1.10"))
+        prob = Resolver.Problem([JSON, JULIA_UUID];
+            compat = Dict(JSON => VersionSpec("0.20")))
+        info = Resolver.pkg_info(reg, prob)
+        sol = Resolver.resolve(info, prob)
+        @test sol !== nothing
+        @test sol[JSON] ∈ VersionSpec("0.20")
+        # the provider still offers the newer versions and the filter keeps
+        # them: they are constrained away, not deleted
+        @test info[JSON].versions[1] ∉ VersionSpec("0.20")
+    end
+
+    # The provider offers a bundled stdlib version whatever the registries say,
+    # and it used to apply project compat to the registry versions only --
+    # before patching the bundled ones back in. `bundled_versions` is what lets
+    # bin/resolve.jl widen its Problem's bounds to reproduce that exactly.
+    # Julia 1.10.8 is frozen, so what it bundles never changes.
+    @testset "bundled stdlib versions" begin
+        bundled = bundled_versions(VersionSpec("1.10.8"))
+        @test haskey(bundled, STATISTICS)
+        @test v"1.10.0" in bundled[STATISTICS]
+        @test !haskey(bundled, JSON) # not a stdlib
     end
 end

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,10 +2,12 @@
 
 ```@docs
 resolve
+Problem
 ```
 
 ## Internals
 
 ```@docs
 Resolver.find_reachable
+Resolver.exclusion_masks
 ```

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -1,7 +1,20 @@
-function filter_pkg_info!(
+filter_pkg_info!(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
+) where {P,V} = filter_pkg_info!(info, Problem(reqs))
+
+function filter_pkg_info!(
+    info :: Dict{P, PkgInfo{P,V}},
+    prob :: Problem{P},
 ) where {P,V}
+    reqs = prob.reqs
+    # user constraints enter as the exclusion masks of the virtual package
+    # that represents them (see Problem.jl): reachability treats an excluded
+    # version as one that conflicts with an always-present version, and
+    # redundancy treats the mask as one more conflict column. the masks are
+    # index-based, so they are rebuilt after every deletion round; only the
+    # constrained packages cost anything
+    excl = exclusion_masks(info, prob)
     # arc consistency first: it needs no marks and it is what makes the
     # deletions safe — dropping a package while a kept version still
     # depends on it would leave a dangling name. then redundancy
@@ -15,12 +28,13 @@ function filter_pkg_info!(
     # rounds strictly shrink the total version count, so the loop
     # terminates
     mark_installable!(info)
-    mark_necessary!(info)
+    mark_necessary!(info, excl)
     drop_unmarked!(info)
     while true
         total = sum(length(i.versions) for i in values(info); init = 0)
-        mark_reachable!(info, reqs)
-        mark_necessary!(info)
+        excl = exclusion_masks(info, prob)
+        mark_reachable!(info, reqs, excl)
+        mark_necessary!(info, excl)
         drop_unmarked!(info)
         sum(length(i.versions) for i in values(info); init = 0) < total ||
             break
@@ -40,6 +54,13 @@ of required "root" packages, using the following recursive logic:
 - P[i] reachable & P[i] conflicts w. reachable => P[i+1] reachable
 - D[end] conflicts w. reachable & P[i] depends on D => P[i+1] reachable
 
+The optional `excl` argument gives, per package, a mask of versions the user
+forbade. Those are the conflict rows of the always-present virtual package that
+represents the user constraints, so a reachable excluded version fires the same
+degradation rule as any other conflict:
+
+- P[i] reachable & P[i] excluded => P[i+1] reachable
+
 The function returns a dictionary mapping packages to the maximum version index
 of that package that could be reached in an optimal solution. If a package
 cannot appear in an optimal solution, it will not appear in this dictionary.
@@ -47,6 +68,7 @@ cannot appear in an optimal solution, it will not appear in this dictionary.
 function find_reachable(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
+    excl :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
 ) where {P,V}
     # intern packages as integer indices so that the fixpoint loop below
     # hashes no package names; all derived tables are indexed by pkg id
@@ -59,10 +81,13 @@ function find_reachable(
     # i.e. a package with no installable version — see below)
     deps = Vector{Vector{Int}}(undef, N)
     partners = Vector{Vector{Tuple{Int,Int}}}(undef, N)
+    # interned exclusion masks (nothing: package unconstrained, the norm)
+    excls = Vector{Union{Nothing,BitVector}}(nothing, N)
     for p = 1:N
         info_p = info[pkgs[p]]
         infos[p] = info_p
         nvers[p] = length(info_p.versions)
+        excls[p] = get(excl, pkgs[p], nothing)
         deps[p] = Int[get(ix, q, 0) for q in info_p.depends]
         # (partner id, offset of p's version block in the partner's matrix)
         prt = Tuple{Int,Int}[
@@ -138,7 +163,12 @@ function find_reachable(
             end
         end
         # process each newly reachable version of p
+        excl_p = excls[p]
         for j = reach[p]+1:min(i, m)
+            # user constraints: p@j conflicts with the always-present
+            # version of the virtual package, so it can never be a resting
+            # point — p can only be installed past it
+            excl_p === nothing || !excl_p[j] || next(p, j)
             # dependencies
             for (k, q) in enumerate(deps[p])
                 info_p.conflicts[j, k] || continue
@@ -184,8 +214,9 @@ end
 function mark_reachable!(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
+    excl :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
 ) where {P,V}
-    reach = find_reachable(info, reqs)
+    reach = find_reachable(info, reqs, excl)
     for (p, info_p) in info
         r = min(get(reach, p, 0), length(info_p.versions))
         info_p.conflicts[1:r, end] .= true
@@ -232,6 +263,7 @@ end
 
 function mark_necessary!(
     info :: Dict{P, PkgInfo{P,V}},
+    excl :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
 ) where {P,V}
     # intern packages as integer indices so that the work loop below
     # hashes no package names (sorted so the processing order — and with
@@ -242,10 +274,13 @@ function mark_necessary!(
     infos = Vector{PkgInfo{P,V}}(undef, N)
     nvers = Vector{Int}(undef, N)
     partners = Vector{Vector{NTuple{3,Int}}}(undef, N)
+    # interned exclusion masks (nothing: package unconstrained, the norm)
+    excls = Vector{Union{Nothing,BitVector}}(nothing, N)
     for p = 1:N
         info_p = info[pkgs[p]]
         infos[p] = info_p
         nvers[p] = length(info_p.versions)
+        excls[p] = get(excl, pkgs[p], nothing)
         # (partner id, partner's version block offset in p's matrix,
         #  p's version block offset in the partner's matrix)
         prt = NTuple{3,Int}[
@@ -258,6 +293,7 @@ function mark_necessary!(
     A = UInt64[]        # active version mask
     D = UInt64[]        # per-version domination candidate masks
     T = UInt64[]        # mask of versions still tracked by the sweep
+    E = UInt64[]        # exclusion mask, padded to the column width
     R = Int[]           # redundant indices vector
     # initialize active column flags
     for p = 1:N
@@ -375,6 +411,29 @@ function mark_necessary!(
                     live = UInt64(0)
                     for w′ = 1:W
                         live |= (D[o + w′] &= X.chunks[base + w′])
+                    end
+                    iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
+                end
+            end
+        end
+        # the virtual package representing the user constraints contributes
+        # one more conflict column — the exclusion mask. its version is
+        # always present, so the column is always active: an excluded
+        # version must not dominate a non-excluded one
+        excl_p = excls[p]
+        if excl_p !== nothing
+            resize!(E, W)
+            fill!(E, 0)
+            copyto!(E, 1, excl_p.chunks, 1, min(W, length(excl_p.chunks)))
+            @inbounds for w = 1:W
+                c = E[w] & T[w]
+                while !iszero(c)
+                    i = ((w - 1) << 6) + trailing_zeros(c) + 1
+                    c &= c - 1
+                    o = (i - 1) * W
+                    live = UInt64(0)
+                    for w′ = 1:W
+                        live |= (D[o + w′] &= E[w′])
                     end
                     iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
                 end

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -55,19 +55,33 @@ end
 
 function pkg_info(
     deps :: DepsProvider{P},
-    reqs :: SetOrVec{P} = deps.packages;
+    prob :: Problem{P};
     filter :: Bool = true,
 ) where {P}
-    data = pkg_data(deps, reqs)
-    info = pkg_info(data, reqs; filter)
+    data = pkg_data(deps, prob.reqs)
+    info = pkg_info(data, prob; filter)
     return info
 end
 
-function pkg_info(
-    data :: AbstractDict{P,<:PkgData{P,V}},
+# bare requirements: an unconstrained problem (which costs nothing to build)
+pkg_info(
+    deps :: DepsProvider{P},
+    reqs :: SetOrVec{P} = deps.packages;
+    filter :: Bool = true,
+) where {P} = pkg_info(deps, Problem(reqs); filter)
+
+pkg_info(
+    data :: AbstractDict{P,<:PkgData{P}},
     reqs :: SetOrVec{P} = keys(data);
     filter :: Bool = true,
+) where {P} = pkg_info(data, Problem(reqs); filter)
+
+function pkg_info(
+    data :: AbstractDict{P,<:PkgData{P,V}},
+    prob :: Problem{P};
+    filter :: Bool = true,
 ) where {P,V}
+    reqs = prob.reqs
     # intern packages as integer indices once, up front: the build phases
     # below run entirely on vectors, and package names reappear only in
     # the final PkgInfo structures. ids follow name order (packages are
@@ -287,7 +301,7 @@ function pkg_info(
     end
 
     # only keep reachable, necessary packages & versions
-    filter && filter_pkg_info!(info, reqs)
+    filter && filter_pkg_info!(info, prob)
 
     return info
 end

--- a/src/Problem.jl
+++ b/src/Problem.jl
@@ -1,0 +1,105 @@
+# An empty dictionary that costs nothing to make: a singleton, since it has no
+# fields. Constructing an unconstrained `Problem` — which every convenience
+# `resolve` entry point does — must not allocate a pair of dictionaries just to
+# say "no constraints", and the filter must not allocate a mask dictionary per
+# round just to say "no masks".
+struct EmptyDict{K,V} <: AbstractDict{K,V} end
+
+Base.length(::EmptyDict) = 0
+Base.iterate(::EmptyDict, state...) = nothing
+Base.haskey(::EmptyDict, key) = false
+Base.get(::EmptyDict, key, default) = default
+Base.getindex(::EmptyDict, key) = throw(KeyError(key))
+
+"""
+    Problem(reqs; compat = ..., pins = ...)
+
+A resolution problem: the required packages `reqs`, plus the user constraints
+that say which versions are admissible — `compat` bounds (allowed-version sets,
+queried with `in`) and `pins` (hold a package at exactly one version). A
+`Problem` carries everything that determines *satisfiability*; orderings (the
+`by` priority order, the version rank order) are `resolve` parameters instead.
+
+Constraints for packages that don't exist, and constraints that exclude
+nothing, are allowed and have no effect.
+"""
+struct Problem{P,V,S}
+    reqs   :: Vector{P}
+    # allowed-version sets, queried via `in(v, s)`, and exact-version pins.
+    # abstractly typed so that the unconstrained case can share one immutable
+    # empty dictionary instead of allocating two per problem
+    compat :: AbstractDict{P,S}
+    pins   :: AbstractDict{P,V}
+end
+
+function Problem(
+    reqs   :: SetOrVec{P};
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+) where {P}
+    Problem{P, valtype(pins), valtype(compat)}(
+        P[p for p in reqs], adopt(compat), adopt(pins))
+end
+
+# a caller's dictionary is copied, so later mutation can't change the problem;
+# the shared empties are immutable and shared on purpose
+adopt(d::AbstractDict) = Dict(d)
+adopt(d::EmptyDict) = d
+
+# does the problem constrain nothing at all? the fast paths below lean on this:
+# an unconstrained resolve must not do any per-version work
+is_constrained(prob::Problem) = !isempty(prob.compat) || !isempty(prob.pins)
+
+# The user constraints are read as a *virtual package*: one always-required
+# version, no dependencies, whose conflict rows are exactly the exclusions
+# below. Under that reading a constrained problem is an ordinary resolution
+# problem, so the filtering theorems (see the manual's Theory section) apply
+# verbatim. The implementation special-cases the virtual package as the
+# per-package exclusion masks computed here — one extra degradation trigger in
+# `find_reachable`, one extra conflict column in `mark_necessary!`, and one
+# selector-guarded clause group per constraint source in `SAT`.
+
+# does the user forbid version v of package p?
+function is_excluded(prob::Problem{P}, p::P, v) where {P}
+    s = get(prob.compat, p, nothing)
+    s === nothing || v ∈ s || return true
+    w = get(prob.pins, p, nothing)
+    w === nothing || v == w || return true
+    return false
+end
+
+# the packages the user constrained, in a deterministic order
+constrained_packages(prob::Problem{P}) where {P} =
+    sort!(collect(union(keys(prob.compat), keys(prob.pins))))
+
+"""
+    exclusion_masks(info, prob) :: AbstractDict{P, BitVector}
+
+The versions of each package that `prob`'s user constraints forbid, as a mask
+over that package's version list in `info`. Only packages with a constraint
+that actually excludes something get an entry, so packages the user did not
+constrain — the overwhelming majority — cost nothing downstream.
+
+Masks are index-based, so they must be recomputed whenever versions are
+dropped and renumbered (see `filter_pkg_info!`).
+"""
+function exclusion_masks(
+    info :: AbstractDict{P}, # a PkgInfo dict (declared before PkgInfo)
+    prob :: Problem{P},
+) where {P}
+    is_constrained(prob) || return EmptyDict{P,BitVector}()
+    excl = Dict{P,BitVector}()
+    for p in constrained_packages(prob)
+        haskey(info, p) || continue # constraint on an absent package
+        vers = info[p].versions
+        e = falses(length(vers))
+        any = false
+        for (i, v) in enumerate(vers)
+            is_excluded(prob, p, v) || continue
+            e[i] = true
+            any = true
+        end
+        any && (excl[p] = e) # allow-everything entries get no mask
+    end
+    return excl
+end

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -91,13 +91,20 @@ function resolve_core(
 end
 
 """
-    resolve(data, reqs; by = identity) -> Union{Dict{P,V}, Nothing}
+    resolve(data, prob::Problem; by = identity) -> Union{Dict{P,V}, Nothing}
+    resolve(data, reqs; by = identity, compat = ..., pins = ...)
 
 Resolve the requirements `reqs` against the package universe described by
 `data`, returning the optimal solution as a dict mapping each needed package
 to its chosen version, or `nothing` when the requirements are not jointly
 satisfiable. The solution covers every requirement and is exactly the
 dependency closure of the requirements under its own chosen versions.
+
+A [`Problem`](@ref) additionally constrains the admissible versions with user
+compat bounds and pins; the answer is the one the same universe with those
+versions deleted would give. The requirements-and-keywords form builds one, so
+`resolve(data, reqs; compat, pins)` and `resolve(data, Problem(reqs; compat,
+pins))` are the same call.
 
 The returned solution is the *layered solution*: requirements are optimized
 first, in the priority order induced by `by` (each package maximized to its
@@ -122,35 +129,62 @@ function resolve(
     return Dict{P,V}(p => sat.info[p].versions[i] for (p, i) in sol)
 end
 
-# convenience entry points
+# primary entry points: a Problem (requirements + user constraints)
 
 function resolve(
     deps :: DepsProvider{P},
-    reqs :: SetOrVec{P} = deps.packages;
+    prob :: Problem{P};
     by   :: Function = identity, # package ordering
 ) where {P}
-    info = pkg_info(deps, reqs)
-    resolve(info, reqs; by)
+    info = pkg_info(deps, prob)
+    resolve(info, prob; by)
 end
 
 function resolve(
     data :: AbstractDict{P,<:PkgData{P}},
-    reqs :: SetOrVec{P} = keys(data);
+    prob :: Problem{P};
     by   :: Function = identity, # package ordering
 ) where {P}
-    info = pkg_info(data, reqs)
-    resolve(info, reqs; by)
+    info = pkg_info(data, prob)
+    resolve(info, prob; by)
 end
 
 function resolve(
     info :: Dict{P,PkgInfo{P,V}},
-    reqs :: SetOrVec{P} = keys(info);
+    prob :: Problem{P};
     by   :: Function = identity, # package ordering
 ) where {P,V}
-    sat = SAT(info)
+    sat = SAT(info, prob)
     # the instance is single-use, so don't bother restoring its state
-    try resolve(sat, reqs; by, restore=false)
+    try resolve(sat, prob.reqs; by, restore=false)
     finally
         finalize(sat)
     end
 end
+
+# convenience entry points: bare requirements, with the user constraints (if
+# any) given as keywords instead of a `Problem`
+
+resolve(
+    deps :: DepsProvider{P},
+    reqs :: SetOrVec{P} = deps.packages;
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+    by     :: Function = identity, # package ordering
+) where {P} = resolve(deps, Problem(reqs; compat, pins); by)
+
+resolve(
+    data :: AbstractDict{P,<:PkgData{P}},
+    reqs :: SetOrVec{P} = keys(data);
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+    by     :: Function = identity, # package ordering
+) where {P} = resolve(data, Problem(reqs; compat, pins); by)
+
+resolve(
+    info :: Dict{P,PkgInfo{P,V}},
+    reqs :: SetOrVec{P} = keys(info);
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+    by     :: Function = identity, # package ordering
+) where {P,V} = resolve(info, Problem(reqs; compat, pins); by)

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -1,9 +1,10 @@
 module Resolver
 
-export resolve
+export resolve, Problem
 
 include("BitKernels.jl")
 include("DepsProvider.jl")
+include("Problem.jl")
 include("PkgInfo.jl")
 include("PkgInfoFiles.jl")
 include("FilterPkgs.jl")

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -2,6 +2,10 @@ mutable struct SAT{P,V}
     info :: Dict{P,PkgInfo{P,V}}
     pico :: Ptr{Cvoid}
     vars :: Dict{P,Int}
+    # selector variable => the user constraint it guards; internal, for
+    # diagnostics (the constraints are asserted as unit clauses inside a push
+    # frame, so popping it relaxes all of them at once)
+    sels :: Dict{Int,Tuple{Symbol,P}}
 end
 
 function Base.show(io::IO, sat::SAT)
@@ -15,17 +19,17 @@ function Base.show(io::IO, sat::SAT)
         ", clauses: ", c, ")")
 end
 
-function SAT(
-    info :: Dict{P,PkgInfo{P,V}},
-) where {P,V}
+# variable indices:
+#   p     vars[p]     package p chosen
+#   p@i   vars[p]+i   version i of p chosen
+#   p@≤k  lads[p]+k   some version ≤ k of p chosen (prefix ladder,
+#                     only for packages with several versions)
+# returns the (sorted) names, the two index maps, and the last used variable
+function sat_variables(
+    info :: Dict{P, <: PkgInfo{P}},
+) where {P}
     # sort names for predictability
     names = sort!(collect(keys(info)))
-
-    # variable indices:
-    #   p     vars[p]     package p chosen
-    #   p@i   vars[p]+i   version i of p chosen
-    #   p@≤k  lads[p]+k   some version ≤ k of p chosen (prefix ladder,
-    #                     only for packages with several versions)
     N = 1
     vars = Dict{P,Int}()
     lads = Dict{P,Int}()
@@ -41,28 +45,35 @@ function SAT(
             N += n_p
         end
     end
-    N -= 1 # last used variable
+    return names, vars, lads, N - 1
+end
+
+# append the literals for "no version in lo:hi of the package
+# with variable base v, ladder base l, and n versions is chosen"
+function run_lits!(lits::Vector{Int}, v::Int, l::Int, lo::Int, hi::Int, n::Int)
+    if lo == hi
+        push!(lits, -(v + lo))
+    elseif lo == 1 && hi == n
+        push!(lits, -v)
+    elseif lo == 1
+        push!(lits, -(l + hi))
+    else
+        push!(lits, -(l + hi), l + lo - 1)
+    end
+    return lits
+end
+
+function SAT(
+    info :: Dict{P,PkgInfo{P,V}},
+) where {P,V}
+    names, vars, lads, N = sat_variables(info)
 
     # instantiate picosat solver
     pico = PicoSAT.init() # TODO: use jl_malloc?
     try # free memory on error
         PicoSAT.adjust(pico, N)
 
-        # append the literals for "no version in lo:hi of the package
-        # with variable base v, ladder base l, and n versions is chosen"
         lits = Int[]
-        function run_lits!(lits::Vector{Int}, v::Int, l::Int, lo::Int, hi::Int, n::Int)
-            if lo == hi
-                push!(lits, -(v + lo))
-            elseif lo == 1 && hi == n
-                push!(lits, -v)
-            elseif lo == 1
-                push!(lits, -(l + hi))
-            else
-                push!(lits, -(l + hi), l + lo - 1)
-            end
-            return lits
-        end
         # default unconstrained variables to false: models then carry
         # fewer spuriously-true packages ("junk"), which makes solves
         # faster and improvement steps land on better versions
@@ -263,7 +274,116 @@ function SAT(
         PicoSAT.reset(pico)
         rethrow()
     end
-    finalizer(finalize, SAT(info, pico, vars))
+    finalizer(finalize, SAT(info, pico, vars, Dict{Int,Tuple{Symbol,P}}()))
+end
+
+# the structural SAT instance for `info`, plus `prob`'s user constraints as
+# selector-guarded exclusion clauses: for each constraint source that forbids a
+# kept version — one per compat entry, one per pin — a fresh selector variable
+# `s` and one clause `(¬s, "no version in run")` per maximal run of forbidden
+# versions. the selectors are then asserted as unit clauses inside a sat_push
+# frame, so production solves see them at level 0 (no assumptions), while a
+# single sat_pop relaxes every user constraint at once. nothing pops the frame
+# in production; the frame exists so diagnostics can.
+#
+# constraints on packages absent from `info`, constraints that forbid nothing,
+# and constraints that forbid only versions the filter already dropped emit no
+# selector and no clauses — with none at all the instance is exactly SAT(info)
+function SAT(
+    info :: Dict{P,PkgInfo{P,V}},
+    prob :: Problem{P},
+) where {P,V}
+    sat = SAT(info)
+    try add_exclusions!(sat, prob)
+    catch
+        finalize(sat)
+        rethrow()
+    end
+    return sat
+end
+
+function add_exclusions!(
+    sat  :: SAT{P,V},
+    prob :: Problem{P},
+) where {P,V}
+    is_constrained(prob) || return sat
+    info = sat.info
+    pico = sat.pico
+    _, vars, lads = sat_variables(info)
+    lits = Int[]
+    mask = BitVector()
+    for p in constrained_packages(prob)
+        haskey(info, p) || continue # constraint on an absent package
+        vers = info[p].versions
+        n_p = length(vers)
+        n_p > 0 || continue # nothing to forbid, and no version variables
+        v_p = vars[p]
+        l_p = get(lads, p, 0)
+        resize!(mask, n_p)
+        # one selector per constraint source, so diagnostics can tell a
+        # compat bound and a pin on the same package apart
+        for kind in (:compat, :pin)
+            fill!(mask, false)
+            found = false
+            if kind == :compat
+                haskey(prob.compat, p) || continue
+                s = prob.compat[p]
+                for (i, v) in enumerate(vers)
+                    v ∈ s && continue
+                    mask[i] = true
+                    found = true
+                end
+            else
+                haskey(prob.pins, p) || continue
+                w = prob.pins[p]
+                for (i, v) in enumerate(vers)
+                    v == w && continue
+                    mask[i] = true
+                    found = true
+                end
+            end
+            found || continue # nothing left to forbid
+            sel = PicoSAT.inc_max_var(pico)
+            sat.sels[sel] = (kind, p)
+            # one clause per maximal run of forbidden versions, via the
+            # prefix ladder (same interval encoding as conflicts)
+            i = 1
+            while i ≤ n_p
+                if mask[i]
+                    lo = i
+                    while i < n_p && mask[i + 1]
+                        i += 1
+                    end
+                    empty!(lits)
+                    push!(lits, -sel)
+                    run_lits!(lits, v_p, l_p, lo, i, n_p)
+                    for x in lits
+                        PicoSAT.add(pico, x)
+                    end
+                    PicoSAT.add(pico, 0)
+                end
+                i += 1
+            end
+        end
+        # the structural instance defaults every package's best version to
+        # true, so that a package that must be chosen is tried at its best
+        # version first. when the user forbids that version, point the phase
+        # at the best version they do allow instead — otherwise the solver's
+        # first guess is infeasible for every constrained package at once
+        i = findfirst(v -> !is_excluded(prob, p, v), vers)
+        if i ≠ 1
+            PicoSAT.set_default_phase_lit(pico, v_p + 1, 0)
+            isnothing(i) || PicoSAT.set_default_phase_lit(pico, v_p + i, 1)
+        end
+    end
+    # assert the selectors in a push frame of their own
+    isempty(sat.sels) && return sat
+    sat_push(sat)
+    for sel in sort!(collect(keys(sat.sels)))
+        PicoSAT.add(pico, sel)
+        PicoSAT.add(pico, 0)
+    end
+    return sat
 end
 
 function finalize(sat::SAT)

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -1,0 +1,454 @@
+# `Problem`: user compat bounds & pins as resolve-time constraints.
+#
+# The oracle throughout is *bake-equivalence*. Forbidding a version by clause
+# and deleting it from the data leave the same model set, hence — by the
+# reduction-invariance theorem — the same layered answer and the same
+# satisfiability verdict. So every constrained resolve is checked against the
+# unconstrained resolve of the "baked" data, which is what user constraints
+# used to mean.
+
+using Resolver: Problem, PkgData, PkgInfo, pkg_info, SAT, PicoSAT,
+    exclusion_masks, is_excluded, finalize, sat_assume, sat_pop, is_satisfiable
+
+# delete the versions `prob` excludes from each package's data, old-style
+function bake(
+    data :: AbstractDict{P,<:PkgData{P,V}},
+    prob :: Problem{P},
+) where {P,V}
+    Vers = Vector{V}
+    Deps = Dict{V,Vector{P}}
+    Comp = Dict{V,Dict{P,Any}}
+    baked = Dict{P,PkgData{P,V,Any,Vers,Deps,Comp}}()
+    for (p, data_p) in data
+        vers = V[v for v in data_p.versions if !is_excluded(prob, p, v)]
+        deps = Deps(v => P[q for q in data_p.depends[v]]
+                    for v in vers if haskey(data_p.depends, v))
+        comp = Comp(v => Dict{P,Any}(data_p.compat[v])
+                    for v in vers if haskey(data_p.compat, v))
+        baked[p] = PkgData(vers, deps, comp)
+    end
+    return baked
+end
+
+# random user constraints over `m` packages with `n` versions each; the m+1st
+# package is never in the data, so entries for it must be no-ops. the draw
+# covers every case that has to work: no entry, an allow-everything entry, an
+# exclude-everything entry (an empty random subset), random subsets, pins at
+# existing and non-existing versions, and compat plus a pin on one package
+#
+# `mild` skips the shapes that make most instances unsatisfiable outright
+# (empty compat sets, pins at non-existing versions), for sweeps that need the
+# instance to stay solvable for a while.
+function random_constraints(m::Int, n::Int; mild::Bool = false)
+    compat = Dict{Int,Vector{Int}}()
+    pins   = Dict{Int,Int}()
+    subset() = mild ? [v for v = 1:n if rand(Bool) || v == rand(1:n)] :
+                      [v for v = 1:n if rand(Bool)]
+    for p = 1:m+1
+        r = rand(1:8)
+        if r ≤ 3
+            compat[p] = subset()
+        elseif r == 4
+            compat[p] = collect(1:n)  # allows everything
+        elseif r == 5
+            pins[p] = rand(1:n)
+        elseif r == 6
+            pins[p] = mild ? rand(1:n) : n + 1 # no such version
+        elseif r == 7
+            compat[p] = subset()
+            mild || (pins[p] = rand(1:n))
+        end
+        # r == 8: leave p unconstrained
+    end
+    return compat, pins
+end
+
+# the constraint shapes worth enumerating exhaustively for one package
+const CONSTRAINT_SHAPES = [
+    :none,        # no entry at all
+    :allow_all,   # compat admits every version (must emit nothing)
+    :exclude_all, # compat admits nothing
+    :best,        # compat admits only the best version
+    :worst,       # compat admits only the worst version
+    :middle,      # compat excludes the best version only
+    :pin_best,
+    :pin_worst,
+    :pin_missing, # pin at a version that doesn't exist
+    :pin_and_compat, # two constraint sources on one package
+]
+
+function constrain!(compat, pins, p::Int, shape::Symbol, n::Int)
+    shape == :none           ? nothing :
+    shape == :allow_all      ? (compat[p] = collect(1:n)) :
+    shape == :exclude_all    ? (compat[p] = Int[]) :
+    shape == :best           ? (compat[p] = [1]) :
+    shape == :worst          ? (compat[p] = [n]) :
+    shape == :middle         ? (compat[p] = collect(2:n)) :
+    shape == :pin_best       ? (pins[p] = 1) :
+    shape == :pin_worst      ? (pins[p] = n) :
+    shape == :pin_missing    ? (pins[p] = n + 1) :
+    shape == :pin_and_compat ? (compat[p] = [1]; pins[p] = n) :
+    error("unknown constraint shape: $shape")
+    return compat, pins
+end
+
+# `resolve(data, prob)` must agree with the unconstrained resolve of the baked
+# data — including when both are `nothing`
+function test_bake_equivalence(data, prob; by::Function = identity)
+    @test resolve(data, prob; by) == resolve(bake(data, prob), prob.reqs; by)
+end
+
+@testset "Problem: construction & masks" begin
+    prob = Problem([:A, :B])
+    @test prob.reqs == [:A, :B]
+    @test isempty(prob.compat) && isempty(prob.pins)
+    prob = Problem(Set([:A]); compat = Dict(:B => [:v1]), pins = Dict(:C => :v2))
+    @test prob isa Problem{Symbol,Symbol,Vector{Symbol}}
+    @test !is_excluded(prob, :B, :v1)
+    @test  is_excluded(prob, :B, :v2)
+    @test !is_excluded(prob, :C, :v2)
+    @test  is_excluded(prob, :C, :v1)
+    @test !is_excluded(prob, :A, :v1) # unconstrained
+
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v2, :v1], nodeps, nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+        :C => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+    excl = exclusion_masks(info, prob)
+    # only constrained packages get a mask; entries for absent packages and
+    # allow-everything entries get none
+    @test sort!(collect(keys(excl))) == [:B, :C]
+    @test excl[:B] == BitVector([true, false]) # compat forbids :v2
+    @test excl[:C] == BitVector([false, true]) # the pin forbids :v1
+    @test isempty(exclusion_masks(info, Problem([:A])))
+    @test isempty(exclusion_masks(info,
+        Problem([:A]; compat = Dict(:A => [:v1, :v2], :Z => Symbol[]))))
+end
+
+@testset "Problem: the unconstrained case is free" begin
+    # `Problem(reqs)` is on every convenience `resolve` path, so it must not
+    # allocate a pair of dictionaries just to say "no constraints": the empty
+    # compat and pins are one shared immutable value
+    reqs = [:A, :B]
+    a, b = Problem(reqs), Problem(reverse(reqs))
+    @test a.compat === b.compat
+    @test a.pins === b.pins
+    @test isempty(a.compat) && isempty(a.pins)
+    @test valtype(a.compat) == valtype(a.pins) == Any
+    @test !haskey(a.compat, :A) && get(a.pins, :A, nothing) === nothing
+    # the mask dictionary of an unconstrained problem is shared the same way
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    info = pkg_info(Dict(:A => PkgData([:v1], Dict{Symbol,Vector{Symbol}}(), nocomp)),
+                    [:A]; filter = false)
+    @test exclusion_masks(info, a) === exclusion_masks(info, b)
+
+    # a caller's dictionary is still copied, so later mutation can't reach in
+    d = Dict(:B => [:v1])
+    p = Problem(reqs; compat = d)
+    @test p.compat == d && p.compat !== d
+
+    # so building one allocates the requirements vector and the struct, and
+    # strictly less than the same call handed an (empty) dictionary to copy
+    build(::Nothing) = Problem(reqs)
+    build(c::AbstractDict) = Problem(reqs; compat = c)
+    empty_dict = Dict{Symbol,Any}()
+    build(nothing); build(empty_dict) # compile both
+    @test @allocated(build(nothing)) < @allocated(build(empty_dict))
+end
+
+@testset "Problem: resolve's convenience keywords" begin
+    # the requirements-and-keywords form of `resolve` just builds the Problem
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    compat = Dict(:B => [:v1])
+    pins = Dict(:A => :v1)
+    prob = Problem([:A]; compat, pins)
+    @test resolve(data, [:A]; compat, pins) == resolve(data, prob)
+    @test resolve(data, [:A]; compat) == resolve(data, Problem([:A]; compat))
+    @test resolve(data, [:A]) == resolve(data, Problem([:A]))
+    info = pkg_info(data, prob)
+    @test resolve(info, [:A]; compat, pins) == resolve(info, prob)
+end
+
+@testset "Problem: exclusions constrain, they don't delete" begin
+    # user constraints are conflict pressure in the filter, not deletions: the
+    # forbidden version stays in the info (reachability keeps prefixes), and
+    # the SAT clauses are what rule it out
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    prob = Problem([:A]; compat = Dict(:B => [:v1]))
+    info = pkg_info(data, prob)
+    @test info[:B].versions == [:v2, :v1] # :v2 forbidden but kept
+    @test resolve(data, prob) == Dict(:A => :v1, :B => :v1)
+    test_bake_equivalence(data, prob)
+
+    # every version of B forbidden: B saturates, so it keeps all its versions
+    # and its dependents degrade past the versions that need it
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    prob = Problem([:A]; compat = Dict(:B => Symbol[]))
+    info = pkg_info(data, prob)
+    # B survives -- its uninstallability is constraint-driven, not a deletion
+    # -- though redundancy collapses it, since versions that are all excluded
+    # alike all dominate each other
+    @test haskey(info, :B)
+    @test resolve(data, prob) == Dict(:A => :v1)
+    test_bake_equivalence(data, prob)
+    # ... and if the dependent can't degrade, the problem is unsatisfiable
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    prob = Problem([:A]; compat = Dict(:B => Symbol[]))
+    @test resolve(data, prob) === nothing
+    test_bake_equivalence(data, prob)
+
+    # an excluded version must not dominate a non-excluded one: B@v2 has no
+    # constraints at all, so it would dominate B@v1 (which conflicts with
+    # A@v2) if the virtual conflict column were missing -- and then pinning B
+    # to v1 would have nothing to select
+    data = Dict(
+        :A => PkgData([:v2, :v1], nodeps,
+                      Dict(:v2 => Dict(:B => [:v2]))),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    prob = Problem([:A, :B]; pins = Dict(:B => :v1))
+    info = pkg_info(data, prob)
+    @test info[:B].versions == [:v2, :v1]
+    @test resolve(data, prob) == Dict(:A => :v1, :B => :v1)
+    test_bake_equivalence(data, prob)
+end
+
+@testset "Problem: SAT selectors" begin
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v2, :v1], nodeps, nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+
+    # no constraints at all: exactly the structural instance
+    plain = SAT(info)
+    same  = SAT(info, Problem([:A]))
+    try
+        @test isempty(plain.sels) && isempty(same.sels)
+        @test PicoSAT.var_count(plain.pico) == PicoSAT.var_count(same.pico)
+        @test PicoSAT.clause_count(plain.pico) == PicoSAT.clause_count(same.pico)
+    finally
+        finalize(plain)
+        finalize(same)
+    end
+
+    # one selector per constraint source that forbids something; allow-all
+    # entries and entries for absent packages get none
+    prob = Problem([:A];
+        compat = Dict(:A => [:v1], :B => [:v1, :v2], :Z => Symbol[]),
+        pins   = Dict(:A => :v1, :Z => :v1))
+    sat = SAT(info, prob)
+    try
+        @test Set(values(sat.sels)) == Set([(:compat, :A), (:pin, :A)])
+        @test length(sat.sels) == 2
+        # every mask has a selector, every selector a mask
+        excl = exclusion_masks(info, prob)
+        @test Set(keys(excl)) == Set(p for (_, p) in values(sat.sels))
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "Problem: popping the frame relaxes the constraints" begin
+    # the user constraints are asserted as unit clauses in a push frame of
+    # their own: nothing pops it in production, but one pop makes every
+    # previously-forbidden assignment feasible again
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v2, :v1], nodeps, nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    prob = Problem([:A, :B];
+        compat = Dict(:A => [:v1]), pins = Dict(:B => :v2))
+    info = pkg_info(data, prob; filter = false)
+    sat = SAT(info, prob)
+    try
+        @test length(sat.sels) == 2
+        # A@v2 is forbidden by compat, B@v1 by the pin
+        sat_assume(sat, :A, 1)
+        @test !is_satisfiable(sat)
+        sat_assume(sat, :B, 2)
+        @test !is_satisfiable(sat)
+        # both jointly feasible once the frame is popped
+        sat_pop(sat)
+        sat_assume(sat, :A, 1)
+        sat_assume(sat, :B, 2)
+        @test is_satisfiable(sat)
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "Problem: brute-force cross-checks" begin
+    # hand-built cases: the brute-force reference resolves the baked data
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    A3B2 = Dict(
+        :A => PkgData([:v3, :v2, :v1],
+                      Dict(:v3 => [:B], :v2 => [:B], :v1 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    conflict = Dict(
+        :A => PkgData([:v3, :v2, :v1],
+                      Dict(:v3 => [:B], :v2 => [:B], :v1 => [:B]),
+                      Dict(:v3 => Dict(:B => [:v2]),
+                           :v2 => Dict(:B => [:v1]))),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+        :C => PkgData([:v2, :v1], Dict(:v2 => [:A]), nocomp),
+    )
+    cases = [
+        (A3B2, Problem([:A]; compat = Dict(:B => [:v1]))),
+        (A3B2, Problem([:A]; pins = Dict(:B => :v2))),
+        (A3B2, Problem([:A]; compat = Dict(:A => [:v2]))),
+        (A3B2, Problem([:A]; compat = Dict(:B => Symbol[]))),
+        (A3B2, Problem([:A]; pins = Dict(:B => :v9))),
+        (A3B2, Problem([:A, :B]; compat = Dict(:Z => Symbol[]))),
+        (A3B2, Problem([:A]; compat = Dict(:A => [:v1, :v2]),
+                             pins = Dict(:A => :v2))),
+        (conflict, Problem([:C]; pins = Dict(:B => :v2))),
+        (conflict, Problem([:C]; compat = Dict(:A => [:v1, :v2]))),
+        (conflict, Problem([:C, :B]; compat = Dict(:B => [:v1]))),
+        (conflict, Problem([:C]; compat = Dict(:C => [:v2], :B => [:v1]))),
+        (conflict, Problem([:A, :B, :C]; pins = Dict(:A => :v3, :B => :v1))),
+    ]
+    lo = p -> -Int(first(string(p))) # reverse alphabetical priority
+    for (data, prob) in cases, by in (identity, lo)
+        baked = bake(data, prob)
+        @test resolve(data, prob; by) == ref_resolve(baked, prob.reqs; by)
+        test_bake_equivalence(data, prob; by)
+    end
+    for (data, prob) in cases
+        test_resolver(bake(data, prob), prob.reqs)
+    end
+end
+
+@testset "Problem: bake equivalence, complete data grids" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # every dependency & compatibility pattern of the smallest grids, with
+    # random user constraints on top of each
+    for m = 1:2, n = 1:2
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for deps_bits = 0:2^d-1
+            deps = make_deps(deps_bits)
+            for comp_bits = 0:2^c-1
+                comp = make_comp(comp_bits)
+                fill_data!(m, n, deps, comp, data)
+                for reqs_bits = 0:2^m-1
+                    reqs = collect(make_reqs(reqs_bits))
+                    for _ = 1:4
+                        compat, pins = random_constraints(m, n)
+                        prob = Problem(reqs; compat, pins)
+                        test_bake_equivalence(data, prob)
+                    end
+                end
+            end
+        end
+    end
+end
+
+@testset "Problem: bake equivalence, exhaustive constraint shapes" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p  # default priority: lower package id first
+    lo = p -> -p # reversed priority
+    # every constraint shape on every package, on random data
+    for (m, n) in ((2, 2), (2, 3), (3, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:3
+            deps = make_deps(randbits(d))
+            comp = make_comp(randbits(c))
+            fill_data!(m, n, deps, comp, data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            for shapes in Iterators.product(ntuple(_ -> CONSTRAINT_SHAPES, m)...)
+                compat = Dict{Int,Vector{Int}}()
+                pins   = Dict{Int,Int}()
+                for (p, shape) in enumerate(shapes)
+                    constrain!(compat, pins, p, shape, n)
+                end
+                prob = Problem(reqs; compat, pins)
+                test_bake_equivalence(data, prob; by = hi)
+                test_bake_equivalence(data, prob; by = lo)
+            end
+        end
+    end
+end
+
+@testset "Problem: bake equivalence, random grids" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    for (m, n) in ((2, 4), (4, 2), (2, 5), (5, 2), (3, 3))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:120
+            deps = make_deps(randbits(d))
+            comp = make_comp(randbits(c))
+            fill_data!(m, n, deps, comp, data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            for _ = 1:4
+                compat, pins = random_constraints(m, n)
+                prob = Problem(reqs; compat, pins)
+                test_bake_equivalence(data, prob; by = rand((hi, lo)))
+            end
+        end
+    end
+end
+
+@testset "Problem: bake equivalence, adversarial" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # the adversarial generator from the main suite, but resolving a
+    # constrained problem: break the solution until it is unsolvable, with
+    # user constraints in force the whole way
+    for m = 2:4, n = 2:3
+        (m*n)^2 ≤ 128 || continue
+        make_deps, make_comp, data, d, c, bit = tiny_data_makers(m, n)
+        for _ = 1:40
+            deps = make_deps(0)
+            comp = make_comp(0)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            compat, pins = random_constraints(m, n; mild = true)
+            prob = Problem(reqs; compat, pins)
+            while true
+                fill_data!(m, n, deps, comp, data)
+                test_bake_equivalence(data, prob)
+                sol = resolve(data, prob)
+                sol === nothing && break
+                p = rand(collect(keys(sol)))
+                v = sol[p]
+                q = rand(1:m-1)
+                q += q ≥ p
+                w = get(sol, q, nothing)
+                if isnothing(w)
+                    b = bit(p, v, q)
+                    @assert iszero(deps.bits & b)
+                    deps = typeof(deps)(deps.bits | b)
+                else
+                    b = bit(p, v, q, w)
+                    @assert iszero(comp.bits & b)
+                    comp = typeof(comp)(comp.bits | b)
+                end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,6 +258,8 @@ end
     test_resolver(data, [:C])
 end
 
+include("problem.jl")
+
 @testset "registry resolve" begin
     rp = registry.provider()
     test_resolver(rp, ["JSON"])


### PR DESCRIPTION
**Base:** `main` (originally stacked on #48, which merged — the branch is rebased onto the squash).

## What

User compat bounds and pins stop being baked into the provider as version deletions. They become part of a new exported `Problem` type and are applied at resolve time:

```julia
prob = Problem(reqs; compat = Dict("JSONx" => spec), pins = Dict("Arrow" => v))
resolve(data, prob; by)
```

- the **registry provider no longer knows about user compat** — its output is user-independent (a prerequisite for caching preprocessed registry data);
- constraints enter the **filter** as per-package exclusion masks with *virtual-package* semantics: the constraints are read as one always-required version whose conflict rows are the exclusions, so the existing filtering theorems (Theory § layered) apply verbatim — reachability treats an excluded version as one that can never be a resting point, and redundancy's domination test counts the mask as one more (always-active) conflict column;
- constraints enter the **SAT instance** as selector-guarded clauses (one selector per constraint source; one clause per maximal run of forbidden versions via the ladder interval encoding), asserted by unit clauses inside a single push frame — production solves see level-0 units, no assumptions, and one `sat_pop` will later let diagnostics relax them individually on the same failed instance.

`resolve(data, reqs)` without constraints is unchanged, down to identical var/clause counts.

## Equivalence

Old and new semantics have identical model sets (deleting a version vs. forbidding it by an always-on clause), so the PR tests exactly that: `resolve(data, prob) == resolve(bake(data, prob), prob.reqs)` — verdicts included — across ~15,000 instances: complete tiny grids × random constraint draws, all 10 constraint shapes exhaustively on small grids × orderings, random larger grids, an adversarial break-until-unsolvable sweep, and brute-force reference cross-checks. No divergence.

## Registry-scale numbers

Unconstrained resolves: identical instance and timing. Constrained (6 compat bounds, 390-package solution): filtering +7%, solve 0.16s → 0.44s — the descent now has to *discover* that forbidden better versions are infeasible (~2 extra solves per constrained package) instead of being handed a pre-shrunk instance. A follow-up can teach the descent to skip excluded versions when picking improvement targets. End-to-end `bin/resolve.jl`: 9.1s → 10.1s (≈7s is Julia startup).

## Review points

1. **Stdlib compat trap (deliberately preserved bug-compatible).** The old provider applied compat to registry versions and then patched julia-bundled stdlib versions back in, so user compat **never applied to bundled stdlibs** (e.g. `Statistics = "1.11"` at `--julia=1.10` silently resolves Statistics 1.10.0). Enforcing the bound would arguably be more correct but breaks the `julia-downgrade-compat` pattern (`"=1.0.0"`-style rewrites), which the repo has a dedicated test for. This PR keeps exact old behavior by widening each bound with `bundled_versions` in `bin/resolve.jl`. Changing that should be its own decision.
2. **Behavior change (decided in review): the project's `[compat] julia` entry now sets the default julia bounds**, and `--julia` overrides it outright (no intersecting) — with neither, the `1` default as before. The winning source feeds the single `julia_versions` spec that drives both the julia version universe and stdlib bundling/pins, so a project bound and the equivalent flag are indistinguishable downstream; the entry is consumed so it can't also constrain `julia` through the `Problem`. Note the inherent syntax asymmetry: `--julia` uses registry VersionRange syntax (`1.10` = the 1.10.x series) while a compat entry means what compat means everywhere (`"1.10"` = `[1.10.0, 2.0.0)`, `"~1.10"` = the series).
3. For a constrained package whose best version is forbidden, the solver's phase hint moves to the best *admissible* version (worth ~15% of constrained-solve cost; no effect unconstrained).

## Co-author

Implemented with [Claude Code](https://claude.com/claude-code): design discussed with, implementation by, and review by Claude, directed and reviewed by @StefanKarpinski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7