### PR TITLE
T1 preprocessing: a universal per-registry cache

### DIFF
--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,7 +1,7 @@
 module Registries
 
 export registry_provider, package_info, bundled_versions,
-    prerelease_exclusion, UPGRADABLE_STDLIBS_UUIDS
+    prerelease_exclusion, yanked_exclusion, is_yanked, UPGRADABLE_STDLIBS_UUIDS
 
 import Base: UUID
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS, StdlibInfo
@@ -201,17 +201,44 @@ prerelease_exclusion(allow_pre::Dict{UUID,Bool}) =
         return !get(allow_pre, uuid, get(allow_pre, UUID(0), false))
     end
 
+## yanked versions
+#
+# Yankedness is the same shape of fact as prerelease-ness: a property of a version
+# that a query may or may not be willing to accept. Nothing offers the user a way
+# to accept one yet -- this kind is always in force -- but modeling it as a
+# constraint rather than a deletion is what keeps the package universe shared, and
+# is what lets a diagnostic eventually say "the only version that satisfies this
+# is yanked" instead of "no such version".
+#
+# A version is offered when *some* registry entry has it un-yanked, so it counts
+# as yanked only when every entry that has it says so -- and a version that no
+# registry has at all (a bundled stdlib) is not a registry version to yank.
+function is_yanked(
+    packages :: Dict{UUID,Vector{PkgEntry}},
+    uuid     :: UUID,
+    v        :: VersionNumber,
+)
+    entries = get(packages, uuid, nothing)
+    entries === nothing && return false
+    found = false
+    for entry in entries
+        info = package_info(entry)
+        haskey(info.version_info, v) || continue
+        isyanked(info, v) || return false
+        found = true
+    end
+    return found
+end
+
+yanked_exclusion(packages::Dict{UUID,Vector{PkgEntry}}) =
+    :yanked => (uuid::UUID, v::VersionNumber) -> is_yanked(packages, uuid, v)
+
 function registry_provider(
     packages       :: Dict{UUID,Vector{PkgEntry}};
     julia_versions :: VersionSpec = VersionSpec("1"),
     workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
                       Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
 )
-    function filter_yanked!(info, vers::Vector{VersionNumber})
-        filter!(v -> !isyanked(info, v), vers)
-        return vers
-    end
-
     julia_vers, stdlibs, stdlib_pins =
         julia_and_stdlib_versions(julia_versions)
 
@@ -264,13 +291,12 @@ function registry_provider(
         elseif uuid in keys(packages)
             for entry in packages[uuid]
                 info = package_info(entry)
-                # versions from this registry, filtered
+                # every version this registry has
                 new_vers = collect(keys(info.version_info))
-                filter_yanked!(info, new_vers)
-                # neither the project's own compat nor prerelease admission is
-                # applied here: both are query constraints, and they reach the
-                # resolver as part of the `Problem` (see bin/resolve.jl). the
-                # provider only decides which versions exist at all
+                # nothing is filtered out here: the project's own compat,
+                # prerelease admission and yankedness are all query constraints,
+                # and they reach the resolver as part of the `Problem` (see
+                # bin/resolve.jl). the provider only decides which versions exist
                 # scan versions and populate deps & compat data
                 for v in new_vers
                     # NOTE: we probably won't support the same name meaning

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -117,12 +117,20 @@ end
 
 # The Julia versions to resolve against, and what they bundle:
 #
-#   stdlibs[uuid][version] : the historical stdlib info for a bundled version
-#   stdlib_pins[uuid]      : the (Julia version, bundled-version spec) pairs.
-#     Recorded so `registry_provider` can reconcile a stdlib version's `julia`
-#     compat with the Julia versions that bundle it. Recorded for the
-#     upgradable stdlibs too, which are bundled without being pinned: a bundled
-#     version must be installable on its Julia either way.
+#   stdlibs[uuid][version] : the historical stdlib info for a bundled version.
+#     One version number can cover entries with *different* dependencies across
+#     Julia versions, which is what the synthetic build number below is for, so
+#     these keys identify an entry rather than merely a version number.
+#   bundlers[uuid][version] : the Julia versions that bundle that entry, as a
+#     spec, keyed exactly as `stdlibs` is. Recorded so `registry_provider` can
+#     reconcile a stdlib version's `julia` compat with the Julia versions that
+#     bundle it. Recorded for the upgradable stdlibs too, which are bundled
+#     without being pinned: a bundled version must be installable on its Julia
+#     either way.
+#   by_patch[uuid][thispatch(version)] : the same, unioned over the entries that
+#     share a major.minor.patch. This is what a *registry* version is widened by,
+#     since a registry version is one version number with no entry to identify,
+#     and major.minor.patch is exactly what a Julia's exact-version pin compares.
 #
 # Split out of `registry_provider` so that `bundled_versions` can report the
 # bundled version sets without building a provider.
@@ -132,7 +140,7 @@ function julia_and_stdlib_versions(
     julia_vers = filter(in(julia_versions), JULIA_VERSIONS)
 
     stdlibs = Dict{UUID,Dict{VersionNumber,StdlibInfo}}()
-    stdlib_pins = Dict{UUID,Vector{Tuple{VersionNumber,VersionSpec}}}()
+    bundlers = Dict{UUID,Dict{VersionNumber,VersionSpec}}()
     for julia_ver in julia_vers
         last_stdlibs = UNREGISTERED_STDLIBS
         for (v, this_stdlibs) in STDLIBS_BY_VERSION
@@ -141,8 +149,6 @@ function julia_and_stdlib_versions(
         end
         for (uuid, stdlib_info) in last_stdlibs
             stdlib_ver = something(stdlib_info.version, julia_ver)
-            push!(get!(()->valtype(stdlib_pins)(), stdlib_pins, uuid),
-                  (julia_ver, VersionSpec(stdlib_ver)))
             deps_u = get!(()->valtype(stdlibs)(), stdlibs, uuid)
             # Sometimes HistoricalStdlibVersions gives the same
             # version number to stdlib entries with different deps.
@@ -166,9 +172,23 @@ function julia_and_stdlib_versions(
                 )
             end
             deps_u[stdlib_ver] = stdlib_info
+            # `julia_vers` is ascending, so the run of Julias that bundle one
+            # entry merges into a single range as it accumulates
+            bundlers_u = get!(()->valtype(bundlers)(), bundlers, uuid)
+            bundlers_u[stdlib_ver] = haskey(bundlers_u, stdlib_ver) ?
+                bundlers_u[stdlib_ver] ∪ VersionSpec(julia_ver) :
+                VersionSpec(julia_ver)
         end
     end
-    return julia_vers, stdlibs, stdlib_pins
+    by_patch = Dict{UUID,Dict{VersionNumber,VersionSpec}}()
+    for (uuid, bundlers_u) in bundlers
+        d = get!(()->valtype(by_patch)(), by_patch, uuid)
+        for (v, spec) in bundlers_u
+            key = Base.thispatch(v)
+            d[key] = haskey(d, key) ? d[key] ∪ spec : spec
+        end
+    end
+    return julia_vers, stdlibs, bundlers, by_patch
 end
 
 # Per package, the versions the provider offers because a Julia in
@@ -180,7 +200,7 @@ end
 function bundled_versions(
     julia_versions :: VersionSpec,
 )
-    _, stdlibs, _ = julia_and_stdlib_versions(julia_versions)
+    _, stdlibs, _, _ = julia_and_stdlib_versions(julia_versions)
     Dict{UUID,Vector{VersionNumber}}(
         uuid => collect(keys(vers)) for (uuid, vers) in stdlibs)
 end
@@ -239,7 +259,7 @@ function registry_provider(
     workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
                       Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
 )
-    julia_vers, stdlibs, stdlib_pins =
+    julia_vers, stdlibs, bundlers, by_patch =
         julia_and_stdlib_versions(julia_versions)
 
     return DepsProvider(keys(packages)) do uuid::UUID
@@ -387,20 +407,29 @@ function registry_provider(
         # The upgradable stdlibs get the same treatment even though no pin makes
         # them conflict: a bundled version must be installable on the Julia that
         # bundles it whether or not that Julia insists on it.
-        if uuid in keys(stdlib_pins)
-            # per version, the Julias that bundle it
-            bundling = Dict{VersionNumber,VersionSpec}()
-            for (julia_ver, ver_spec) in stdlib_pins[uuid]
-                for v in vers
-                    v in ver_spec || continue # julia_ver bundles this version
-                    bundling[v] = haskey(bundling, v) ?
-                        bundling[v] ∪ VersionSpec(julia_ver) : VersionSpec(julia_ver)
+        if uuid in keys(bundlers)
+            bundlers_u = bundlers[uuid]
+            by_patch_u = by_patch[uuid]
+            for v in vers
+                if v in bundled_only
+                    # `v` is one of the stdlib table's own keys, so it names an
+                    # entry: the Julias that bundle *it* are the ones that ship
+                    # its dependency set. Matching by version number instead
+                    # would pair a Julia with a same-numbered entry whose deps
+                    # belong to a different Julia -- which is exactly what the
+                    # synthetic build number exists to prevent.
+                    comp_v = get!(()->valtype(comp)(), comp, v)
+                    comp_v[JULIA_UUID] = bundlers_u[v]
+                else
+                    # a registry version names no entry, so it is widened by
+                    # every Julia that bundles its version number -- which is
+                    # what a Julia's exact-version pin matches
+                    julias = get(by_patch_u, Base.thispatch(v), nothing)
+                    julias === nothing && continue
+                    comp_v = get!(()->valtype(comp)(), comp, v)
+                    comp_v[JULIA_UUID] =
+                        get(comp_v, JULIA_UUID, VersionSpec("*")) ∪ julias
                 end
-            end
-            for (v, julias) in bundling
-                comp_v = get!(()->valtype(comp)(), comp, v)
-                comp_v[JULIA_UUID] = v in bundled_only ? julias :
-                    get(comp_v, JULIA_UUID, VersionSpec("*")) ∪ julias
             end
         end
         # insert dependency on julia itself

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,7 +1,7 @@
 module Registries
 
 export registry_provider, package_info, bundled_versions,
-    UPGRADABLE_STDLIBS_UUIDS
+    prerelease_exclusion, UPGRADABLE_STDLIBS_UUIDS
 
 import Base: UUID
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS, StdlibInfo
@@ -128,11 +128,8 @@ end
 # bundled version sets without building a provider.
 function julia_and_stdlib_versions(
     julia_versions :: VersionSpec,
-    allow_pre      :: Dict{UUID,Bool} = Dict(UUID(0) => false),
 )
     julia_vers = filter(in(julia_versions), JULIA_VERSIONS)
-    get(allow_pre, JULIA_UUID, allow_pre[UUID(0)]) ||
-        filter!(v -> isempty(v.prerelease), julia_vers)
 
     stdlibs = Dict{UUID,Dict{VersionNumber,StdlibInfo}}()
     stdlib_pins = Dict{UUID,Vector{Tuple{VersionNumber,VersionSpec}}}()
@@ -182,34 +179,41 @@ end
 # Julias", so it stays available for introspection and for the tests.
 function bundled_versions(
     julia_versions :: VersionSpec,
-    allow_pre      :: Dict{UUID,Bool} = Dict(UUID(0) => false),
 )
-    _, stdlibs, _ = julia_and_stdlib_versions(julia_versions, allow_pre)
+    _, stdlibs, _ = julia_and_stdlib_versions(julia_versions)
     Dict{UUID,Vector{VersionNumber}}(
         uuid => collect(keys(vers)) for (uuid, vers) in stdlibs)
 end
 
+## prerelease admission
+#
+# Whether a query will accept prerelease versions is a *query* fact, not a
+# registry one: the versions exist either way. So the provider offers them all
+# and `--allow-pre` reaches the resolver as one of the `Problem`'s exclusion
+# kinds, forbidding the prereleases of the packages it was not given for -- which
+# is what deleting them used to accomplish, minus the need for a private universe.
+#
+# `allow_pre` is keyed by package uuid with the zero uuid holding the default,
+# exactly as the flag parses it.
+prerelease_exclusion(allow_pre::Dict{UUID,Bool}) =
+    :prerelease => function (uuid::UUID, v::VersionNumber)
+        isempty(v.prerelease) && return false
+        return !get(allow_pre, uuid, get(allow_pre, UUID(0), false))
+    end
+
 function registry_provider(
     packages       :: Dict{UUID,Vector{PkgEntry}};
     julia_versions :: VersionSpec = VersionSpec("1"),
-    allow_pre      :: Dict{UUID,Bool} = Dict{UUID,Bool}(),
     workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
                       Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
 )
-    function filter_pre!(uuid::UUID, vers::Vector{VersionNumber})
-        if !get(allow_pre, uuid, allow_pre[UUID(0)])
-            filter!(v->isempty(v.prerelease), vers)
-        end
-        return vers
-    end
-
     function filter_yanked!(info, vers::Vector{VersionNumber})
         filter!(v -> !isyanked(info, v), vers)
         return vers
     end
 
     julia_vers, stdlibs, stdlib_pins =
-        julia_and_stdlib_versions(julia_versions, allow_pre)
+        julia_and_stdlib_versions(julia_versions)
 
     return DepsProvider(keys(packages)) do uuid::UUID
         if uuid in keys(workspace_pkgs)
@@ -262,12 +266,11 @@ function registry_provider(
                 info = package_info(entry)
                 # versions from this registry, filtered
                 new_vers = collect(keys(info.version_info))
-                filter_pre!(uuid, new_vers)
                 filter_yanked!(info, new_vers)
-                # the project's own compat is *not* applied here: it is a user
-                # constraint, and it reaches the resolver as part of the
-                # `Problem` (see bin/resolve.jl). the provider only decides
-                # which versions exist at all
+                # neither the project's own compat nor prerelease admission is
+                # applied here: both are query constraints, and they reach the
+                # resolver as part of the `Problem` (see bin/resolve.jl). the
+                # provider only decides which versions exist at all
                 # scan versions and populate deps & compat data
                 for v in new_vers
                     # NOTE: we probably won't support the same name meaning

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -88,7 +88,11 @@ end
 
 ## extracting the dependency graph from registries
 
-function sort_versions_default(uuid::UUID, vers::Set{VersionNumber})
+# The canonical version order: newest first. It is a property of the registry
+# state alone, so the provider's output -- and with it the T1 artifact built from
+# it -- is the same whatever ordering a query prefers; the preference ordering is
+# the `order` argument to `Resolver.resolve` (see bin/resolve.jl).
+function sort_versions(uuid::UUID, vers::Set{VersionNumber})
     sort!(collect(vers), rev=true)
 end
 
@@ -188,7 +192,6 @@ end
 function registry_provider(
     packages       :: Dict{UUID,Vector{PkgEntry}};
     julia_versions :: VersionSpec = VersionSpec("1"),
-    sort_versions  :: Function = sort_versions_default,
     allow_pre      :: Dict{UUID,Bool} = Dict{UUID,Bool}(),
     workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
                       Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,7 +1,8 @@
 module Registries
 
 export registry_provider, package_info, bundled_versions,
-    prerelease_exclusion, yanked_exclusion, is_yanked, UPGRADABLE_STDLIBS_UUIDS
+    prerelease_exclusion, yanked_exclusion, is_yanked, is_registered, is_bundled,
+    UPGRADABLE_STDLIBS_UUIDS
 
 import Base: UUID
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS, StdlibInfo
@@ -115,7 +116,7 @@ function dedup_values!(d::AbstractDict, vers::Vector)
     return d
 end
 
-# The Julia versions to resolve against, and what they bundle:
+# What each Julia version bundles, across the *whole* Julia version universe:
 #
 #   stdlibs[uuid][version] : the historical stdlib info for a bundled version.
 #     One version number can cover entries with *different* dependencies across
@@ -132,13 +133,14 @@ end
 #     since a registry version is one version number with no entry to identify,
 #     and major.minor.patch is exactly what a Julia's exact-version pin compares.
 #
-# Split out of `registry_provider` so that `bundled_versions` can report the
-# bundled version sets without building a provider.
+# There is one such universe per registry state. Which Julia versions a *query*
+# wants is not a property of the universe but a constraint on it: the `--julia`
+# flag and a project's own `[compat] julia` bound both reach the resolver as an
+# ordinary compat entry on `julia` in the `Problem` (see bin/resolve.jl). So this
+# is computed once, for every Julia there is, and every query shares it.
 function julia_and_stdlib_versions(
-    julia_versions :: VersionSpec,
+    julia_vers :: AbstractVector{VersionNumber} = JULIA_VERSIONS,
 )
-    julia_vers = filter(in(julia_versions), JULIA_VERSIONS)
-
     stdlibs = Dict{UUID,Dict{VersionNumber,StdlibInfo}}()
     bundlers = Dict{UUID,Dict{VersionNumber,VersionSpec}}()
     for julia_ver in julia_vers
@@ -188,22 +190,36 @@ function julia_and_stdlib_versions(
             d[key] = haskey(d, key) ? d[key] ∪ spec : spec
         end
     end
-    return julia_vers, stdlibs, bundlers, by_patch
+    return stdlibs, bundlers, by_patch
 end
+
+const STDLIB_VERSIONS, BUNDLERS, BUNDLERS_BY_PATCH = julia_and_stdlib_versions()
 
 # Per package, the versions the provider offers because a Julia in
 # `julia_versions` bundles them, regardless of what the registries say. Nothing
 # in the resolve path needs this -- a bundled version is an ordinary candidate,
 # and a user bound that excludes it excludes the Julias that ship it -- but it
 # is the answer to "which versions of this stdlib can I even get on these
-# Julias", so it stays available for introspection and for the tests.
+# Julias", so it stays available for introspection and for the tests. Read off
+# the shared tables, so the versions it names are the ones a resolve produces,
+# synthetic build numbers and all.
 function bundled_versions(
-    julia_versions :: VersionSpec,
+    julia_versions :: VersionSpec = VersionSpec("*"),
 )
-    _, stdlibs, _, _ = julia_and_stdlib_versions(julia_versions)
-    Dict{UUID,Vector{VersionNumber}}(
-        uuid => collect(keys(vers)) for (uuid, vers) in stdlibs)
+    julias = filter(in(julia_versions), JULIA_VERSIONS)
+    out = Dict{UUID,Vector{VersionNumber}}()
+    for (uuid, vers) in STDLIB_VERSIONS
+        bundlers_u = BUNDLERS[uuid]
+        vs = [v for v in keys(vers) if any(in(bundlers_u[v]), julias)]
+        isempty(vs) || (out[uuid] = vs)
+    end
+    return out
 end
+
+# Does some Julia bundle this exact version of this package? False for every
+# version the registries alone provide, and for packages that are not stdlibs.
+is_bundled(uuid::UUID, v::VersionNumber) =
+    haskey(STDLIB_VERSIONS, uuid) && haskey(STDLIB_VERSIONS[uuid], v)
 
 ## prerelease admission
 #
@@ -253,14 +269,34 @@ end
 yanked_exclusion(packages::Dict{UUID,Vector{PkgEntry}}) =
     :yanked => (uuid::UUID, v::VersionNumber) -> is_yanked(packages, uuid, v)
 
+# Do the registries have this version, as opposed to it existing only because
+# some Julia bundles it? (the provider's `bundled_only`, from the outside.) Only
+# the reporting path needs the distinction -- for resolving, a bundled version is
+# an ordinary candidate whose `julia` compat says where it ships.
+function is_registered(
+    packages :: Dict{UUID,Vector{PkgEntry}},
+    uuid     :: UUID,
+    v        :: VersionNumber,
+)
+    entries = get(packages, uuid, nothing)
+    entries === nothing && return false
+    any(haskey(package_info(entry).version_info, v) for entry in entries)
+end
+
+# The package universe the registries and Julia's history describe: every version
+# of every package, every Julia version, and every stdlib version any Julia
+# bundles. It has no query-dependent parameters, which is the point -- one
+# universe per registry state, and every query is a `Problem` over it.
+#
+# (`workspace_pkgs` is not a query knob: a workspace's member packages are part of
+# the environment's package universe, fixed at their local versions, the way a
+# registry's packages are part of it at their registered versions.)
 function registry_provider(
     packages       :: Dict{UUID,Vector{PkgEntry}};
-    julia_versions :: VersionSpec = VersionSpec("1"),
     workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
                       Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
 )
-    julia_vers, stdlibs, bundlers, by_patch =
-        julia_and_stdlib_versions(julia_versions)
+    stdlibs, bundlers, by_patch = STDLIB_VERSIONS, BUNDLERS, BUNDLERS_BY_PATCH
 
     return DepsProvider(keys(packages)) do uuid::UUID
         if uuid in keys(workspace_pkgs)
@@ -284,7 +320,7 @@ function registry_provider(
         # entry); the widening below bounds them to their bundling Julias
         bundled_only = Set{VersionNumber}()
         if uuid == JULIA_UUID
-            union!(vers, julia_vers)
+            union!(vers, JULIA_VERSIONS)
             for v in vers
                 deps[v] = valtype(deps)()
                 # find relevant stdlibs stanza

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -257,13 +257,15 @@ end
 # project bound outright rather than intersecting with it, so the flag always
 # says exactly what will be resolved for.
 #
-# Whichever source wins feeds the one `julia_versions` spec that determines
-# both the `julia` package's version universe and, through it, which
-# historical stdlib versions are bundled and pinned (see Registries.jl) --
-# so a project bound and the equivalent `--julia` are indistinguishable
-# downstream. The bound is *consumed* here: it must not also constrain
-# `julia` as a user compat entry in the `Problem` below, or the two readings
-# of the same entry would compound.
+# Whichever source wins is an ordinary compat entry on `julia`: the provider
+# offers every Julia version there is, along with every stdlib version any of
+# them bundles (see Registries.jl), and this bound constrains the `julia`
+# package the way any other bound constrains its own. So a project bound and
+# the equivalent `--julia` are indistinguishable downstream -- and the Julias
+# the bound excludes are excluded by clause rather than missing from the
+# universe, which is what lets one artifact answer for any of them. The
+# stdlib <-> Julia couplings do the rest: a Julia the bound rules out cannot
+# be chosen, so neither can a stdlib version only that Julia bundles.
 
 const julia_versions = something(
     handle_opts(:julia) do val::String
@@ -272,9 +274,11 @@ const julia_versions = something(
             usage("Invalid compat version spec: --julia=$val")
         end
     end,
-    pop!(project_compat, JULIA_UUID, nothing),
+    get(project_compat, JULIA_UUID, nothing),
     VersionSpec("1"),
 )
+
+project_compat[JULIA_UUID] = julia_versions
 
 ## options: parsing packages specs
 
@@ -453,17 +457,12 @@ end
 
 ## do an actual resolve
 
-reg = registry_provider(
-    packages;
-    julia_versions,
-    workspace_pkgs,
-)
+reg = registry_provider(packages; workspace_pkgs)
 
 # the project's compat bounds are user constraints, not part of the package
 # universe: they go into the `Problem`, which forbids the versions they exclude
-# by clause instead of deleting them from the provider's data. (the `julia`
-# bound is not among them: it was consumed above, as the Julia version
-# universe.)
+# by clause instead of deleting them from the provider's data. the `julia` bound
+# is one of them, no longer special (see above).
 #
 # every bound is enforced strictly, stdlibs included. a bound on a stdlib is not
 # inert: a Julia version is compatible with exactly the stdlib versions it
@@ -611,14 +610,28 @@ for (uuid, version) in sol
 end
 
 if output == :print_versions
-    # the best version of a package that the project's constraints admit: the
-    # info keeps the versions the Problem forbids (they are constrained away,
-    # not deleted), so they don't count as available here. The info lists
-    # versions in the canonical order, not the requested one, so rank them here
-    # with the same comparator the resolve used
+    # The best version of a package that was actually available. The universe
+    # holds every version of every package and every Julia, and says what a query
+    # admits by constraining rather than by leaving things out -- so "available"
+    # has to be spelled out here: the project's bounds must admit it, and it must
+    # be a version the registries have or one that a Julia the bound admits
+    # bundles. (A version bundled only by some other Julia is in the universe but
+    # was never on offer, and would make every stdlib look sub-optimal.) The info
+    # lists versions in the canonical order, not the requested one, so rank them
+    # with the same comparator the resolve used.
+    bundled_here = bundled_versions(julia_versions)
+    function on_offer(uuid::UUID, v::VersionNumber)
+        # a version the registries have is on offer whatever Julia we target,
+        # and so is anything no Julia bundles (`julia` itself included)
+        is_bundled(uuid, v) || return true
+        is_registered(packages, uuid, v) && return true
+        # otherwise it exists only because some Julia bundles it
+        return v in get(bundled_here, uuid, ())
+    end
     function best_version(uuid::UUID)
         vers = sort!(copy(pkg_info[uuid].versions); lt = version_order(uuid))
-        i = findfirst(v -> !Resolver.is_excluded(problem, uuid, v), vers)
+        i = findfirst(v -> !Resolver.is_excluded(problem, uuid, v) &&
+                           on_offer(uuid, v), vers)
         return isnothing(i) ? first(vers) : vers[i]
     end
     # print packages and versions in priority order, required packages first

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -473,12 +473,16 @@ reg = registry_provider(
 # admits, and no registry version fits either, the requirements really are
 # unsatisfiable and saying so beats silently ignoring the bound.
 #
-# prerelease admission rides along as an exclusion kind: `--allow-pre` says which
-# packages' prereleases the query accepts, and the rest are forbidden the same
-# way a compat bound forbids a version.
+# the admission knobs ride along as exclusion kinds: `--allow-pre` says which
+# packages' prereleases the query accepts, and yanked versions are forbidden
+# outright (there is no option to accept one yet), each the same way a compat
+# bound forbids a version.
 const problem = Problem(reqs;
     compat = project_compat,
-    excludes = [prerelease_exclusion(allow_pre)],
+    excludes = [
+        prerelease_exclusion(allow_pre),
+        yanked_exclusion(packages),
+    ],
 )
 
 pkg_info = Resolver.pkg_info(reg, problem)

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -363,7 +363,14 @@ handle_opts(r"^(allow_pre|(un)?fix|max|min)") do opt, val
     end
 end
 
-## version sorting
+## version ordering
+#
+# The version preference ordering is a *query* parameter, not part of the package
+# universe: it decides which of the valid solutions is optimal, not which
+# solutions are valid. So the provider hands over versions in the canonical order
+# (newest first, see Registries.jl) and this ordering reaches the resolver as
+# `resolve`'s `order` argument -- one comparator per package, built from the
+# --fix*/--max*/--min* options and the old manifest.
 
 function fixed(
     u::Nothing, # no old version
@@ -387,7 +394,7 @@ function fixed(
     end
 end
 
-function order(level::Symbol) :: Function
+function level_order(level::Symbol) :: Function
     level == :min && return (u::VersionNumber, v::VersionNumber) -> u < v
     level == :max && return (u::VersionNumber, v::VersionNumber) -> u > v
     level == :min_minor && return (u::VersionNumber, v::VersionNumber) ->
@@ -400,20 +407,19 @@ function order(level::Symbol) :: Function
         thismajor(u) ≠ thismajor(v) ? thismajor(u) > thismajor(v) : u < v
 end
 
-function sort_versions(uuid::UUID, vers::Set{VersionNumber})
+function version_order(uuid::UUID) :: Function
     fixed_by = fixed(
         get(old_versions, uuid, nothing),
         get(FIX_PATCH, uuid, FIX_PATCH[ZERO_UUID]),
         get(FIX_MINOR, uuid, FIX_MINOR[ZERO_UUID]),
         get(FIX_MAJOR, uuid, FIX_MAJOR[ZERO_UUID]),
     )
-    <ₒ = order(get(ORDER_MAP, uuid, ORDER_MAP[ZERO_UUID]))
+    <ₒ = level_order(get(ORDER_MAP, uuid, ORDER_MAP[ZERO_UUID]))
     function lt(u::VersionNumber, v::VersionNumber)
         fixed_u = fixed_by(u) :: UInt8
         fixed_v = fixed_by(v) :: UInt8
         fixed_u ≠ fixed_v ? fixed_u > fixed_v : u <ₒ v
     end
-    sort!(collect(vers); lt)
 end
 
 ## options: sorting packages (resolution priority)
@@ -450,7 +456,6 @@ end
 reg = registry_provider(
     packages;
     julia_versions,
-    sort_versions,
     allow_pre,
     workspace_pkgs,
 )
@@ -471,7 +476,7 @@ reg = registry_provider(
 const problem = Problem(reqs; compat = project_compat)
 
 pkg_info = Resolver.pkg_info(reg, problem)
-sol = resolve(pkg_info, problem; by=sort_packages_by)
+sol = resolve(pkg_info, problem; by=sort_packages_by, order=version_order)
 sol === nothing && error("Unsatisfiable")
 
 ## output results
@@ -598,9 +603,11 @@ end
 if output == :print_versions
     # the best version of a package that the project's constraints admit: the
     # info keeps the versions the Problem forbids (they are constrained away,
-    # not deleted), so they don't count as available here
+    # not deleted), so they don't count as available here. The info lists
+    # versions in the canonical order, not the requested one, so rank them here
+    # with the same comparator the resolve used
     function best_version(uuid::UUID)
-        vers = pkg_info[uuid].versions
+        vers = sort!(copy(pkg_info[uuid].versions); lt = version_order(uuid))
         i = findfirst(v -> !Resolver.is_excluded(problem, uuid, v), vers)
         return isnothing(i) ? first(vers) : vers[i]
     end

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -456,7 +456,6 @@ end
 reg = registry_provider(
     packages;
     julia_versions,
-    allow_pre,
     workspace_pkgs,
 )
 
@@ -473,7 +472,14 @@ reg = registry_provider(
 # Julia choice to satisfy it. If no admissible Julia bundles a version the bound
 # admits, and no registry version fits either, the requirements really are
 # unsatisfiable and saying so beats silently ignoring the bound.
-const problem = Problem(reqs; compat = project_compat)
+#
+# prerelease admission rides along as an exclusion kind: `--allow-pre` says which
+# packages' prereleases the query accepts, and the rest are forbidden the same
+# way a compat bound forbids a version.
+const problem = Problem(reqs;
+    compat = project_compat,
+    excludes = [prerelease_exclusion(allow_pre)],
+)
 
 pkg_info = Resolver.pkg_info(reg, problem)
 sol = resolve(pkg_info, problem; by=sort_packages_by, order=version_order)

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -26,6 +26,11 @@ const LINEAR_ALGEBRA = UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e")
 const JSON = UUID("682c06a0-de6a-54ab-a142-c8b1cf79cde6")
 const STATISTICS = UUID("10745b16-79ce-11e8-11f9-7d13ad32a3b2")
 const DELIMITED_FILES = UUID("8bb1440f-4735-579b-a4ab-409b98df4dab")
+# LLVM_full_jll has prerelease versions in the General registry (11.0.0-rc5 &c),
+# and Wine_jll has *only* prerelease versions -- so it must not resolve at all
+# unless prereleases are admitted.
+const LLVM_FULL_JLL = UUID("a3ccf953-465e-511d-b87f-60a6490c289d")
+const WINE_JLL = UUID("9fae3aff-8997-5dd1-9b84-5d0cc5e0bffa")
 
 # Load packages from the installed registries (mirrors bin/resolve.jl).
 const packages = Dict{UUID,Vector{PkgEntry}}()
@@ -38,8 +43,25 @@ end
 make_provider(julia::VersionSpec) = registry_provider(
     packages;
     julia_versions = julia,
-    allow_pre = Dict(UUID(0) => false),
 )
+
+# `--allow-pre`'s dictionary: the zero uuid holds the default
+no_pre = Dict(UUID(0) => false)
+all_pre = Dict(UUID(0) => true)
+
+# The old baked path, for the knobs that used to be applied by deleting versions
+# from the provider's output: `prob`'s excluded versions gone from the data, and
+# with them their deps & compat entries (which `pkg_info` reads by version).
+function bake(data::AbstractDict{P}, prob::Resolver.Problem{P}) where {P}
+    baked = empty(data)
+    for (p, d) in data
+        vers = [v for v in d.versions if !Resolver.is_excluded(prob, p, v)]
+        baked[p] = Resolver.PkgData(vers,
+            typeof(d.depends)(v => d.depends[v] for v in vers if haskey(d.depends, v)),
+            typeof(d.compat)(v => d.compat[v] for v in vers if haskey(d.compat, v)))
+    end
+    return baked
+end
 
 # Is the requirement set resolvable for the given Julia spec?
 function resolves(reqs::Vector{UUID}; julia::VersionSpec)
@@ -180,6 +202,44 @@ end
         @test Resolver.resolve(info, prob; order) == Resolver.resolve(baked, prob)
         @test Resolver.resolve(info, prob; order)[JULIA_UUID] <
               Resolver.resolve(info, prob)[JULIA_UUID]
+    end
+
+    # Prerelease admission is a query constraint, not a property of the package
+    # universe: the versions exist either way, and `--allow-pre` says which of
+    # them a query accepts. The oracle is the old path, where the provider
+    # deleted the prereleases it was not told to keep -- so resolving against the
+    # data with them dropped must give exactly what constraining them gives, at
+    # registry scale and for every admission setting.
+    @testset "prerelease admission is a resolve-time constraint" begin
+        reg = make_provider(VersionSpec("1.10"))
+        reqs = sort([LLVM_FULL_JLL, WINE_JLL, JSON, JULIA_UUID])
+        data = Resolver.pkg_data(reg, reqs)
+        # the provider really does offer prereleases now
+        @test any(!isempty(v.prerelease) for v in data[LLVM_FULL_JLL].versions)
+        # and the one artifact keeps them, for every query to constrain as it likes
+        info = Resolver.pkg_info(reg, reqs)
+        @test any(!isempty(v.prerelease) for v in info[LLVM_FULL_JLL].versions)
+
+        for allow_pre in (no_pre, all_pre,
+                          Dict(UUID(0) => false, LLVM_FULL_JLL => true))
+            excludes = [prerelease_exclusion(allow_pre)]
+            prob = Resolver.Problem(reqs; excludes)
+            old = bake(data, prob) # the versions deleted, as the provider used to
+            @test Resolver.resolve(data, prob) == Resolver.resolve(old, reqs)
+            @test Resolver.resolve(info, prob) == Resolver.resolve(old, reqs)
+        end
+
+        # and it is not inert: every Wine_jll in the registry is a prerelease, so
+        # requiring it is unsatisfiable unless prereleases are admitted -- per
+        # package or globally, the flag's two shapes
+        wine = ["Wine_jll" => WINE_JLL]
+        @test isnothing(resolve_versions("", ["--julia=1.10"]; deps = wine))
+        pre = resolve_versions("", ["--julia=1.10", "--allow-pre=Wine_jll"];
+                               deps = wine)
+        @test !isnothing(pre)
+        @test !isempty(pre[WINE_JLL].prerelease)
+        @test pre == resolve_versions("", ["--julia=1.10", "--allow-pre"];
+                                      deps = wine)
     end
 
     # The provider offers a bundled stdlib version whatever the registries say,

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -311,6 +311,41 @@ end
         @test sol[LIBSODIUM_JLL] == v"1.0.21+0"
     end
 
+    # HistoricalStdlibVersions gives one stdlib version number to entries with
+    # different dependency sets across Julia versions -- the provider tells them
+    # apart with a synthetic build number -- so a bundled entry has to be matched
+    # to the Julias that bundle *it*, not to every Julia that bundles something
+    # with the same version number. Julia 1.11 and 1.12 both bundle a Markdown
+    # 1.11.0, and only 1.12's depends on JuliaSyntaxHighlighting.
+    @testset "a bundled stdlib entry belongs to its own Julias" begin
+        MARKDOWN = UUID("d6f4376e-aef5-505a-96c1-9c027394607a")
+        JULIA_SYNTAX_HIGHLIGHTING = UUID("ac6e5ff7-fb65-4e79-a425-ec3bc9c03011")
+        reg = make_provider(VersionSpec("1.11 - 1.12"))
+        pd = Resolver.pkg_data(reg, [MARKDOWN])[MARKDOWN]
+        # two entries with the same version number, told apart by the build
+        entries = [v for v in pd.versions if Base.thispatch(v) == v"1.11.0"]
+        @test length(entries) == 2
+        with = only(v for v in entries
+                    if JULIA_SYNTAX_HIGHLIGHTING in pd.depends[v])
+        without = only(v for v in entries if v ≠ with)
+        # each is admitted by the Julias that ship it, and by no others
+        @test v"1.12.0" ∈ pd.compat[with][JULIA_UUID]
+        @test v"1.11.0" ∉ pd.compat[with][JULIA_UUID]
+        @test v"1.11.0" ∈ pd.compat[without][JULIA_UUID]
+        @test v"1.12.0" ∉ pd.compat[without][JULIA_UUID]
+        # ... so a resolve on 1.12 gets 1.12's Markdown, dependencies and all
+        sol = resolve_versions("", ["--julia=1.12.0"];
+                               deps = ["Markdown" => MARKDOWN])
+        @test !isnothing(sol)
+        @test sol[MARKDOWN] == v"1.11.0"
+        @test haskey(sol, JULIA_SYNTAX_HIGHLIGHTING)
+        sol = resolve_versions("", ["--julia=1.11.0"];
+                               deps = ["Markdown" => MARKDOWN])
+        @test !isnothing(sol)
+        @test sol[MARKDOWN] == v"1.11.0"
+        @test !haskey(sol, JULIA_SYNTAX_HIGHLIGHTING)
+    end
+
     # The provider offers a bundled stdlib version whatever the registries say,
     # so `bundled_versions` answers "which versions of this stdlib can I get on
     # these Julias at all" -- the version sets the couplings below are stated

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -31,6 +31,11 @@ const DELIMITED_FILES = UUID("8bb1440f-4735-579b-a4ab-409b98df4dab")
 # unless prereleases are admitted.
 const LLVM_FULL_JLL = UUID("a3ccf953-465e-511d-b87f-60a6490c289d")
 const WINE_JLL = UUID("9fae3aff-8997-5dd1-9b84-5d0cc5e0bffa")
+# Compat 4.0.0 is yanked from General (the julia-downgrade-compat case, see the
+# "yanked packages" testset in the package suite), and libsodium_jll's *newest*
+# registered version is too.
+const COMPAT = UUID("34da2185-b29b-5c13-b0c7-acf172513d20")
+const LIBSODIUM_JLL = UUID("a9144af2-ca23-56d9-984f-0d03f7b5ccf8")
 
 # Load packages from the installed registries (mirrors bin/resolve.jl).
 const packages = Dict{UUID,Vector{PkgEntry}}()
@@ -240,6 +245,70 @@ end
         @test !isempty(pre[WINE_JLL].prerelease)
         @test pre == resolve_versions("", ["--julia=1.10", "--allow-pre"];
                                       deps = wine)
+    end
+
+    # Yankedness is the same shape of fact as prerelease-ness -- a property of a
+    # version that a query may or may not accept -- so it is modeled the same
+    # way, as an exclusion kind, even though nothing yet offers the user a way to
+    # turn it off. The oracle is the old path, where the provider deleted yanked
+    # versions outright.
+    @testset "yanked versions are constrained, not deleted" begin
+        reg = make_provider(VersionSpec("1.10"))
+        reqs = sort([COMPAT, LIBSODIUM_JLL, JULIA_UUID])
+        data = Resolver.pkg_data(reg, reqs)
+        yanked = yanked_exclusion(packages)
+        forbids = last(yanked)
+
+        # `is_yanked` reads the registries, not the version number: Compat 4.0.0
+        # is yanked from General and libsodium_jll's newest version is too
+        @test forbids(COMPAT, v"4.0.0")
+        @test !forbids(COMPAT, v"4.1.0")
+        @test forbids(LIBSODIUM_JLL, v"1.0.22+0")
+        @test !forbids(LIBSODIUM_JLL, v"1.0.21+0")
+        @test !forbids(JSON, v"0.21.4")
+        @test !forbids(JULIA_UUID, v"1.10.0") # not a registered package at all
+        @test !forbids(COMPAT, v"99.0.0")     # no such version
+
+        # the provider offers them and the one artifact keeps them
+        @test v"4.0.0" in data[COMPAT].versions
+        info = Resolver.pkg_info(reg, reqs)
+        @test v"4.0.0" in info[COMPAT].versions
+
+        prob = Resolver.Problem(reqs; excludes = [yanked])
+        old = bake(data, prob) # the versions deleted, as the provider used to
+        @test Resolver.resolve(data, prob) == Resolver.resolve(old, reqs)
+        @test Resolver.resolve(info, prob) == Resolver.resolve(old, reqs)
+        # ... together with the prerelease kind, and under a reversed ordering
+        both = Resolver.Problem(reqs;
+            excludes = [yanked, prerelease_exclusion(no_pre)])
+        @test Resolver.resolve(info, both) ==
+              Resolver.resolve(bake(data, both), reqs)
+        order = u -> (<)
+        @test Resolver.resolve(info, both; order) ==
+              Resolver.resolve(bake(data, both), reqs; order)
+
+        # The selector map names the kind, so a diagnostic could one day say
+        # "the only version that satisfies this is yanked". libsodium_jll's
+        # yanked version is its *newest*, so nothing dominates it and the filter
+        # has to keep it -- it is ruled out by clause. Compat's is not, so
+        # redundancy elimination deletes it, which is the filter subsuming the
+        # deletion the provider used to do.
+        work = Resolver.prepare_pkg_info(info, prob)
+        sat = Resolver.SAT(work, prob)
+        try
+            @test (:yanked, LIBSODIUM_JLL) in values(sat.sels)
+            @test v"1.0.22+0" in work[LIBSODIUM_JLL].versions
+            @test v"4.0.0" ∉ work[COMPAT].versions
+        finally
+            Resolver.finalize(sat)
+        end
+
+        # end to end: libsodium_jll's newest registered version is yanked, so the
+        # resolve must land on the one below it
+        sol = resolve_versions("", ["--julia=1.10"];
+                               deps = ["libsodium_jll" => LIBSODIUM_JLL])
+        @test !isnothing(sol)
+        @test sol[LIBSODIUM_JLL] == v"1.0.21+0"
     end
 
     # The provider offers a bundled stdlib version whatever the registries say,

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -141,6 +141,47 @@ end
         @test info[JSON].versions[1] ∉ VersionSpec("0.20")
     end
 
+    # The version preference ordering is a resolve parameter, not part of the
+    # package universe: the provider always hands over the canonical order
+    # (newest first), and a query's ordering is `resolve`'s `order` argument. The
+    # oracle is the old path, where the ordering was baked into the provider's
+    # version vectors -- so sorting the data that way and resolving canonically
+    # must give exactly what passing the comparator gives, at registry scale.
+    @testset "the version ordering is a resolve parameter" begin
+        reg = make_provider(VersionSpec("1.10"))
+        reqs = sort([JSON, COMPILER_SUPPORT_LIBRARIES_JLL, JULIA_UUID])
+        prob = Resolver.Problem(reqs)
+        data = Resolver.pkg_data(reg, reqs)
+        # the provider's own order is canonical, so nothing needs permuting
+        info = Resolver.pkg_info(data, reqs)
+        @test Resolver.version_permutations(info, _ -> >) === nothing
+        # oldest first, then a couple of the real --max-minor / --min-minor
+        # comparators the options build
+        minor(u, v) = Base.thisminor(u) ≠ Base.thisminor(v) ?
+            Base.thisminor(u) > Base.thisminor(v) : u < v
+        rminor(u, v) = Base.thisminor(u) ≠ Base.thisminor(v) ?
+            Base.thisminor(u) < Base.thisminor(v) : u > v
+        for lt in (<, minor, rminor)
+            order = _ -> lt
+            baked = Dict(u => Resolver.PkgData(
+                            sort(collect(d.versions); lt), d.depends, d.compat)
+                         for (u, d) in data)
+            @test Resolver.resolve(data, prob; order) ==
+                  Resolver.resolve(baked, prob)
+            # ... and the one T1 artifact answers under any of them
+            @test Resolver.resolve(info, prob; order) ==
+                  Resolver.resolve(baked, prob)
+        end
+        # a per-package ordering: only julia reversed, everything else canonical
+        order = u -> u == JULIA_UUID ? (<) : (>)
+        baked = Dict(u => Resolver.PkgData(
+                        sort(collect(d.versions); lt = order(u)),
+                        d.depends, d.compat) for (u, d) in data)
+        @test Resolver.resolve(info, prob; order) == Resolver.resolve(baked, prob)
+        @test Resolver.resolve(info, prob; order)[JULIA_UUID] <
+              Resolver.resolve(info, prob)[JULIA_UUID]
+    end
+
     # The provider offers a bundled stdlib version whatever the registries say,
     # so `bundled_versions` answers "which versions of this stdlib can I get on
     # these Julias at all" -- the version sets the couplings below are stated

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -45,14 +45,29 @@ for reg in reachable_registries()
     end
 end
 
-make_provider(julia::VersionSpec) = registry_provider(
-    packages;
-    julia_versions = julia,
-)
+# The one package universe: `registry_provider` has no query-dependent parameters
+# left, so there is nothing to vary here.
+const reg = registry_provider(packages)
 
 # `--allow-pre`'s dictionary: the zero uuid holds the default
 no_pre = Dict(UUID(0) => false)
 all_pre = Dict(UUID(0) => true)
+
+# The `Problem` bin/resolve.jl builds: the Julia bound as an ordinary compat entry
+# on `julia`, the project's other bounds beside it, and the admission kinds.
+function make_problem(
+    reqs      :: Vector{UUID};
+    julia     :: VersionSpec,
+    compat    :: AbstractDict = Dict{UUID,VersionSpec}(),
+    allow_pre :: Dict{UUID,Bool} = no_pre,
+)
+    c = Dict{UUID,Any}(compat)
+    c[JULIA_UUID] = julia
+    Resolver.Problem(reqs; compat = c, excludes = [
+        prerelease_exclusion(allow_pre),
+        yanked_exclusion(packages),
+    ])
+end
 
 # The old baked path, for the knobs that used to be applied by deleting versions
 # from the provider's output: `prob`'s excluded versions gone from the data, and
@@ -70,9 +85,9 @@ end
 
 # Is the requirement set resolvable for the given Julia spec?
 function resolves(reqs::Vector{UUID}; julia::VersionSpec)
-    reg = make_provider(julia)
-    info = Resolver.pkg_info(reg, reqs)
-    Resolver.resolve(info, reqs) !== nothing
+    prob = make_problem(reqs; julia)
+    info = Resolver.pkg_info(reg, prob)
+    Resolver.resolve(info, prob) !== nothing
 end
 
 # Resolve a project with the given dependencies, `[compat]` body and command
@@ -129,7 +144,6 @@ end
     # bound must still govern). Julia 1.10.8 is a frozen release, so its bundled
     # CompilerSupportLibraries_jll (1.1.1) never changes.
     @testset "stdlib julia-compat is widened, not cleared" begin
-        reg = make_provider(VersionSpec("1.10.8"))
         pd = Resolver.pkg_data(reg, [COMPILER_SUPPORT_LIBRARIES_JLL])[COMPILER_SUPPORT_LIBRARIES_JLL]
         compatible(v) = (spec = get(pd.compat[v], JULIA_UUID, nothing);
                          spec === nothing || v"1.10.8" ∈ spec)
@@ -156,8 +170,7 @@ end
     # applies them: they reach the resolver as part of a `Problem`, which
     # forbids the excluded versions by clause rather than deleting them.
     @testset "project compat travels in the Problem" begin
-        reg = make_provider(VersionSpec("1.10"))
-        prob = Resolver.Problem([JSON, JULIA_UUID];
+        prob = make_problem([JSON, JULIA_UUID]; julia = VersionSpec("1.10"),
             compat = Dict(JSON => VersionSpec("0.20")))
         info = Resolver.pkg_info(reg, prob)
         sol = Resolver.resolve(info, prob)
@@ -175,9 +188,8 @@ end
     # version vectors -- so sorting the data that way and resolving canonically
     # must give exactly what passing the comparator gives, at registry scale.
     @testset "the version ordering is a resolve parameter" begin
-        reg = make_provider(VersionSpec("1.10"))
         reqs = sort([JSON, COMPILER_SUPPORT_LIBRARIES_JLL, JULIA_UUID])
-        prob = Resolver.Problem(reqs)
+        prob = make_problem(reqs; julia = VersionSpec("1.10"))
         data = Resolver.pkg_data(reg, reqs)
         # the provider's own order is canonical, so nothing needs permuting
         info = Resolver.pkg_info(data, reqs)
@@ -216,7 +228,6 @@ end
     # data with them dropped must give exactly what constraining them gives, at
     # registry scale and for every admission setting.
     @testset "prerelease admission is a resolve-time constraint" begin
-        reg = make_provider(VersionSpec("1.10"))
         reqs = sort([LLVM_FULL_JLL, WINE_JLL, JSON, JULIA_UUID])
         data = Resolver.pkg_data(reg, reqs)
         # the provider really does offer prereleases now
@@ -253,7 +264,6 @@ end
     # turn it off. The oracle is the old path, where the provider deleted yanked
     # versions outright.
     @testset "yanked versions are constrained, not deleted" begin
-        reg = make_provider(VersionSpec("1.10"))
         reqs = sort([COMPAT, LIBSODIUM_JLL, JULIA_UUID])
         data = Resolver.pkg_data(reg, reqs)
         yanked = yanked_exclusion(packages)
@@ -320,19 +330,19 @@ end
     @testset "a bundled stdlib entry belongs to its own Julias" begin
         MARKDOWN = UUID("d6f4376e-aef5-505a-96c1-9c027394607a")
         JULIA_SYNTAX_HIGHLIGHTING = UUID("ac6e5ff7-fb65-4e79-a425-ec3bc9c03011")
-        reg = make_provider(VersionSpec("1.11 - 1.12"))
         pd = Resolver.pkg_data(reg, [MARKDOWN])[MARKDOWN]
-        # two entries with the same version number, told apart by the build
+        # several entries share the version number, told apart by the build
         entries = [v for v in pd.versions if Base.thispatch(v) == v"1.11.0"]
-        @test length(entries) == 2
-        with = only(v for v in entries
-                    if JULIA_SYNTAX_HIGHLIGHTING in pd.depends[v])
-        without = only(v for v in entries if v ≠ with)
-        # each is admitted by the Julias that ship it, and by no others
-        @test v"1.12.0" ∈ pd.compat[with][JULIA_UUID]
-        @test v"1.11.0" ∉ pd.compat[with][JULIA_UUID]
-        @test v"1.11.0" ∈ pd.compat[without][JULIA_UUID]
-        @test v"1.12.0" ∉ pd.compat[without][JULIA_UUID]
+        @test length(entries) ≥ 2
+        with = [v for v in entries if JULIA_SYNTAX_HIGHLIGHTING in pd.depends[v]]
+        without = setdiff(entries, with)
+        @test !isempty(with) && !isempty(without)
+        # each is admitted by the Julias that ship it, and by no others: the
+        # entry Julia 1.12 bundles is the one with the extra dependency
+        @test any(v -> v"1.12.0" ∈ pd.compat[v][JULIA_UUID], with)
+        @test all(v -> v"1.12.0" ∉ pd.compat[v][JULIA_UUID], without)
+        @test any(v -> v"1.11.0" ∈ pd.compat[v][JULIA_UUID], without)
+        @test all(v -> v"1.11.0" ∉ pd.compat[v][JULIA_UUID], with)
         # ... so a resolve on 1.12 gets 1.12's Markdown, dependencies and all
         sol = resolve_versions("", ["--julia=1.12.0"];
                                deps = ["Markdown" => MARKDOWN])
@@ -357,12 +367,67 @@ end
         @test !haskey(bundled, JSON) # not a stdlib
     end
 
+    # The Julia universe is not a query parameter either: the provider offers
+    # *every* Julia version, along with every stdlib version any of them bundles,
+    # and the `--julia` / project bound is an ordinary compat entry on `julia`. The
+    # stdlib <-> Julia couplings then do the work a restricted universe used to:
+    # a Julia the bound rules out cannot be chosen, so neither can a version only
+    # that Julia bundles.
+    @testset "the julia universe is the whole universe" begin
+        pd = Resolver.pkg_data(reg, [JULIA_UUID])[JULIA_UUID]
+        # every Julia there is, 0.x and the prerelease included -- the admission
+        # kinds and the bound are what narrow it
+        @test length(pd.versions) == length(Registries.JULIA_VERSIONS)
+        @test any(v -> v.major == 0, pd.versions)
+        @test any(v -> !isempty(v.prerelease), pd.versions)
+
+        # ... and each of them still pins the stdlibs it bundles, so the pins are
+        # per candidate Julia as before (LinearAlgebra is versioned with Julia)
+        @test v"1.10.8" ∈ pd.compat[v"1.10.8"][LINEAR_ALGEBRA]
+        @test v"1.11.0" ∉ pd.compat[v"1.10.8"][LINEAR_ALGEBRA]
+        @test !haskey(pd.compat[v"1.10.8"], STATISTICS) # upgradable: unpinned
+
+        # A version that exists only as a bundled stdlib is admitted by exactly
+        # the Julias that bundle it, drawn from the whole universe -- so a bound
+        # elsewhere that only such a version satisfies steers the Julia choice,
+        # and a Julia bound that excludes those Julias is unsatisfiable rather
+        # than inert. Statistics 1.10.0 ships only with Julia 1.10 (the registry
+        # starts at 1.11.0).
+        sd = Resolver.pkg_data(reg, [STATISTICS])[STATISTICS]
+        @test v"1.10.0" in sd.versions
+        julias = sd.compat[v"1.10.0"][JULIA_UUID]
+        @test v"1.10.8" ∈ julias
+        @test v"1.11.0" ∉ julias
+        @test v"1.9.0" ∉ julias
+        # a registry version keeps its own bound (Statistics 1.11.1 declares
+        # `julia = "1.9.4 - 1"`, so nothing older) and gains the Julias that
+        # bundle it (1.11.x, whose pins would otherwise be unsatisfiable there)
+        reg_julias = sd.compat[v"1.11.1"][JULIA_UUID]
+        @test v"1.9.0" ∉ reg_julias
+        @test v"1.11.6" ∈ reg_julias
+
+        # the whole point: one artifact, several Julia bounds, each answer the
+        # one a from-scratch resolve of that bound gives
+        reqs = sort([LINEAR_ALGEBRA, JSON, JULIA_UUID])
+        info = Resolver.pkg_info(reg, reqs)
+        for julia in (VersionSpec("1.9"), VersionSpec("1.10"), VersionSpec("1.11"),
+                      VersionSpec("1"), VersionSpec("1.10.8"))
+            prob = make_problem(reqs; julia)
+            sol = Resolver.resolve(info, prob)
+            @test !isnothing(sol)
+            @test sol[JULIA_UUID] ∈ julia
+            @test isempty(sol[JULIA_UUID].prerelease)
+            @test sol == Resolver.resolve(reg, prob)
+        end
+        # and a bound no Julia satisfies is unsatisfiable, not silently widened
+        @test isnothing(Resolver.resolve(info,
+            make_problem(reqs; julia = VersionSpec("99"))))
+    end
+
     # The Julia versions to resolve for come from `--julia` if given, otherwise
     # from the project's own `[compat] julia` bound, otherwise from the `1`
-    # default. Unlike every other compat entry, the `julia` bound selects a
-    # version *universe* rather than constraining one: it decides which Julias
-    # exist to be resolved among, and with them which stdlib versions are
-    # bundled and pinned.
+    # default -- the one bound whose reach goes beyond its own package, since the
+    # stdlib couplings propagate it.
     @testset "julia compat as the default julia bound" begin
         # the newest release the `1` default admits: what resolving with
         # neither a flag nor a project bound has always picked

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,6 +8,10 @@ Problem
 ## Internals
 
 ```@docs
+Resolver.pkg_info
+Resolver.version_classes
+Resolver.prepare_pkg_info
+Resolver.class_representatives
 Resolver.find_reachable
 Resolver.exclusion_masks
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,6 +11,7 @@ Problem
 Resolver.pkg_info
 Resolver.version_classes
 Resolver.prepare_pkg_info
+Resolver.version_permutations
 Resolver.class_representatives
 Resolver.find_reachable
 Resolver.exclusion_masks

--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -392,11 +392,25 @@ to rebuild than the first.
 The implementation draws the line between the first tier and the rest
 at `pkg_info`, whose output — conflict matrices, the arc-consistency
 prune and the classes (`version_classes`) — is exactly the
-registry-only artifact. Everything ordering- or problem-dependent runs
-per resolve in `prepare_pkg_info`: the classes are refined by the
-user's constraints and collapsed to their best members
-(`class_representatives`), and the collapsed problem is then filtered
+registry-only artifact, and it merges the second and third tiers into
+one per-resolve pass, `prepare_pkg_info`, since the middle tier is
+cheap enough not to be worth storing. That pass lays each package's
+versions out in the ordering the query asked for
+(`version_permutations`), refines the classes by the user's constraints
+and collapses each to its best member in that ordering
+(`class_representatives`), and filters the result
 (`filter_pkg_info!`).
+
+The ordering is a `resolve` parameter rather than part of the problem,
+which is what makes one artifact serve every query: it selects among
+the valid solutions instead of changing which solutions are valid. What
+*does* change the model set — the user's compat bounds and pins, and
+the admission of prerelease and yanked versions — is a `Problem`, and
+enters as constraints on the artifact's versions rather than as
+deletions from it (see `exclusion_masks`). So there is one T1 artifact
+per registry state, full stop: every version the registry state offers
+is in it, in canonical order, and each query says which of them it will
+accept and in what order it prefers them.
 
 !!! warning "Formalization boundary"
     Theorems 2, 3, 5, and 6 are proved against the rule set as stated

--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -54,8 +54,8 @@ itself, which pins the unique answer.
 
 ## Filtering
 
-Real problems are shrunk before solving by two passes (`pkg_info` with
-`filter=true`, the default):
+Real problems are shrunk before solving by two passes
+(`filter_pkg_info!`, run per resolve from `prepare_pkg_info`):
 
 **Reachability** (`find_reachable`) computes, per package, a version
 *prefix* to keep, by a fixpoint of *conflict-driven degradation*:
@@ -388,6 +388,15 @@ filtering, which is fast and not worth caching). A non-standard
 ordering — say, preferring versions closest to an installed manifest —
 invalidates only the middle tier, which is orders of magnitude cheaper
 to rebuild than the first.
+
+The implementation draws the line between the first tier and the rest
+at `pkg_info`, whose output — conflict matrices, the arc-consistency
+prune and the classes (`version_classes`) — is exactly the
+registry-only artifact. Everything ordering- or problem-dependent runs
+per resolve in `prepare_pkg_info`: the classes are refined by the
+user's constraints and collapsed to their best members
+(`class_representatives`), and the collapsed problem is then filtered
+(`filter_pkg_info!`).
 
 !!! warning "Formalization boundary"
     Theorems 2, 3, 5, and 6 are proved against the rule set as stated

--- a/src/BitKernels.jl
+++ b/src/BitKernels.jl
@@ -73,6 +73,44 @@ function copy_col_bits!(dest::Vector{UInt64}, off::Int, X::BitMatrix, j::Int, le
     return dest
 end
 
+# rows of a conflicts matrix are strided across the column spans, so the two
+# primitives the interchangeability test needs read them bit by bit: a hash of
+# row i over the first n columns, and exact equality of rows i and j over them
+
+function row_hash(X::BitMatrix, i::Int, n::Int, W::Int)
+    chunks = X.chunks
+    wi = ((i - 1) >> 6) + 1
+    bi = (i - 1) & 63
+    h = zero(UInt)
+    acc = UInt64(0)
+    nb = 0
+    @inbounds for k = 1:n
+        acc |= ((chunks[(k - 1) * W + wi] >> bi) & 1) << nb
+        nb += 1
+        if nb == 64
+            h = hash(acc, h)
+            acc = UInt64(0)
+            nb = 0
+        end
+    end
+    nb > 0 && (h = hash(acc, h))
+    return h
+end
+
+function rows_equal(X::BitMatrix, i::Int, j::Int, n::Int, W::Int)
+    chunks = X.chunks
+    wi = ((i - 1) >> 6) + 1
+    bi = (i - 1) & 63
+    wj = ((j - 1) >> 6) + 1
+    bj = (j - 1) & 63
+    @inbounds for k = 1:n
+        base = (k - 1) * W
+        ((chunks[base + wi] >> bi) & 1) ==
+        ((chunks[base + wj] >> bj) & 1) || return false
+    end
+    return true
+end
+
 # highest set row ≤ hi in column j of X, or 0 if none
 function col_max_upto(X::BitMatrix, j::Int, hi::Int)
     hi ≤ 0 && return 0

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -1,3 +1,119 @@
+"""
+    class_representatives(info, prob) :: Dict{P, BitVector}
+
+Per package, a mask of the versions that survive collapsing its
+interchangeability classes: the T1 classes (`version_classes`) refined by
+`prob`, then one representative per refined class.
+
+**Refinement.** User compat and pins are the only constraints that can tell two
+members of a T1 class apart, because they are stated on version *values*
+instead of on the registry's rows — so splitting each class by `prob`'s
+[`exclusion_masks`](@ref Resolver.exclusion_masks) is enough, and it costs
+nothing for the packages the user did not constrain. Read as the virtual
+package of `Problem`'s docstring, this is just row equality again, over one
+more conflict column.
+
+**Representative.** The best member in the active rank order, which is version
+order, so the lowest-indexed one.
+
+Collapsing is answer-preserving: identical constraint rows are in particular a
+subset of each other, so a class member is dominated by its representative and
+the redundancy theorem's swap argument applies (see the manual's Theory section,
+lemma on interchangeable versions). Representatives *are* versions, and the
+members dropped are exactly the ones the layered answer never chooses, so
+nothing has to be mapped back afterwards.
+"""
+function class_representatives(
+    info :: AbstractDict{P, PkgInfo{P,V}},
+    prob :: Problem{P} = Problem(P[]),
+) where {P,V}
+    excl = exclusion_masks(info, prob)
+    keep = Dict{P,BitVector}()
+    seen = Bool[] # refined classes already represented
+    for (p, info_p) in info
+        m = length(info_p.versions)
+        cls = info_p.classes
+        e = get(excl, p, nothing)
+        k = falses(m)
+        resize!(seen, 2m)
+        fill!(seen, false)
+        for i = 1:m
+            # refined class key: the T1 class, split by forbidden-ness
+            c = 2 * cls[i] - (e !== nothing && e[i])
+            seen[c] && continue
+            seen[c] = true
+            k[i] = true # the first member found is the best one
+        end
+        keep[p] = k
+    end
+    return keep
+end
+
+"""
+    prepare_pkg_info(info, prob, [info′]; group = true) :: Dict{P,PkgInfo{P,V}}
+
+The per-resolve half of preprocessing, run on a T1 artifact (see
+[`pkg_info`](@ref Resolver.pkg_info)) to produce the universe the SAT instance
+is built over. Two steps, in this order:
+
+1. **Collapse** each interchangeability class, refined by `prob`, to its best
+   member (`class_representatives`).
+2. **Filter** the collapsed universe for reachability and redundancy against
+   the actual requirements and constraints (`filter_pkg_info!`).
+
+Filtering has to come second: both of its passes are stated in terms of the
+version ordering, and both get cheaper the fewer versions there are. The
+collapse is handed over as *marks* rather than as a rebuilt universe, so the
+two steps share one materialization (see `copy_marked!`).
+
+The result is a fresh dict — `info` is left untouched, so a T1 artifact stays
+reusable across resolves — unless the caller passes its own scratch dict as
+`info′`, or `info` itself when it owns it. `group = false` skips the collapse,
+which is the ungrouped path the tests compare against.
+"""
+function prepare_pkg_info(
+    info  :: AbstractDict{P, PkgInfo{P,V}},
+    prob  :: Problem{P},
+    info′ :: Dict{P, PkgInfo{P,V}} = Dict{P, PkgInfo{P,V}}();
+    group :: Bool = true,
+) where {P,V}
+    keep = group ? class_representatives(info, prob) : nothing
+    copy_marked!(info′, info, keep)
+    filter_pkg_info!(info′, prob)
+    return info′
+end
+
+# Copy `info` into `info′`, marking active exactly the versions `keep` selects
+# (all of them when it is `nothing`); when the two are the same dict, only the
+# marks are written. This is how the collapse is handed to `filter_pkg_info!`:
+# as *marks* rather than as an already-shrunken universe, so that the filter's
+# own first `drop_unmarked!` materializes the collapse and its own deletions
+# together, in one rebuild instead of two. Every pass the filter runs before
+# that point reads the version flags as the version set, so they all see the
+# collapsed problem — which is the problem the interchangeability lemma
+# licenses substituting for the original.
+function copy_marked!(
+    info′ :: Dict{P, PkgInfo{P,V}},
+    info  :: AbstractDict{P, PkgInfo{P,V}},
+    keep  :: Union{Nothing, AbstractDict{P, BitVector}} = nothing,
+) where {P,V}
+    for (p, info_p) in info
+        X = info_p.conflicts
+        m = length(info_p.versions)
+        n = size(X, 2) - 1
+        if info′ === info
+            keep === nothing || (X[1:m, end] .= keep[p])
+            continue
+        end
+        X′ = copy(X)
+        X′[1:m, end] .= keep === nothing ? true : keep[p]
+        X′[m+1, 1:n] .= true
+        info′[p] = PkgInfo(copy(info_p.versions), copy(info_p.depends),
+                           copy(info_p.interacts), X′, copy(info_p.classes))
+    end
+    return info′
+end
+
 filter_pkg_info!(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
@@ -15,9 +131,14 @@ function filter_pkg_info!(
     # index-based, so they are rebuilt after every deletion round; only the
     # constrained packages cost anything
     excl = exclusion_masks(info, prob)
-    # arc consistency first: it needs no marks and it is what makes the
-    # deletions safe — dropping a package while a kept version still
-    # depends on it would leave a dangling name. then redundancy
+    # the version flags on entry are the version set to filter: normally all
+    # of them, but `prepare_pkg_info` seeds them with the interchangeability
+    # collapse, so that the first `drop_unmarked!` below deletes the collapsed
+    # members along with everything the passes here find.
+    #
+    # arc consistency first: it needs no reachability marks and it is what
+    # makes the deletions safe — dropping a package while a kept version
+    # still depends on it would leave a dangling name. then redundancy
     # elimination — it needs no reachability marks and does most of the
     # shrinking — then alternate reachability and redundancy until neither
     # deletes anything: each deleted version can expose more of both kinds
@@ -234,9 +355,19 @@ function mark_installable!(
     # arc-consistency test — a sound approximation of deleting model-free
     # versions (see the theory docs) — and it is also what keeps `depends`
     # from naming a package that `drop_unmarked!` deletes as empty
+    #
+    # a dependency naming a package that is not in `info` at all counts the
+    # same way: it cannot be satisfied either, and a deletion elsewhere (the
+    # class collapse, say, or an earlier `drop_unmarked!`) is exactly how one
+    # comes about. `info` does not change here, so the absentees are found once
+    absent = Set{P}()
+    for info_p in values(info), q in info_p.depends
+        haskey(info, q) || push!(absent, q)
+    end
     empties = Set{P}()
     while true
         empty!(empties)
+        union!(empties, absent)
         for (p, info_p) in info
             X = info_p.conflicts
             any(X[i, end] for i = 1:length(info_p.versions)) && continue
@@ -518,6 +649,7 @@ function drop_unmarked!(
         D = info_p.depends
         T = info_p.interacts
         X = info_p.conflicts
+        C = info_p.classes
         m = length(V)
         n = size(X, 2) - 1
         W = col_words(X)
@@ -533,11 +665,7 @@ function drop_unmarked!(
         if m′ == m && all(K)
             X[m+1, 1:n] .= true
             if info !== info′
-                V′ = copy(V)
-                D′ = copy(D)
-                T′ = copy(T)
-                X′ = copy(X)
-                info′[p] = PkgInfo(V′, D′, T′, X′)
+                info′[p] = PkgInfo(copy(V), copy(D), copy(T), copy(X), copy(C))
             end
             continue
         end
@@ -604,8 +732,14 @@ function drop_unmarked!(
         @assert j′ == b′
         X′[1:m′, end] .= true  # kept versions are active
         X′[m′+1, 1:b′] .= true # kept columns are active
+        # the surviving versions keep the classes they were in: dropping
+        # versions and columns can only *merge* row-equality classes (fewer
+        # rows to distinguish, fewer columns to differ in), so restricting the
+        # partition stays sound, if possibly finer than the truth. `pkg_info`
+        # is where it is computed exactly
+        C′ = renumber_classes!(C[I])
         # assign new struct into info′
-        info′[p] = PkgInfo(V′, D′, T′, X′)
+        info′[p] = PkgInfo(V′, D′, T′, X′, C′)
     end
     return info′
 end

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -1,5 +1,45 @@
 """
-    class_representatives(info, prob) :: Dict{P, BitVector}
+    version_permutations(info, order) :: Union{Nothing, Dict{P, Vector{Int}}}
+
+Per package, the permutation that puts its versions into the ordering `order`
+asks for: `perm[r]` is the index, in the T1 version list, of the `r`-th best
+version. Only the packages that actually need reordering get an entry, and the
+whole result is `nothing` when none of them do — so the *canonical* order, which
+is the one the T1 artifact carries, costs nothing.
+
+`order` is `nothing` for the canonical order, or a callable mapping a package to
+a `lt` comparator over its versions (`lt(u, v)` = "u is preferred to v"). The
+ordering is the one query knob that is not a *constraint*: it does not change
+which solutions are valid, only which valid solution is optimal. That is why it
+is a `resolve` parameter rather than part of the [`Problem`](@ref), and why the
+T1 artifact can be built and cached without knowing it (see the manual's Theory
+section, on order-free deletion and on interchangeability classes being
+ordering-independent while the representative choice is not).
+"""
+version_permutations(
+    info  :: AbstractDict{P, PkgInfo{P,V}},
+    order :: Nothing,
+) where {P,V} = nothing
+
+function version_permutations(
+    info  :: AbstractDict{P, PkgInfo{P,V}},
+    order,
+) where {P,V}
+    perms = Dict{P, Vector{Int}}()
+    for (p, info_p) in info
+        vers = info_p.versions
+        lt = order(p)
+        # the common case by far — a comparator that agrees with the canonical
+        # order, e.g. "newest first" on a registry that already lists versions
+        # that way — is detected in one linear pass and costs nothing more
+        issorted(vers; lt) && continue
+        perms[p] = sortperm(vers; lt, alg = MergeSort)
+    end
+    return isempty(perms) ? nothing : perms
+end
+
+"""
+    class_representatives(info, prob, perms) :: Dict{P, BitVector}
 
 Per package, a mask of the versions that survive collapsing its
 interchangeability classes: the T1 classes (`version_classes`) refined by
@@ -13,8 +53,9 @@ nothing for the packages the user did not constrain. Read as the virtual
 package of `Problem`'s docstring, this is just row equality again, over one
 more conflict column.
 
-**Representative.** The best member in the active rank order, which is version
-order, so the lowest-indexed one.
+**Representative.** The best member in the active rank order — the
+lowest-indexed one when the order is canonical, and otherwise the one `perms`
+(see [`version_permutations`](@ref Resolver.version_permutations)) ranks first.
 
 Collapsing is answer-preserving: identical constraint rows are in particular a
 subset of each other, so a class member is dominated by its representative and
@@ -24,8 +65,9 @@ members dropped are exactly the ones the layered answer never chooses, so
 nothing has to be mapped back afterwards.
 """
 function class_representatives(
-    info :: AbstractDict{P, PkgInfo{P,V}},
-    prob :: Problem{P} = Problem(P[]),
+    info  :: AbstractDict{P, PkgInfo{P,V}},
+    prob  :: Problem{P} = Problem(P[]),
+    perms :: Union{Nothing, AbstractDict{P, Vector{Int}}} = nothing,
 ) where {P,V}
     excl = exclusion_masks(info, prob)
     keep = Dict{P,BitVector}()
@@ -34,15 +76,19 @@ function class_representatives(
         m = length(info_p.versions)
         cls = info_p.classes
         e = get(excl, p, nothing)
+        perm = perms === nothing ? nothing : get(perms, p, nothing)
         k = falses(m)
         resize!(seen, 2m)
         fill!(seen, false)
-        for i = 1:m
+        for r = 1:m
+            # walk the versions best first, so the first member of a class
+            # found is the one the active order ranks best
+            i = perm === nothing ? r : perm[r]
             # refined class key: the T1 class, split by forbidden-ness
             c = 2 * cls[i] - (e !== nothing && e[i])
             seen[c] && continue
             seen[c] = true
-            k[i] = true # the first member found is the best one
+            k[i] = true
         end
         keep[p] = k
     end
@@ -50,53 +96,66 @@ function class_representatives(
 end
 
 """
-    prepare_pkg_info(info, prob, [info′]; group = true) :: Dict{P,PkgInfo{P,V}}
+    prepare_pkg_info(info, prob, [info′]; group = true, order = nothing)
 
 The per-resolve half of preprocessing, run on a T1 artifact (see
 [`pkg_info`](@ref Resolver.pkg_info)) to produce the universe the SAT instance
-is built over. Two steps, in this order:
+is built over. Three steps, in this order:
 
-1. **Collapse** each interchangeability class, refined by `prob`, to its best
-   member (`class_representatives`).
-2. **Filter** the collapsed universe for reachability and redundancy against
+1. **Lay out** each package's versions in the ordering the query wants
+   (`version_permutations`), which is a no-op for the canonical order.
+2. **Collapse** each interchangeability class, refined by `prob`, to its best
+   member in that ordering (`class_representatives`).
+3. **Filter** the collapsed universe for reachability and redundancy against
    the actual requirements and constraints (`filter_pkg_info!`).
 
-Filtering has to come second: both of its passes are stated in terms of the
-version ordering, and both get cheaper the fewer versions there are. The
-collapse is handed over as *marks* rather than as a rebuilt universe, so the
-two steps share one materialization (see `copy_marked!`).
+Filtering has to come last: both of its passes are stated in terms of the
+version ordering, and both get cheaper the fewer versions there are. The layout
+and the collapse share one materialization with it: the collapse is handed over
+as *marks* rather than as a rebuilt universe, so the filter's own first
+`drop_unmarked!` performs both (see `copy_marked!`).
 
 The result is a fresh dict — `info` is left untouched, so a T1 artifact stays
 reusable across resolves — unless the caller passes its own scratch dict as
-`info′`, or `info` itself when it owns it. `group = false` skips the collapse,
-which is the ungrouped path the tests compare against.
+`info′`, or `info` itself when it owns it (which reordering rules out, since it
+rebuilds the matrices). `group = false` skips the collapse, which is the
+ungrouped path the tests compare against.
 """
 function prepare_pkg_info(
     info  :: AbstractDict{P, PkgInfo{P,V}},
     prob  :: Problem{P},
     info′ :: Dict{P, PkgInfo{P,V}} = Dict{P, PkgInfo{P,V}}();
     group :: Bool = true,
+    order = nothing, # nothing = canonical, else package -> `lt` comparator
 ) where {P,V}
-    keep = group ? class_representatives(info, prob) : nothing
-    copy_marked!(info′, info, keep)
+    perms = version_permutations(info, order)
+    keep = group ? class_representatives(info, prob, perms) : nothing
+    # reordering reads every matrix while writing a differently laid out one,
+    # so the in-place shortcut is only available for the canonical order
+    perms === nothing || info′ !== info ||
+        (info′ = Dict{P, PkgInfo{P,V}}())
+    copy_marked!(info′, info, keep, perms)
     filter_pkg_info!(info′, prob)
     return info′
 end
 
-# Copy `info` into `info′`, marking active exactly the versions `keep` selects
-# (all of them when it is `nothing`); when the two are the same dict, only the
-# marks are written. This is how the collapse is handed to `filter_pkg_info!`:
-# as *marks* rather than as an already-shrunken universe, so that the filter's
-# own first `drop_unmarked!` materializes the collapse and its own deletions
-# together, in one rebuild instead of two. Every pass the filter runs before
-# that point reads the version flags as the version set, so they all see the
-# collapsed problem — which is the problem the interchangeability lemma
+# Copy `info` into `info′`, laid out in the order `perms` gives (the order it
+# already has when that is `nothing`) and marking active exactly the versions
+# `keep` selects (all of them when it is `nothing`); when the two are the same
+# dict, only the marks are written. This is how the collapse is handed to
+# `filter_pkg_info!`: as *marks* rather than as an already-shrunken universe, so
+# that the filter's own first `drop_unmarked!` materializes the collapse and its
+# own deletions together, in one rebuild instead of two. Every pass the filter
+# runs before that point reads the version flags as the version set, so they all
+# see the collapsed problem — which is the problem the interchangeability lemma
 # licenses substituting for the original.
 function copy_marked!(
     info′ :: Dict{P, PkgInfo{P,V}},
     info  :: AbstractDict{P, PkgInfo{P,V}},
     keep  :: Union{Nothing, AbstractDict{P, BitVector}} = nothing,
+    perms :: Union{Nothing, AbstractDict{P, Vector{Int}}} = nothing,
 ) where {P,V}
+    src = Int[] # scratch: output column => source column
     for (p, info_p) in info
         X = info_p.conflicts
         m = length(info_p.versions)
@@ -105,13 +164,81 @@ function copy_marked!(
             keep === nothing || (X[1:m, end] .= keep[p])
             continue
         end
-        X′ = copy(X)
-        X′[1:m, end] .= keep === nothing ? true : keep[p]
+        perm = perms === nothing ? nothing : get(perms, p, nothing)
+        # a reordered partner's interaction block is indexed by that partner's
+        # versions, so its columns move with them; every other column stays put
+        cols = nothing
+        if perms !== nothing
+            for (q, off) in info_p.interacts
+                perm_q = get(perms, q, nothing)
+                perm_q === nothing && continue
+                if cols === nothing
+                    cols = resize!(src, n)
+                    for j = 1:n
+                        cols[j] = j
+                    end
+                end
+                for (r, j) in enumerate(perm_q)
+                    cols[off + r] = off + j
+                end
+            end
+        end
+        X′ = perm === nothing && cols === nothing ? copy(X) :
+             relaid_conflicts(X, m, n, perm, cols)
+        if keep === nothing
+            X′[1:m, end] .= true
+        elseif perm === nothing
+            X′[1:m, end] .= keep[p]
+        else
+            k = keep[p]
+            for r = 1:m
+                X′[r, end] = k[perm[r]]
+            end
+        end
         X′[m+1, 1:n] .= true
-        info′[p] = PkgInfo(copy(info_p.versions), copy(info_p.depends),
-                           copy(info_p.interacts), X′, copy(info_p.classes))
+        info′[p] = PkgInfo(
+            perm === nothing ? copy(info_p.versions) : info_p.versions[perm],
+            copy(info_p.depends), copy(info_p.interacts), X′,
+            perm === nothing ? copy(info_p.classes) : info_p.classes[perm])
     end
     return info′
+end
+
+# A conflicts matrix laid out under a reordering: row `r` reads source row
+# `perm[r]` (this package's versions) and column `j` reads source column
+# `cols[j]` (a reordered partner's block); `nothing` for either means unchanged.
+# Only the version rows of the `n` conflict columns are written — the caller
+# sets the flag row and the version-flag column. Columns whose rows do not move
+# are blitted word by word, which is the whole matrix whenever only partners
+# were reordered.
+function relaid_conflicts(
+    X    :: BitMatrix,
+    m    :: Int,
+    n    :: Int,
+    perm :: Union{Nothing, Vector{Int}},
+    cols :: Union{Nothing, Vector{Int}},
+)
+    X′ = falses(size(X, 1), n + 1)
+    W = col_words(X)
+    ch = X.chunks
+    ch′ = X′.chunks
+    @inbounds for r = 1:n
+        j = cols === nothing ? r : cols[r]
+        base = (j - 1) * W
+        base′ = (r - 1) * W
+        if perm === nothing
+            for w = 1:W
+                ch′[base′ + w] = ch[base + w]
+            end
+        else
+            for i′ = 1:m
+                i = perm[i′]
+                b = (ch[base + ((i - 1) >> 6) + 1] >> ((i - 1) & 63)) & 1
+                ch′[base′ + ((i′ - 1) >> 6) + 1] |= b << ((i′ - 1) & 63)
+            end
+        end
+    end
+    return X′
 end
 
 filter_pkg_info!(

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -3,13 +3,140 @@ struct PkgInfo{P,V}
     depends   :: Vector{P}
     interacts :: Dict{P, Int}
     conflicts :: BitMatrix
+    # the interchangeability partition of `versions`, as a class id per
+    # version (see `version_classes`): versions share a class when nothing in
+    # the registry can tell them apart. Derived from `conflicts`, and at the
+    # T1 boundary (`pkg_info`) exactly so
+    classes   :: Vector{Int}
 end
 
+PkgInfo(
+    versions  :: Vector{V},
+    depends   :: Vector{P},
+    interacts :: Dict{P,Int},
+    conflicts :: BitMatrix,
+) where {P,V} = PkgInfo{P,V}(versions, depends, interacts, conflicts,
+    version_classes(conflicts, length(versions)))
+
+# `classes` is a function of `conflicts`, so it is not compared: in-place
+# shrinking (see `drop_unmarked!`) leaves a sound but possibly finer partition
+# than a recomputation would give, and that difference is not a difference of
+# content
 function Base.:(==)(a::PkgInfo, b::PkgInfo)
     a.versions  == b.versions  &&
     a.depends   == b.depends   &&
     a.interacts == b.interacts &&
     a.conflicts == b.conflicts
+end
+
+"""
+    version_classes(X, m) :: Vector{Int}
+
+The interchangeability partition of the `m` versions whose conflicts matrix is
+`X`, as a class id per version — ids numbered `1, 2, …` in the version order of
+each class's first member.
+
+Per the manual's Theory section (lemma on interchangeable versions), two
+versions of a package are *interchangeable* when they have the same dependency
+set and every compatibility entry in the problem — their own and every other
+package's — constrains them equally. In `PkgInfo` terms that is exactly row
+equality, and the test is purely local to `X`: the dependency columns carry the
+dependency set, and the interaction blocks carry every compatibility entry that
+mentions the package, incoming as much as outgoing, because `pkg_info` records
+each conflict symmetrically in both partners' matrices. (The incoming half is
+not optional — another package's bound can admit one of two versions and not
+the other, and then they are genuinely distinguishable.)
+
+The partition is a property of the registry alone: it is independent of the
+requirements, of the version ordering, and of any user constraints. That is
+what puts it on the T1 side of the boundary, and what lets the collapse to
+class representatives be a per-resolve step (see `class_representatives`).
+
+The scan is word-parallel over columns: one pass computes, for every adjacent
+pair of versions at once, whether their rows differ anywhere, which yields the
+classes that are contiguous runs of versions — nearly all of them in practice,
+since dependency sets and compat bounds vary in blocks. A second pass hashes
+one row per run and merges runs whose rows compare equal, so the result is the
+exact row-equality partition, hence invariant under reordering versions.
+"""
+function version_classes(X::BitMatrix, m::Int)
+    version_classes!(Vector{Int}(undef, m), X, m)
+end
+
+function version_classes!(ids::Vector{Int}, X::BitMatrix, m::Int)
+    resize!(ids, m)
+    m > 0 || return ids
+    n = size(X, 2) - 1
+    W = col_words(X)
+    chunks = X.chunks
+
+    # pass 1: word-parallel adjacency differences. bit i-1 of `d` records
+    # whether rows i and i+1 differ; within a word, row i's bit and row i+1's
+    # bit are adjacent, so one shift-and-xor per word compares 64 pairs at
+    # once (the topmost pair straddles into the next word)
+    d = zeros(UInt64, W)
+    @inbounds for k = 1:n
+        base = (k - 1) * W
+        for w = 1:W
+            c = chunks[base + w]
+            nxt = w < W ? chunks[base + w + 1] : UInt64(0)
+            d[w] |= (c ⊻ (c >> 1)) ⊻ ((nxt & 1) << 63)
+        end
+    end
+    runs = Int[1] # first version of each run of adjacent identical rows
+    nc = 1
+    ids[1] = 1
+    @inbounds for i = 2:m
+        if !iszero(d[((i - 2) >> 6) + 1] & (UInt64(1) << ((i - 2) & 63)))
+            nc += 1
+            push!(runs, i)
+        end
+        ids[i] = nc # = the index of i's run
+    end
+    nc > 1 || return ids
+
+    # pass 2: merge runs whose rows are equal but not adjacent. hashes only
+    # bucket the candidates; every merge is confirmed by comparing the rows
+    buckets = Dict{UInt,Vector{Int}}()
+    for (r, i) in enumerate(runs)
+        push!(get!(() -> Int[], buckets, row_hash(X, i, n, W)), r)
+    end
+    canon = collect(1:nc) # each run's earliest run with an equal row
+    merged = false
+    for rs in values(buckets)
+        length(rs) > 1 || continue
+        sort!(rs)
+        for a = 2:length(rs)
+            for b = 1:a-1
+                canon[rs[b]] == rs[b] || continue # not a class of its own
+                rows_equal(X, runs[rs[b]], runs[rs[a]], n, W) || continue
+                canon[rs[a]] = rs[b]
+                merged = true
+                break
+            end
+        end
+    end
+    merged || return ids
+
+    # renumber the surviving classes in order of first appearance
+    num = zeros(Int, nc)
+    nc′ = 0
+    for r = 1:nc
+        canon[r] == r && (num[r] = (nc′ += 1))
+    end
+    @inbounds for i = 1:m
+        ids[i] = num[canon[ids[i]]]
+    end
+    return ids
+end
+
+# renumber class ids to 1, 2, … in order of first appearance
+function renumber_classes!(ids::Vector{Int})
+    num = Dict{Int,Int}()
+    for (i, c) in enumerate(ids)
+        ids[i] = get!(() -> length(num) + 1, num, c)
+    end
+    return ids
 end
 
 function pkg_data(
@@ -55,33 +182,54 @@ end
 
 function pkg_info(
     deps :: DepsProvider{P},
-    prob :: Problem{P};
+    reqs :: SetOrVec{P} = deps.packages;
     filter :: Bool = true,
 ) where {P}
-    data = pkg_data(deps, prob.reqs)
-    info = pkg_info(data, prob; filter)
+    data = pkg_data(deps, reqs)
+    info = pkg_info(data, reqs; filter)
     return info
 end
 
-# bare requirements: an unconstrained problem (which costs nothing to build)
+# a `Problem`'s requirements are all of it that reaches T1 — that is the point
+# of the boundary — so these are pure conveniences for `pkg_info(_, prob.reqs)`.
+# Elsewhere the `Problem` form is the primary one and the requirements form the
+# convenience; here the dependence really does run the other way
+
 pkg_info(
     deps :: DepsProvider{P},
-    reqs :: SetOrVec{P} = deps.packages;
+    prob :: Problem{P};
     filter :: Bool = true,
-) where {P} = pkg_info(deps, Problem(reqs); filter)
+) where {P} = pkg_info(deps, prob.reqs; filter)
 
 pkg_info(
     data :: AbstractDict{P,<:PkgData{P}},
-    reqs :: SetOrVec{P} = keys(data);
-    filter :: Bool = true,
-) where {P} = pkg_info(data, Problem(reqs); filter)
-
-function pkg_info(
-    data :: AbstractDict{P,<:PkgData{P,V}},
     prob :: Problem{P};
     filter :: Bool = true,
+) where {P} = pkg_info(data, prob.reqs; filter)
+
+"""
+    pkg_info(data, reqs = all packages; filter = true) :: Dict{P,PkgInfo{P,V}}
+
+The **T1 artifact**: the dependency closure of `reqs`, encoded as one `PkgInfo`
+per package — conflict matrices, plus the
+preprocessing that depends on the registry *alone*, namely the arc-consistency
+prune (`mark_installable!`) and the interchangeability partition
+(`version_classes`). Nothing here depends on the version ordering, on user
+compat or pins, or (beyond the closure) on the requirements, so the result can
+be computed once and shared by, or cached across, arbitrarily many resolves.
+
+`filter = false` skips the arc-consistency prune, leaving the conflict matrices
+exactly as the data spells them out.
+
+Requirement-specific and constraint-specific shrinking — reachability and
+redundancy elimination — happens per resolve instead, after the classes have
+been refined and collapsed: see `prepare_pkg_info`.
+"""
+function pkg_info(
+    data :: AbstractDict{P,<:PkgData{P,V}},
+    reqs :: SetOrVec{P} = keys(data);
+    filter :: Bool = true,
 ) where {P,V}
-    reqs = prob.reqs
     # intern packages as integer indices once, up front: the build phases
     # below run entirely on vectors, and package names reappear only in
     # the final PkgInfo structures. ids follow name order (packages are
@@ -290,18 +438,36 @@ function pkg_info(
         end
     end
 
-    # materialize the package-keyed PkgInfo structures
+    # materialize the package-keyed PkgInfo structures. classes start out as
+    # singletons (always a sound partition) and are computed for real below,
+    # once the prune has settled which versions there are
     info = Dict{P,PkgInfo{P,V}}()
     for pi = 1:N
         D = pkgs[depids[pi]]
         T = Dict{P,Int}(
             pkgs[qi] => offs[pi][k]
             for (k, qi) in enumerate(interacts[pi]))
-        info[pkgs[pi]] = PkgInfo{P,V}(datas[pi].versions, D, T, mats[pi])
+        info[pkgs[pi]] = PkgInfo{P,V}(
+            datas[pi].versions, D, T, mats[pi], collect(1:nver[pi]))
     end
 
-    # only keep reachable, necessary packages & versions
-    filter && filter_pkg_info!(info, prob)
+    # the T1 preprocessing: arc consistency, then interchangeability. Both are
+    # properties of the registry alone — the arc-consistency test deletes
+    # versions one of whose dependencies has no versions at all, which is a
+    # sound approximation of deleting model-free versions and, per the manual's
+    # Theory section, exactly the kind of deletion that is safe for *every*
+    # ordering and requirement set; the classes are row equality. Reachability
+    # and redundancy elimination are not of that kind — both are stated in
+    # terms of the version ordering, and reachability in terms of the
+    # requirements too — so they now run per resolve, in `prepare_pkg_info`.
+    if filter
+        mark_installable!(info)
+        drop_unmarked!(info)
+    end
+    for info_p in values(info)
+        version_classes!(info_p.classes, info_p.conflicts,
+                         length(info_p.versions))
+    end
 
     return info
 end

--- a/src/PkgInfoFiles.jl
+++ b/src/PkgInfoFiles.jl
@@ -44,6 +44,9 @@ function load_pkg_info_file(
             interacts = read_vals(io, pv)
             conflicts = read_bits(io, padded_rows(length(versions)))
             interacts = Dict{P, Int}(q => 0 for q in interacts)
+            # the interchangeability classes are a function of the conflicts
+            # matrix, so the file need not carry them: the four-argument
+            # constructor recomputes them
             info[p] = PkgInfo(versions, depends, interacts, conflicts)
         end
         # compute interacts dict values

--- a/src/Problem.jl
+++ b/src/Problem.jl
@@ -11,17 +11,34 @@ Base.haskey(::EmptyDict, key) = false
 Base.get(::EmptyDict, key, default) = default
 Base.getindex(::EmptyDict, key) = throw(KeyError(key))
 
+# The kinds with no versions to forbid: the shared empty value for a problem's
+# `excludes`, for the same reason `EmptyDict` exists.
+const NoKinds = Pair{Symbol,Any}[]
+
 """
-    Problem(reqs; compat = ..., pins = ...)
+    Problem(reqs; compat = ..., pins = ..., excludes = ...)
 
-A resolution problem: the required packages `reqs`, plus the user constraints
-that say which versions are admissible — `compat` bounds (allowed-version sets,
-queried with `in`) and `pins` (hold a package at exactly one version). A
-`Problem` carries everything that determines *satisfiability*; orderings (the
-`by` priority order, the version rank order) are `resolve` parameters instead.
+A resolution problem: the required packages `reqs`, plus the constraints that say
+which versions are admissible. A `Problem` carries everything that determines
+*satisfiability*; orderings (the `by` priority order, the `order` version rank
+order) are `resolve` parameters instead.
 
-Constraints for packages that don't exist, and constraints that exclude
-nothing, are allowed and have no effect.
+Three kinds of constraint, in two shapes:
+
+  * `compat`: per package, the set of allowed versions (queried with `in`).
+  * `pins`: per package, the one version it is held at.
+  * `excludes`: the *admission* knobs — "no prereleases", "no yanked versions" —
+    which say something about versions rather than about particular packages, and
+    so come as `kind => predicate` pairs, where `predicate(p, v)` is true for the
+    versions that source forbids and `kind` is a symbol naming it.
+
+Constraints for packages that don't exist, and constraints that exclude nothing,
+are allowed and have no effect.
+
+Every constraint here is a constraint on a *shared* package universe rather than
+a deletion from a private one: that is what lets a single T1 artifact (see
+[`pkg_info`](@ref Resolver.pkg_info)) serve queries that admit different things,
+and what lets diagnostics eventually name the kind that ruled a version out.
 """
 struct Problem{P,V,S}
     reqs   :: Vector{P}
@@ -30,15 +47,19 @@ struct Problem{P,V,S}
     # empty dictionary instead of allocating two per problem
     compat :: AbstractDict{P,S}
     pins   :: AbstractDict{P,V}
+    # admission knobs: per kind, a predicate `(p, v) -> Bool` that is true for
+    # the versions that kind forbids
+    excludes :: Vector{Pair{Symbol,Any}}
 end
 
 function Problem(
     reqs   :: SetOrVec{P};
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+    excludes = NoKinds,
 ) where {P}
     Problem{P, valtype(pins), valtype(compat)}(
-        P[p for p in reqs], adopt(compat), adopt(pins))
+        P[p for p in reqs], adopt(compat), adopt(pins), adopt_kinds(excludes))
 end
 
 # a caller's dictionary is copied, so later mutation can't change the problem;
@@ -46,9 +67,13 @@ end
 adopt(d::AbstractDict) = Dict(d)
 adopt(d::EmptyDict) = d
 
-# does the problem constrain nothing at all? the fast paths below lean on this:
+adopt_kinds(kinds) = isempty(kinds) ? NoKinds :
+    Pair{Symbol,Any}[Symbol(kind) => forbids for (kind, forbids) in kinds]
+
+# does the problem constrain anything at all? the fast paths below lean on this:
 # an unconstrained resolve must not do any per-version work
-is_constrained(prob::Problem) = !isempty(prob.compat) || !isempty(prob.pins)
+is_constrained(prob::Problem) =
+    !isempty(prob.compat) || !isempty(prob.pins) || !isempty(prob.excludes)
 
 # The user constraints are read as a *virtual package*: one always-required
 # version, no dependencies, whose conflict rows are exactly the exclusions
@@ -59,26 +84,54 @@ is_constrained(prob::Problem) = !isempty(prob.compat) || !isempty(prob.pins)
 # `find_reachable`, one extra conflict column in `mark_necessary!`, and one
 # selector-guarded clause group per constraint source in `SAT`.
 
-# does the user forbid version v of package p?
+# does the problem forbid version v of package p?
 function is_excluded(prob::Problem{P}, p::P, v) where {P}
     s = get(prob.compat, p, nothing)
     s === nothing || v ∈ s || return true
     w = get(prob.pins, p, nothing)
     w === nothing || v == w || return true
+    for (_, forbids) in prob.excludes
+        forbids(p, v)::Bool && return true
+    end
     return false
 end
 
-# the packages the user constrained, in a deterministic order
-constrained_packages(prob::Problem{P}) where {P} =
-    sort!(collect(union(keys(prob.compat), keys(prob.pins))))
+# the packages a constraint could forbid a version of. Compat bounds and pins
+# name their packages, and only a handful of packages are named, which is what
+# makes constraining cheap; an admission knob is stated about versions instead, so
+# it reaches every package in the universe.
+exclusion_candidates(info::AbstractDict{P}, prob::Problem{P}) where {P} =
+    isempty(prob.excludes) ?
+        union(keys(prob.compat), keys(prob.pins)) : keys(info)
+
+# ... the same set in a deterministic order, for the places that number things
+constrained_packages(info::AbstractDict{P}, prob::Problem{P}) where {P} =
+    sort!(P[p for p in exclusion_candidates(info, prob)])
+
+# The constraints are read as a *virtual package*: one always-required version,
+# no dependencies, whose conflict rows are exactly the exclusions. This lists,
+# per source that says anything about `p`, the kind and a predicate on `p`'s
+# versions — one selector per source, so diagnostics can tell a compat bound, a
+# pin and an admission knob on the same package apart.
+function exclusion_sources(prob::Problem{P}, p::P) where {P}
+    srcs = Pair{Symbol,Any}[]
+    s = get(prob.compat, p, nothing)
+    s === nothing || push!(srcs, :compat => (v -> v ∉ s))
+    w = get(prob.pins, p, nothing)
+    w === nothing || push!(srcs, :pin => (v -> v != w))
+    for (kind, forbids) in prob.excludes
+        push!(srcs, kind => (v -> forbids(p, v)::Bool))
+    end
+    return srcs
+end
 
 """
     exclusion_masks(info, prob) :: AbstractDict{P, BitVector}
 
-The versions of each package that `prob`'s user constraints forbid, as a mask
-over that package's version list in `info`. Only packages with a constraint
-that actually excludes something get an entry, so packages the user did not
-constrain — the overwhelming majority — cost nothing downstream.
+The versions of each package that `prob`'s constraints forbid, as a mask over
+that package's version list in `info`. Only packages with a constraint that
+actually excludes something get an entry, so packages nothing constrains — the
+overwhelming majority, absent an admission knob — cost nothing downstream.
 
 Masks are index-based, so they must be recomputed whenever versions are
 dropped and renumbered (see `filter_pkg_info!`).
@@ -89,7 +142,7 @@ function exclusion_masks(
 ) where {P}
     is_constrained(prob) || return EmptyDict{P,BitVector}()
     excl = Dict{P,BitVector}()
-    for p in constrained_packages(prob)
+    for p in exclusion_candidates(info, prob)
         haskey(info, p) || continue # constraint on an absent package
         vers = info[p].versions
         e = falses(length(vers))

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -118,10 +118,20 @@ a `SAT` instance. The `SAT` method also accepts `restore::Bool = true`: when
 true the instance's clauses are restored before returning so the instance
 can be reused; `restore = false` is faster for single-use instances.
 
-The other methods accept `group::Bool = true`: whether to collapse each
-package's interchangeable versions to one representative before solving (see
-`prepare_pkg_info`). Grouping is an optimization and cannot change the answer;
-`group = false` is the escape hatch that says so.
+The other methods accept two more keywords:
+
+  * `order`: the *version* preference ordering, as a callable mapping a package
+    to a `lt` comparator over its versions ("is preferred to"). The default,
+    `nothing`, means the order the universe already lists them in — which for a
+    T1 artifact (see [`pkg_info`](@ref Resolver.pkg_info)) is the canonical one
+    the registry state fixes. The ordering is not a constraint: it selects among
+    the valid solutions rather than changing which ones are valid, so it is a
+    parameter here instead of part of the `Problem`, and one artifact serves
+    every ordering.
+  * `group::Bool = true`: whether to collapse each package's interchangeable
+    versions to one representative before solving (see `prepare_pkg_info`).
+    Grouping is an optimization and cannot change the answer; `group = false` is
+    the escape hatch that says so.
 """
 function resolve(
     sat  :: SAT{P,V},
@@ -134,7 +144,8 @@ function resolve(
     return Dict{P,V}(p => sat.info[p].versions[i] for (p, i) in sol)
 end
 
-# resolve a universe that `prepare_pkg_info` has already collapsed & filtered
+# resolve a universe that `prepare_pkg_info` has already laid out, collapsed
+# & filtered
 function resolve_prepared(
     info :: Dict{P,PkgInfo{P,V}},
     prob :: Problem{P};
@@ -158,9 +169,10 @@ function resolve(
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
     group :: Bool = true, # collapse interchangeable versions
+    order = nothing, # version ordering
 ) where {P}
     info = pkg_info(deps, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; group), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob; by)
 end
 
 function resolve(
@@ -168,9 +180,10 @@ function resolve(
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
     group :: Bool = true, # collapse interchangeable versions
+    order = nothing, # version ordering
 ) where {P}
     info = pkg_info(data, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; group), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob; by)
 end
 
 # a caller-supplied info may be a reusable (or cached) T1 artifact, so this
@@ -180,8 +193,9 @@ function resolve(
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
     group :: Bool = true, # collapse interchangeable versions
+    order = nothing, # version ordering
 ) where {P,V}
-    resolve_prepared(prepare_pkg_info(info, prob; group), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob; group, order), prob; by)
 end
 
 # convenience entry points: bare requirements, with the user constraints (if
@@ -194,7 +208,8 @@ resolve(
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
     group  :: Bool = true, # collapse interchangeable versions
-) where {P} = resolve(deps, Problem(reqs; compat, pins); by, group)
+    order  = nothing, # version ordering
+) where {P} = resolve(deps, Problem(reqs; compat, pins); by, group, order)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
@@ -203,7 +218,8 @@ resolve(
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
     group  :: Bool = true, # collapse interchangeable versions
-) where {P} = resolve(data, Problem(reqs; compat, pins); by, group)
+    order  = nothing, # version ordering
+) where {P} = resolve(data, Problem(reqs; compat, pins); by, group, order)
 
 resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},
@@ -212,4 +228,5 @@ resolve(
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
     group  :: Bool = true, # collapse interchangeable versions
-) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, group)
+    order  = nothing, # version ordering
+) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, group, order)

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -117,6 +117,11 @@ carries.
 a `SAT` instance. The `SAT` method also accepts `restore::Bool = true`: when
 true the instance's clauses are restored before returning so the instance
 can be reused; `restore = false` is faster for single-use instances.
+
+The other methods accept `group::Bool = true`: whether to collapse each
+package's interchangeable versions to one representative before solving (see
+`prepare_pkg_info`). Grouping is an optimization and cannot change the answer;
+`group = false` is the escape hatch that says so.
 """
 function resolve(
     sat  :: SAT{P,V},
@@ -129,27 +134,8 @@ function resolve(
     return Dict{P,V}(p => sat.info[p].versions[i] for (p, i) in sol)
 end
 
-# primary entry points: a Problem (requirements + user constraints)
-
-function resolve(
-    deps :: DepsProvider{P},
-    prob :: Problem{P};
-    by   :: Function = identity, # package ordering
-) where {P}
-    info = pkg_info(deps, prob)
-    resolve(info, prob; by)
-end
-
-function resolve(
-    data :: AbstractDict{P,<:PkgData{P}},
-    prob :: Problem{P};
-    by   :: Function = identity, # package ordering
-) where {P}
-    info = pkg_info(data, prob)
-    resolve(info, prob; by)
-end
-
-function resolve(
+# resolve a universe that `prepare_pkg_info` has already collapsed & filtered
+function resolve_prepared(
     info :: Dict{P,PkgInfo{P,V}},
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
@@ -162,6 +148,42 @@ function resolve(
     end
 end
 
+# primary entry points: a Problem (requirements + user constraints). each
+# builds the T1 artifact for the problem's requirements, then prepares it —
+# the T1 info is freshly built and nobody else holds it, so preparation is
+# allowed to shrink it in place
+
+function resolve(
+    deps :: DepsProvider{P},
+    prob :: Problem{P};
+    by   :: Function = identity, # package ordering
+    group :: Bool = true, # collapse interchangeable versions
+) where {P}
+    info = pkg_info(deps, prob)
+    resolve_prepared(prepare_pkg_info(info, prob, info; group), prob; by)
+end
+
+function resolve(
+    data :: AbstractDict{P,<:PkgData{P}},
+    prob :: Problem{P};
+    by   :: Function = identity, # package ordering
+    group :: Bool = true, # collapse interchangeable versions
+) where {P}
+    info = pkg_info(data, prob)
+    resolve_prepared(prepare_pkg_info(info, prob, info; group), prob; by)
+end
+
+# a caller-supplied info may be a reusable (or cached) T1 artifact, so this
+# method prepares into a dict of its own and leaves the argument alone
+function resolve(
+    info :: AbstractDict{P,PkgInfo{P,V}},
+    prob :: Problem{P};
+    by   :: Function = identity, # package ordering
+    group :: Bool = true, # collapse interchangeable versions
+) where {P,V}
+    resolve_prepared(prepare_pkg_info(info, prob; group), prob; by)
+end
+
 # convenience entry points: bare requirements, with the user constraints (if
 # any) given as keywords instead of a `Problem`
 
@@ -171,7 +193,8 @@ resolve(
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
-) where {P} = resolve(deps, Problem(reqs; compat, pins); by)
+    group  :: Bool = true, # collapse interchangeable versions
+) where {P} = resolve(deps, Problem(reqs; compat, pins); by, group)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
@@ -179,12 +202,14 @@ resolve(
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
-) where {P} = resolve(data, Problem(reqs; compat, pins); by)
+    group  :: Bool = true, # collapse interchangeable versions
+) where {P} = resolve(data, Problem(reqs; compat, pins); by, group)
 
 resolve(
-    info :: Dict{P,PkgInfo{P,V}},
+    info :: AbstractDict{P,PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info);
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
-) where {P,V} = resolve(info, Problem(reqs; compat, pins); by)
+    group  :: Bool = true, # collapse interchangeable versions
+) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, group)

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -277,14 +277,15 @@ function SAT(
     finalizer(finalize, SAT(info, pico, vars, Dict{Int,Tuple{Symbol,P}}()))
 end
 
-# the structural SAT instance for `info`, plus `prob`'s user constraints as
+# the structural SAT instance for `info`, plus `prob`'s constraints as
 # selector-guarded exclusion clauses: for each constraint source that forbids a
-# kept version — one per compat entry, one per pin — a fresh selector variable
-# `s` and one clause `(¬s, "no version in run")` per maximal run of forbidden
-# versions. the selectors are then asserted as unit clauses inside a sat_push
-# frame, so production solves see them at level 0 (no assumptions), while a
-# single sat_pop relaxes every user constraint at once. nothing pops the frame
-# in production; the frame exists so diagnostics can.
+# kept version — one per compat entry, one per pin, one per admission kind and
+# package — a fresh selector variable `s` and one clause `(¬s, "no version in
+# run")` per maximal run of forbidden versions. the selectors are then asserted
+# as unit clauses inside a sat_push frame, so production solves see them at
+# level 0 (no assumptions), while a single sat_pop relaxes every constraint at
+# once. nothing pops the frame in production; the frame exists so diagnostics
+# can.
 #
 # constraints on packages absent from `info`, constraints that forbid nothing,
 # and constraints that forbid only versions the filter already dropped emit no
@@ -312,7 +313,7 @@ function add_exclusions!(
     _, vars, lads = sat_variables(info)
     lits = Int[]
     mask = BitVector()
-    for p in constrained_packages(prob)
+    for p in constrained_packages(info, prob)
         haskey(info, p) || continue # constraint on an absent package
         vers = info[p].versions
         n_p = length(vers)
@@ -320,27 +321,16 @@ function add_exclusions!(
         v_p = vars[p]
         l_p = get(lads, p, 0)
         resize!(mask, n_p)
-        # one selector per constraint source, so diagnostics can tell a
-        # compat bound and a pin on the same package apart
-        for kind in (:compat, :pin)
+        # one selector per constraint source (see `exclusion_sources`), so
+        # diagnostics can tell a compat bound, a pin and an admission knob on
+        # the same package apart
+        for (kind, forbids) in exclusion_sources(prob, p)
             fill!(mask, false)
             found = false
-            if kind == :compat
-                haskey(prob.compat, p) || continue
-                s = prob.compat[p]
-                for (i, v) in enumerate(vers)
-                    v ∈ s && continue
-                    mask[i] = true
-                    found = true
-                end
-            else
-                haskey(prob.pins, p) || continue
-                w = prob.pins[p]
-                for (i, v) in enumerate(vers)
-                    v == w && continue
-                    mask[i] = true
-                    found = true
-                end
+            for (i, v) in enumerate(vers)
+                forbids(v) || continue
+                mask[i] = true
+                found = true
             end
             found || continue # nothing left to forbid
             sel = PicoSAT.inc_max_var(pico)

--- a/test/classes.jl
+++ b/test/classes.jl
@@ -1,0 +1,426 @@
+# T1 preprocessing: interchangeability classes and the collapse to class
+# representatives.
+#
+# Two oracles run throughout:
+#
+#   * for the *classes*, a reference partition computed straight off the raw
+#     `PkgData` from the lemma's definition (same dependency set; every
+#     compatibility entry in the problem, the package's own and every other
+#     package's, constrains the two versions equally) — a completely different
+#     computation from the bit-matrix row scan it checks;
+#
+#   * for the *collapse*, the ungrouped resolve. Grouping is an optimization,
+#     so `resolve(…; group = true)` and `resolve(…; group = false)` must return
+#     the very same answer — and the very same `nothing` — everywhere,
+#     including where user constraints split classes.
+
+using Resolver: PkgData, PkgInfo, DepsProvider, Problem, pkg_info, pkg_data,
+    version_classes, class_representatives, prepare_pkg_info, is_excluded
+using .TestResolver: each_potential_solution, is_valid_solution
+
+# the class partition of package p, as a set of sets of version *values*
+function class_sets(info::AbstractDict{P}, p::P) where {P}
+    info_p = info[p]
+    cls = info_p.classes
+    vers = info_p.versions
+    Set(Set(vers[i] for i in eachindex(cls) if cls[i] == c)
+        for c in unique(cls))
+end
+
+# the test data's dictionaries are minimal AbstractDicts without a three-arg
+# `get`, so look entries up the long way
+lookup(d, k, default) = haskey(d, k) ? d[k] : default
+
+# does version v of p forbid version w of q? (unknown packages and a package's
+# entries about itself are no constraints, exactly as `pkg_info` reads them)
+function ref_forbids(data, p, v, q, w)
+    p == q && return false
+    haskey(data, q) || return false
+    c = lookup(data[p].compat, v, nothing)
+    c === nothing && return false
+    s = lookup(c, q, nothing)
+    s === nothing && return false
+    return w ∉ s
+end
+
+# the lemma's interchangeability relation, read off the raw data: same
+# dependency set, and every compatibility entry in the problem constrains the
+# two versions equally — p's own entries *and* every other package's entries
+# that mention p, which is the half that keeps genuinely distinguishable
+# versions apart
+function ref_class_sets(data::AbstractDict{P}, p::P) where {P}
+    others = sort!(P[q for q in keys(data) if q != p])
+    depset(v) = Set(q for q in lookup(data[p].depends, v, ()) if q != p)
+    conflicts(v) = [(q, w, ref_forbids(data, p, v, q, w) ||
+                            ref_forbids(data, q, w, p, v))
+                    for q in others for w in data[q].versions]
+    key(v) = (depset(v), conflicts(v))
+    groups = Dict{Any,Set}()
+    for v in data[p].versions
+        push!(get!(() -> Set{Any}(), groups, key(v)), v)
+    end
+    return Set(values(groups))
+end
+
+# the classes must be exactly the reference partition, for every package
+function test_classes(data)
+    info = pkg_info(data, keys(data); filter = false)
+    for p in keys(data)
+        @test class_sets(info, p) == ref_class_sets(data, p)
+        # no class ever spans different dependency sets
+        for cls in class_sets(info, p)
+            @test length(Set(Set(lookup(data[p].depends, v, ())) for v in cls)) == 1
+        end
+    end
+    return info
+end
+
+# swapping one member of a class for another preserves the validity of any
+# solution — the soundness half of the lemma, checked over *every* potential
+# solution rather than only the valid ones (a strictly stronger statement).
+#
+# The converse is deliberately not asserted: it is not a theorem. Two versions
+# with different rows can still be indistinguishable in practice if every
+# assignment that would tell them apart is invalid for an unrelated reason
+# (say, their shared dependency conflicts with the partner whose bound differs).
+# The reference partition above is what pins the class test down from the other
+# side.
+function test_class_swaps(data)
+    info = pkg_info(data, keys(data); filter = false)
+    pkgs = sort!(collect(keys(data)))
+    V = eltype(info[first(pkgs)].versions)
+    bad = nothing # first counterexample, if the lemma ever fails
+    for (i, p) in enumerate(pkgs)
+        for cls in class_sets(info, p)
+            length(cls) > 1 || continue
+            members = sort!(collect(cls))
+            each_potential_solution(data, pkgs) do s
+                s[i] === nothing && return
+                t = Vector{Union{V,Nothing}}(s)
+                t[i] = first(members)
+                base = is_valid_solution(data, pkgs, t)
+                for v in members
+                    t[i] = v
+                    is_valid_solution(data, pkgs, t) == base && continue
+                    bad === nothing && (bad = (p, first(members), v, copy(t)))
+                end
+            end
+        end
+    end
+    @test bad === nothing
+end
+
+# grouping cannot change the answer, whatever the constraints or the ordering
+function test_collapse_invariance(data, prob; by::Function = identity)
+    @test resolve(data, prob; by, group = true) ==
+          resolve(data, prob; by, group = false)
+end
+
+# the constraints that split classes: forbid exactly one member of a
+# multi-member class, or pin one member of it
+function class_splitting_problems(data, reqs)
+    info = pkg_info(data, keys(data); filter = false)
+    probs = []
+    for p in sort!(collect(keys(data)))
+        vers = collect(data[p].versions)
+        for cls in class_sets(info, p)
+            length(cls) > 1 || continue
+            for v in sort!(collect(cls))
+                push!(probs, Problem(reqs;
+                    compat = Dict(p => [w for w in vers if w != v])))
+                push!(probs, Problem(reqs; pins = Dict(p => v)))
+            end
+        end
+    end
+    return probs
+end
+
+@testset "classes: the interchangeability test" begin
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+
+    # no constraints at all: every version of every package is interchangeable
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1], nodeps, nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = test_classes(data)
+    @test info[:A].classes == [1, 1, 1]
+    @test info[:B].classes == [1, 1]
+    @test resolve(data, [:A, :B]) == Dict(:A => :v3, :B => :v2)
+
+    # differing dependency sets split
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1], Dict(:v3 => [:B], :v2 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = test_classes(data)
+    @test info[:A].classes == [1, 1, 2]
+
+    # an *incoming* bound splits: nothing about B's own rows differs, but A@v1
+    # admits only B@v2, so B's two versions are genuinely distinguishable
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:B]), Dict(:v1 => Dict(:B => [:v2]))),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = test_classes(data)
+    @test info[:B].classes == [1, 2]
+
+    # classes need not be contiguous runs: A@v3 and A@v1 share a row, A@v2
+    # does not, and the merge pass has to find them
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1], nodeps, Dict(:v2 => Dict(:B => [:v2]))),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = test_classes(data)
+    @test info[:A].classes == [1, 2, 1]
+
+    # ... and the collapse keeps the best member of each of them
+    keep = class_representatives(info)
+    @test keep[:A] == BitVector([true, true, false])
+
+    # a pin inside a class refines it: the pinned version becomes a class of
+    # its own, so the collapse cannot drop it
+    prob = Problem([:A]; pins = Dict(:A => :v1))
+    @test class_representatives(info, prob)[:A] == BitVector([true, true, true])
+end
+
+@testset "classes: reference partition, complete data grids" begin
+    # every dependency & compatibility pattern of the smallest grids
+    for m = 1:2, n = 1:2
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for deps_bits = 0:2^d-1
+            deps = make_deps(deps_bits)
+            for comp_bits = 0:2^c-1
+                comp = make_comp(comp_bits)
+                fill_data!(m, n, deps, comp, data)
+                test_classes(data)
+                test_class_swaps(data)
+            end
+        end
+    end
+end
+
+@testset "classes: reference partition, random grids" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    for (m, n) in ((2, 3), (3, 2), (2, 4), (3, 3), (4, 2), (2, 5), (5, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:150
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            test_classes(data)
+            test_class_swaps(data)
+        end
+    end
+end
+
+@testset "collapse invariance: complete data grids" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    for m = 1:2, n = 1:2
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for deps_bits = 0:2^d-1
+            deps = make_deps(deps_bits)
+            for comp_bits = 0:2^c-1
+                comp = make_comp(comp_bits)
+                fill_data!(m, n, deps, comp, data)
+                for reqs_bits = 0:2^m-1
+                    reqs = collect(make_reqs(reqs_bits))
+                    for by in (hi, lo)
+                        test_collapse_invariance(data, Problem(reqs); by)
+                    end
+                    for _ = 1:4
+                        compat, pins = random_constraints(m, n)
+                        test_collapse_invariance(data, Problem(reqs; compat, pins))
+                    end
+                end
+            end
+        end
+    end
+end
+
+@testset "collapse invariance: random grids" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    for (m, n) in ((2, 4), (4, 2), (2, 5), (5, 2), (3, 3))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:120
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            for _ = 1:4
+                compat, pins = random_constraints(m, n)
+                test_collapse_invariance(data, Problem(reqs; compat, pins);
+                                         by = rand((hi, lo)))
+            end
+        end
+    end
+end
+
+@testset "collapse invariance: constraints that split classes" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    splits = 0
+    for (m, n) in ((2, 3), (3, 2), (3, 3), (2, 4), (4, 2), (2, 5), (5, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:60
+            # sparse patterns, so that classes have several members to split
+            deps = make_deps(randbits(d) & randbits(d))
+            comp = make_comp(randbits(c) & randbits(c) & randbits(c))
+            fill_data!(m, n, deps, comp, data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            probs = class_splitting_problems(data, reqs)
+            splits += length(probs)
+            for prob in probs, by in (hi, lo)
+                test_collapse_invariance(data, prob; by)
+                # ... and the grouped answer is also the answer the same
+                # universe with those versions deleted would give
+                test_bake_equivalence(data, prob; by)
+            end
+        end
+    end
+    @test splits > 1000 # the sweep really did split classes
+end
+
+@testset "collapse invariance: exhaustive constraint shapes" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    for (m, n) in ((2, 2), (2, 3), (3, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:3
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            for shapes in Iterators.product(ntuple(_ -> CONSTRAINT_SHAPES, m)...)
+                compat = Dict{Int,Vector{Int}}()
+                pins   = Dict{Int,Int}()
+                for (p, shape) in enumerate(shapes)
+                    constrain!(compat, pins, p, shape, n)
+                end
+                prob = Problem(reqs; compat, pins)
+                test_collapse_invariance(data, prob; by = hi)
+                test_collapse_invariance(data, prob; by = lo)
+            end
+        end
+    end
+end
+
+@testset "collapse invariance: adversarial" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # break the solution until it is unsolvable, with constraints in force the
+    # whole way, checking grouping against no grouping at every step
+    for m = 2:4, n = 2:3
+        (m*n)^2 ≤ 128 || continue
+        make_deps, make_comp, data, d, c, bit = tiny_data_makers(m, n)
+        for _ = 1:30
+            deps = make_deps(0)
+            comp = make_comp(0)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            compat, pins = random_constraints(m, n; mild = true)
+            prob = Problem(reqs; compat, pins)
+            while true
+                fill_data!(m, n, deps, comp, data)
+                test_collapse_invariance(data, prob)
+                sol = resolve(data, prob)
+                sol === nothing && break
+                p = rand(collect(keys(sol)))
+                v = sol[p]
+                q = rand(1:m-1)
+                q += q ≥ p
+                w = get(sol, q, nothing)
+                if isnothing(w)
+                    b = bit(p, v, q)
+                    @assert iszero(deps.bits & b)
+                    deps = typeof(deps)(deps.bits | b)
+                else
+                    b = bit(p, v, q, w)
+                    @assert iszero(comp.bits & b)
+                    comp = typeof(comp)(comp.bits | b)
+                end
+            end
+        end
+    end
+end
+
+# reorder each package's version vector; the dependency and compatibility
+# dictionaries are keyed by version *value*, so they carry over untouched
+permute_versions(data::AbstractDict, perms) = Dict(
+    p => PkgData(perms[p], data_p.depends, data_p.compat)
+    for (p, data_p) in data)
+
+@testset "classes: T1 is independent of the version ordering" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    for (m, n) in ((2, 3), (3, 3), (3, 2), (2, 4), (4, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:20
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            base = pkg_info(data, keys(data); filter = false)
+            for _ = 1:3
+                perms = Dict(p => randperm(n) for p = 1:m)
+                perm = permute_versions(data, perms)
+                info = pkg_info(perm, keys(perm); filter = false)
+                # the classes are sets of version values, unchanged
+                for p = 1:m
+                    @test class_sets(info, p) == class_sets(base, p)
+                end
+                # and the answer under the permuted ordering is the same
+                # whether or not it is reached by collapsing
+                test_collapse_invariance(perm, Problem(reqs))
+                compat, pins = random_constraints(m, n)
+                test_collapse_invariance(perm, Problem(reqs; compat, pins))
+            end
+        end
+    end
+end
+
+@testset "T1: all requirements vs. requirement-specific" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # `pkg_info(deps)` — every package required — is the persistable artifact.
+    # Resolving any requirement set against it must give what resolving against
+    # the closure of those requirements alone gives: the per-resolve filter is
+    # seeded by the actual requirements and does the restriction.
+    for (m, n) in ((3, 2), (3, 3), (4, 2), (2, 4))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:40
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            deps = DepsProvider(p -> data[p], collect(1:m))
+            all_reqs = pkg_info(deps)          # T1 over every package
+            for reqs_bits = 0:2^m-1
+                reqs = collect(make_reqs(reqs_bits))
+                specific = pkg_info(deps, reqs) # T1 over the closure of reqs
+                compat, pins = random_constraints(m, n)
+                for prob in (Problem(reqs), Problem(reqs; compat, pins))
+                    @test resolve(all_reqs, prob) == resolve(specific, prob)
+                    @test resolve(all_reqs, prob) == resolve(data, prob)
+                    # the T1 artifacts are reusable: resolving does not
+                    # consume them
+                    @test resolve(all_reqs, prob) == resolve(all_reqs, prob)
+                end
+            end
+        end
+    end
+end
+
+@testset "T1: the artifact is left alone by resolving" begin
+    # a caller-supplied info may be a cache: `resolve` must not shrink it
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1],
+                      Dict(:v3 => [:B], :v2 => [:B], :v1 => [:B]),
+                      Dict(:v3 => Dict(:B => [:v2]))),
+        :B => PkgData([:v2, :v1], Dict{Symbol,Vector{Symbol}}(), nocomp),
+        :C => PkgData([:v1], Dict(:v1 => [:A]), nocomp),
+    )
+    info = pkg_info(data)
+    before = deepcopy(info)
+    prob = Problem([:C]; compat = Dict(:B => [:v1]))
+    @test resolve(info, prob) == resolve(data, prob)
+    @test info == before
+    @test all(info[p].classes == before[p].classes for p in keys(info))
+    # ... and preparing it explicitly yields a universe of its own
+    work = prepare_pkg_info(info, prob)
+    @test info == before
+    @test work !== info
+end

--- a/test/ordering.jl
+++ b/test/ordering.jl
@@ -1,0 +1,202 @@
+# The version ordering as a resolve parameter.
+#
+# T1 (`pkg_info`) is built on whatever order the data comes in — the *canonical*
+# order — and the preference ordering a query wants is the `order` argument to
+# `resolve`. The oracle throughout is the OLD path, where the ordering was baked
+# into the provider: sorting each package's version vector by a comparator and
+# resolving canonically must give exactly what passing that comparator gives.
+#
+# That is a strictly stronger statement than the ordering-independence of T1
+# (tested in classes.jl by permuting the data): here the *same* artifact serves
+# every ordering, so the reordering has to happen inside `prepare_pkg_info`,
+# down to the partner blocks of every conflicts matrix.
+
+using Resolver: PkgData, PkgInfo, DepsProvider, Problem, pkg_info,
+    prepare_pkg_info, version_permutations, class_representatives
+
+# a comparator over the tiny data's integer versions, from a ranking: `ranks[v]`
+# is how good v is, lower being better
+ranked(ranks::AbstractVector{Int}) = (u::Int, v::Int) -> ranks[u] < ranks[v]
+
+# `order` values: a callable package -> comparator. `nothing` is the canonical
+# order, which is what the artifact carries.
+const CANONICAL = nothing
+reversed(m::Int, n::Int) = p -> (u::Int, v::Int) -> u > v
+# one random ranking per package, so the partner blocks of each matrix are
+# permuted differently from the rows
+function shuffled(m::Int, n::Int)
+    ranks = Dict(p => randperm(n) for p = 1:m)
+    p -> ranked(ranks[p])
+end
+# only *some* packages reordered: exercises the mixed fast/slow paths
+function partly(m::Int, n::Int)
+    ranks = Dict(p => (isodd(p) ? collect(1:n) : reverse(1:n)) for p = 1:m)
+    p -> ranked(collect(ranks[p]))
+end
+
+# the old baked path: the provider hands over versions already in the order the
+# query wants (the version-keyed deps & compat dicts carry over untouched)
+function bake_order(data::AbstractDict{P}, order) where {P}
+    order === nothing && return data
+    Dict(p => PkgData(sort!(collect(data_p.versions); lt = order(p)),
+                      data_p.depends, data_p.compat)
+         for (p, data_p) in data)
+end
+
+# passing a comparator == baking the same order into the data, for both the
+# grouped and the ungrouped path
+function test_order_equivalence(data, prob, order; by::Function = identity)
+    baked = bake_order(data, order)
+    for group in (true, false)
+        @test resolve(data, prob; by, order, group) ==
+              resolve(baked, prob; by, group)
+    end
+end
+
+@testset "ordering: permutations and identity" begin
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1], nodeps, nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = pkg_info(data)
+
+    # the canonical order needs no permutations at all, and neither does a
+    # comparator that agrees with it: the artifact is already laid out that way
+    @test version_permutations(info, nothing) === nothing
+    down = p -> (u, v) -> u > v # :v3 > :v2 > :v1, i.e. the canonical order here
+    @test version_permutations(info, down) === nothing
+
+    # a comparator that disagrees gets an entry per package it reorders
+    up = p -> (u, v) -> u < v
+    perms = version_permutations(info, up)
+    @test perms == Dict(:A => [3, 2, 1], :B => [2, 1])
+
+    # ... and only for the packages it reorders
+    mixed = p -> p == :A ? (u, v) -> u < v : (u, v) -> u > v
+    @test version_permutations(info, mixed) == Dict(:A => [3, 2, 1])
+
+    # the representative of a class is its best member in the *active* order
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1], nodeps, Dict(:v2 => Dict(:B => [:v2]))),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+    @test info[:A].classes == [1, 2, 1] # :v3 and :v1 are interchangeable
+    prob = Problem([:A])
+    @test class_representatives(info, prob)[:A] == BitVector([1, 1, 0])
+    up_perms = version_permutations(info, up)
+    @test class_representatives(info, prob, up_perms)[:A] ==
+          BitVector([0, 1, 1]) # reversed: :v1 now represents the class
+
+    # and the answer follows the order: ascending picks the worst versions
+    @test resolve(data, [:A, :B]) == Dict(:A => :v3, :B => :v2)
+    @test resolve(data, [:A, :B]; order = up) == Dict(:A => :v1, :B => :v1)
+end
+
+@testset "ordering: comparator vs. baked, complete data grids" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    for m = 1:2, n = 1:2
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for deps_bits = 0:2^d-1
+            deps = make_deps(deps_bits)
+            for comp_bits = 0:2^c-1
+                comp = make_comp(comp_bits)
+                fill_data!(m, n, deps, comp, data)
+                for reqs_bits = 0:2^m-1
+                    reqs = collect(make_reqs(reqs_bits))
+                    for mk in (reversed, shuffled, partly), by in (hi, lo)
+                        order = mk(m, n)
+                        test_order_equivalence(data, Problem(reqs), order; by)
+                        compat, pins = random_constraints(m, n)
+                        test_order_equivalence(
+                            data, Problem(reqs; compat, pins), order; by)
+                    end
+                end
+            end
+        end
+    end
+end
+
+@testset "ordering: comparator vs. baked, random grids" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    for (m, n) in ((2, 3), (3, 2), (3, 3), (2, 4), (4, 2), (2, 5), (5, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:60
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            for mk in (reversed, shuffled, partly)
+                order = mk(m, n)
+                by = rand((hi, lo))
+                test_order_equivalence(data, Problem(reqs), order; by)
+                compat, pins = random_constraints(m, n)
+                test_order_equivalence(
+                    data, Problem(reqs; compat, pins), order; by)
+                # ... and the ordering must not disturb the bake-equivalence of
+                # the user constraints either
+                prob = Problem(reqs; compat, pins)
+                @test resolve(data, prob; by, order) ==
+                      resolve(bake(bake_order(data, order), prob), reqs; by)
+            end
+        end
+    end
+end
+
+@testset "ordering: comparator vs. baked, exhaustive constraint shapes" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    for (m, n) in ((2, 2), (2, 3), (3, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:2
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            order = shuffled(m, n)
+            for shapes in Iterators.product(ntuple(_ -> CONSTRAINT_SHAPES, m)...)
+                compat = Dict{Int,Vector{Int}}()
+                pins   = Dict{Int,Int}()
+                for (p, shape) in enumerate(shapes)
+                    constrain!(compat, pins, p, shape, n)
+                end
+                prob = Problem(reqs; compat, pins)
+                test_order_equivalence(data, prob, order; by = hi)
+                test_order_equivalence(data, prob, order; by = lo)
+            end
+        end
+    end
+end
+
+@testset "ordering: one T1 artifact serves every ordering" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # The universality claim, at the level the cache will be used: build the
+    # all-requirements artifact once, then resolve it under several orderings
+    # and several constraint sets, cross-checking each against a from-scratch
+    # resolve of the data baked that way — and confirm the artifact survives.
+    for (m, n) in ((3, 2), (3, 3), (4, 2), (2, 4))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:20
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            deps = DepsProvider(p -> data[p], collect(1:m))
+            all_reqs = pkg_info(deps) # T1 over every package
+            before = deepcopy(all_reqs)
+            for reqs_bits = 1:2^m-1
+                reqs = collect(make_reqs(reqs_bits))
+                compat, pins = random_constraints(m, n)
+                for prob in (Problem(reqs), Problem(reqs; compat, pins)),
+                    order in (CANONICAL, reversed(m, n), shuffled(m, n))
+                    baked = bake_order(data, order)
+                    @test resolve(all_reqs, prob; order) == resolve(baked, prob)
+                    # ... and the same artifact answers the next query too
+                    @test resolve(all_reqs, prob; order) ==
+                          resolve(all_reqs, prob; order)
+                end
+            end
+            @test all_reqs == before
+        end
+    end
+end

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -302,6 +302,93 @@ end
     end
 end
 
+@testset "Problem: exclusion kinds" begin
+    # `excludes` carries the *admission* knobs — "no prereleases", "no yanked
+    # versions" — which are stated about versions rather than about packages, so
+    # they come as `kind => predicate` pairs instead of per-package entries.
+    # Semantically a kind is nothing but another constraint source: forbidding
+    # exactly the versions a compat entry forbids must be the same problem.
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+
+    odd = :test => (p, v) -> v == :v2 # forbid :v2 of every package
+    prob = Problem([:A]; excludes = [odd])
+    @test  is_excluded(prob, :A, :v2)
+    @test !is_excluded(prob, :A, :v1)
+    @test  is_excluded(prob, :Z, :v2) # a kind applies to packages too
+
+    # the kind reaches every package in the universe, unlike compat and pins
+    excl = exclusion_masks(info, prob)
+    @test sort!(collect(keys(excl))) == [:A, :B]
+    @test excl[:A] == excl[:B] == BitVector([true, false])
+
+    # ... and it is the same problem as the equivalent compat bounds
+    both = Problem([:A]; compat = Dict(:A => [:v1], :B => [:v1]))
+    @test exclusion_masks(info, both) == excl
+    @test resolve(data, prob) == resolve(data, both)
+    test_bake_equivalence(data, prob)
+
+    # one selector per source, so a kind, a compat bound and a pin on the same
+    # package stay distinguishable
+    prob = Problem([:A]; compat = Dict(:A => [:v1, :v2]),
+                         pins = Dict(:B => :v1), excludes = [odd])
+    sat = SAT(info, prob)
+    try
+        @test Set(values(sat.sels)) ==
+              Set([(:test, :A), (:test, :B), (:pin, :B)])
+    finally
+        finalize(sat)
+    end
+
+    # no kinds means no cost: the shared empty vector, and an unconstrained
+    # problem that still allocates nothing but its requirements
+    a, b = Problem([:A]), Problem([:B])
+    @test a.excludes === b.excludes
+    @test isempty(a.excludes)
+    @test isempty(Problem([:A]; excludes = Pair{Symbol,Any}[]).excludes)
+    @test exclusion_masks(info, a) === exclusion_masks(info, b)
+end
+
+@testset "Problem: exclusion kinds are ordinary constraints" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # A kind that forbids a random version subset per package must behave
+    # exactly like the compat entries that forbid the same versions, and (by
+    # bake-equivalence) exactly like deleting them from the data. Swept over the
+    # tiny grids, with compat and pins in force on top.
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:40
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            allowed = Dict(p => [v for v = 1:n if rand(Bool)] for p = 1:m+1)
+            kinds = [:test => (p, v) -> !(v in get(allowed, p, 1:n))]
+            for cs in (nothing, random_constraints(m, n))
+                compat, pins = cs === nothing ?
+                    (Dict{Int,Vector{Int}}(), Dict{Int,Int}()) : cs
+                as_kind = Problem(reqs; compat, pins, excludes = kinds)
+                as_compat = Problem(reqs;
+                    compat = mergewith!(∩, Dict(compat), Dict(allowed)), pins)
+                for by in (identity, p -> -p)
+                    @test resolve(data, as_kind; by) ==
+                          resolve(data, as_compat; by)
+                    test_bake_equivalence(data, as_kind; by)
+                end
+                # ... and the collapse and the ordering stay orthogonal to it
+                @test resolve(data, as_kind; group = false) ==
+                      resolve(data, as_kind; group = true)
+                order = p -> (u, v) -> u > v
+                @test resolve(data, as_kind; order) ==
+                      resolve(bake(data, as_kind), reqs; order)
+            end
+        end
+    end
+end
+
 @testset "Problem: brute-force cross-checks" begin
     # hand-built cases: the brute-force reference resolves the baked data
     nodeps = Dict{Symbol,Vector{Symbol}}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -256,9 +256,29 @@ end
     @test isempty(info[:A].depends)
     test_resolver(data, [:A])
     test_resolver(data, [:C])
+
+    # resolving an *unpruned* info reaches the same answers: dropping the
+    # version-less package leaves `depends` naming a package that is gone, and
+    # arc consistency has to read that as uninstallable too
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
+        :B => PkgData(Symbol[], nodeps, nocomp),
+    )
+    info = pkg_info(data, [:A]; filter = false)
+    @test resolve(info, [:A]) === nothing
+    @test resolve(info, [:A]; group = false) === nothing
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B]), nocomp),
+        :B => PkgData(Symbol[], nodeps, nocomp),
+        :C => PkgData([:v1], Dict(:v1 => [:A]), nocomp),
+    )
+    info = pkg_info(data, [:C]; filter = false)
+    @test resolve(info, [:C]) == Dict(:C => :v1, :A => :v1)
+    @test resolve(info, [:C]; group = false) == Dict(:C => :v1, :A => :v1)
 end
 
 include("problem.jl")
+include("classes.jl")
 
 @testset "registry resolve" begin
     rp = registry.provider()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -279,6 +279,7 @@ end
 
 include("problem.jl")
 include("classes.jl")
+include("ordering.jl")
 
 @testset "registry resolve" begin
     rp = registry.provider()

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -7,7 +7,8 @@ using Test
 
 module TestResolver
 
-using Resolver: resolve, DepsProvider, PkgData, PkgInfo, pkg_data, pkg_info
+using Resolver: resolve, DepsProvider, PkgData, PkgInfo, pkg_data, pkg_info,
+    filter_pkg_info!
 using Test
 
 export test_resolver, ref_resolve
@@ -91,7 +92,10 @@ function test_resolver(
         # @info "optimality testing full data"
         info = data # type unstable but 🤷
     else
-        info = pkg_info(data, reqs)
+        # bound the enumeration by the *uncollapsed* filtered universe: the
+        # collapsed one is smaller, and enumerating fewer candidate solutions
+        # would only weaken the domination check below
+        info = filter_pkg_info!(pkg_info(data, reqs), reqs)
         Π = prod(float(length(ip.versions)+1) for ip in values(info))
         if Π > Π⁺
             # @info "no optimality testing"


### PR DESCRIPTION
## What

`pkg_info`'s output becomes the **T1 artifact: a universal per-registry cache** — computed once per registry state, independent of *every* query parameter, serving any resolve against that registry. Six commits, one claim:

```
perf: make pkg_info the T1 boundary, with interchangeability classes
refactor: the version ordering is a resolve parameter, not the provider's
feat: prerelease admission is a constraint, not a deleted version
feat: yanked versions are constrained, not deleted from the universe
fix: match a bundled stdlib entry to the Julias that bundle that entry
feat: the julia bound is a compat entry, not a version universe
```

After this PR the provider has **zero query-dependent parameters** — `registry_provider(packages; workspace_pkgs)` (workspace members are universe, not query). Everything the old provider baked in is now per-resolve:

- **T1 boundary + interchangeability classes**: `pkg_info` = dependency closure + arc-consistency + classes (the theory docs' interchangeable-versions lemma, incoming half included — a purely local row-equality test). Classes are cached structure; per-resolve they're refined by the `Problem` (only user constraints can split them) and collapsed to the ordering-best representative.
- **Ordering**: provider emits canonical order; `resolve(…; order)` takes a per-package comparator. Permutations are computed only for packages whose order actually differs (zero for the default), and `copy_marked!` lays the working matrices out in the active order — reach, ladder, descent all see rank order exactly as before.
- **Prereleases and yanked**: `Problem` grew `excludes` — admission knobs as `kind => predicate` riding the same exclusion machinery as compat/pins, with `(:prerelease, p)` / `(:yanked, p)` entries in the selector map (so future diagnostics can *name* them: "only a yanked version satisfies this"). `--allow-pre` semantics preserved exactly; yanked is behaviorally a no-op (redundancy already dominates most yanked versions) but T1 stops depending on it.
- **Julia universe**: all 105 julia versions and every stdlib version any of them bundles are in the artifact; the `--julia`/project bound is an ordinary compat entry on `julia`. #51's steering and bundled-only semantics carry over (a forbidden julia can't be chosen, so neither can versions only it bundles).

## The correctness model

If T1 is generated for a requirement set, any problem over a *subset* of those reqs resolves correctly from it (requirement-monotonicity); built for all packages, it serves the whole registry — with any ordering, any compat/pins, any admission settings, any julia bound. Tested directly: one artifact answering five julia bounds, multiple orderings, and multiple admission settings, each equal to a from-scratch resolve.

## Verification

- Full suite green: ~1.05M assertions, including ~50k new ordering-equality assertions (comparator vs. pre-baked data across grids, constraint shapes, both group settings), 2,880 exclusion-kind equivalence cases, and 7,760 one-artifact-serves-every-ordering assertions.
- 144-way option grid (julia bounds × orderings × admission flags × projects) against the pre-PR baked pipeline: **byte-identical except exactly 7 diffs, all from the `c69e33a` fix below**.

## The one behavior change (`c69e33a`)

HistoricalStdlibVersions assigns one version number to stdlib entries with *different deps* across julias; the provider disambiguates with synthetic build numbers, but the julia↔stdlib pin matched by major.minor.patch only — so every same-numbered entry was admitted on every julia that bundled any of them (julia 1.12 could take julia 1.11's Markdown). Reachable before this PR; the wider universe made it visible. Fixed by matching pins to the exact bundled entry. The 7 grid diffs are its corrections — e.g. the `--min` downgrade-style project now gets julia 1.6's Pkg *with* its ArgTools/Downloads/Tar/LibCURL deps instead of julia 1.5's same-numbered Pkg and a manifest missing all four.

## Cost (DataFrames/Plots/DiffEq closure)

The universal artifact vs. the narrowest old bound (`--julia=1.10`): +8.5% versions, +32% matrix bits (13.3 → 17.0 MiB), T1 build 0.31 → 0.38s. Vs. the old default bound: +3.8% / +16%. Per-resolve: prepare 0.12s canonical / 0.21s under a non-canonical ordering; admission-mask construction ~12ms per filter round with both kinds active, ~0 with none. Registry-wide, prereleases (21 versions) and yanked (352) are noise; the julia universe is the whole cost — and it's what buys "one artifact, every query."

## Notes

- `bundled_versions(spec)` (introspection) now includes prerelease julias' bundles; no resolve path reads it.
- Pre-existing crash found, untouched: `pkg_info` over *every* registered package hits a `KeyError` on a registry entry (`LibMPDec_jll`) whose compat names a dep absent from its deps map — needs its own fix before whole-registry T1 persistence; tracked separately.
- Docs: theory `layered.md`'s cache-tier paragraph rewritten to state the universality claim; `version_permutations` in api.md.

## Co-author

Implemented with [Claude Code](https://claude.com/claude-code): design discussed with, implementation by, and review by Claude, directed and reviewed by @StefanKarpinski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7