### PR TITLE
Match Pkg: don't pin the upgradable stdlibs to their bundled versions

### DIFF
--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -115,13 +115,13 @@ end
 #
 #   stdlibs[uuid][version] : the historical stdlib info for a bundled version
 #   stdlib_pins[uuid]      : the (Julia version, bundled-version spec) pairs.
-#     Recorded so `registry_provider` can widen a stdlib's own `julia` compat
-#     to include the Julia versions that bundle each of its versions. Recorded
-#     for the upgradable stdlibs too, which are bundled without being pinned:
-#     the widening keeps a bundled version installable on its Julia either way.
+#     Recorded so `registry_provider` can reconcile a stdlib version's `julia`
+#     compat with the Julia versions that bundle it. Recorded for the
+#     upgradable stdlibs too, which are bundled without being pinned: a bundled
+#     version must be installable on its Julia either way.
 #
-# Split out of `registry_provider` because `bin/resolve.jl` needs the bundled
-# version sets too (see `bundled_versions`).
+# Split out of `registry_provider` so that `bundled_versions` can report the
+# bundled version sets without building a provider.
 function julia_and_stdlib_versions(
     julia_versions :: VersionSpec,
     allow_pre      :: Dict{UUID,Bool} = Dict(UUID(0) => false),
@@ -171,11 +171,11 @@ function julia_and_stdlib_versions(
 end
 
 # Per package, the versions the provider offers because a Julia in
-# `julia_versions` bundles them -- regardless of what the registries say, and
-# regardless of any user compat. `bin/resolve.jl` widens the project's compat
-# bounds with these so that moving compat out of the provider (where it was
-# applied to the registry versions *before* the bundled ones were patched in)
-# doesn't change any answers.
+# `julia_versions` bundles them, regardless of what the registries say. Nothing
+# in the resolve path needs this -- a bundled version is an ordinary candidate,
+# and a user bound that excludes it excludes the Julias that ship it -- but it
+# is the answer to "which versions of this stdlib can I even get on these
+# Julias", so it stays available for introspection and for the tests.
 function bundled_versions(
     julia_versions :: VersionSpec,
     allow_pre      :: Dict{UUID,Bool} = Dict(UUID(0) => false),
@@ -226,6 +226,9 @@ function registry_provider(
         vers = Set{VersionNumber}()
         deps = Dict{VersionNumber,Vector{UUID}}()
         comp = Dict{VersionNumber,Dict{UUID,VersionSpec}}()
+        # versions that exist only because a Julia bundles them (no registry
+        # entry); the widening below bounds them to their bundling Julias
+        bundled_only = Set{VersionNumber}()
         if uuid == JULIA_UUID
             union!(vers, julia_vers)
             for v in vers
@@ -315,6 +318,7 @@ function registry_provider(
             for (v, info) in stdlibs[uuid]
                 v in vers && continue # prefer real registry data
                 push!(vers, v)
+                push!(bundled_only, v)
                 deps[v] = info.deps
             end
         end
@@ -332,24 +336,39 @@ function registry_provider(
         # anything pulling in the BLAS stack (LinearAlgebra -> OpenBLAS_jll ->
         # CompilerSupportLibraries_jll) is unsatisfiable there.
         #
-        # We *widen* rather than drop the bound: each version keeps its registry
-        # `julia` compat and additionally admits every Julia that bundles it.
-        # This is important because the same version can be a bundled stdlib for
-        # one Julia yet a resolvable dependency for another; for the latter the
-        # registry bound must still govern, so dropping it outright would wrongly
-        # make the version installable on Julias it isn't compatible with.
+        # For a version that *is* in the registry we widen rather than replace:
+        # it keeps its registry `julia` compat and additionally admits every
+        # Julia that bundles it. This is important because the same version can
+        # be a bundled stdlib for one Julia yet a resolvable dependency for
+        # another; for the latter the registry bound must still govern, so
+        # dropping it outright would wrongly make the version installable on
+        # Julias it isn't compatible with.
         #
-        # The upgradable stdlibs get the same widening even though no pin makes
+        # A version that exists *only* as a bundled stdlib has no registry bound
+        # to keep, and it is not installable anywhere except where it ships:
+        # its `julia` compat is exactly the Julias that bundle it. Leaving it
+        # unbounded would let it pair with any Julia -- which the pins used to
+        # rule out for pinned stdlibs, but nothing rules out for the upgradable
+        # ones (so a Julia 1.12 resolve could take the Statistics that only
+        # Julia 1.10 ships).
+        #
+        # The upgradable stdlibs get the same treatment even though no pin makes
         # them conflict: a bundled version must be installable on the Julia that
         # bundles it whether or not that Julia insists on it.
         if uuid in keys(stdlib_pins)
+            # per version, the Julias that bundle it
+            bundling = Dict{VersionNumber,VersionSpec}()
             for (julia_ver, ver_spec) in stdlib_pins[uuid]
                 for v in vers
                     v in ver_spec || continue # julia_ver bundles this version
-                    comp_v = get!(()->valtype(comp)(), comp, v)
-                    comp_v[JULIA_UUID] =
-                        get(comp_v, JULIA_UUID, VersionSpec("*")) ∪ VersionSpec(julia_ver)
+                    bundling[v] = haskey(bundling, v) ?
+                        bundling[v] ∪ VersionSpec(julia_ver) : VersionSpec(julia_ver)
                 end
+            end
+            for (v, julias) in bundling
+                comp_v = get!(()->valtype(comp)(), comp, v)
+                comp_v[JULIA_UUID] = v in bundled_only ? julias :
+                    get(comp_v, JULIA_UUID, VersionSpec("*")) ∪ julias
             end
         end
         # insert dependency on julia itself

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,13 +1,32 @@
 module Registries
 
-export registry_provider, package_info, bundled_versions
+export registry_provider, package_info, bundled_versions,
+    UPGRADABLE_STDLIBS_UUIDS
 
 import Base: UUID
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS, StdlibInfo
 import JSON
+import Pkg
 import Pkg.Registry: JULIA_UUID, PkgEntry, RegistryInstance, init_package_info!, isyanked, reachable_registries
 import Pkg.Versions: VersionSpec
 import Resolver: DepsProvider, PkgData
+
+## the upgradable stdlibs
+#
+# Julia bundles a version of every stdlib, but two of them it does not *pin*:
+# `Pkg.Types.UPGRADABLE_STDLIBS`. For those, registry versions compete with the
+# bundled one like any other package's, which is what Pkg does and what we
+# model (see the JULIA_UUID branch of the provider). Pkg only grew the constant
+# in 1.12, so fall back to its values on the older Pkgs `bin/` supports.
+const UPGRADABLE_STDLIBS_UUIDS =
+    if isdefined(Pkg.Types, :UPGRADABLE_STDLIBS_UUIDS)
+        Set{UUID}(Pkg.Types.UPGRADABLE_STDLIBS_UUIDS)
+    else
+        Set{UUID}([
+            UUID("8bb1440f-4735-579b-a4ab-409b98df4dab"), # DelimitedFiles
+            UUID("10745b16-79ce-11e8-11f9-7d13ad32a3b2"), # Statistics
+        ])
+    end
 
 ## metaprogram around Pkg's `init_package_info!` signature change
 #
@@ -95,9 +114,11 @@ end
 # The Julia versions to resolve against, and what they bundle:
 #
 #   stdlibs[uuid][version] : the historical stdlib info for a bundled version
-#   stdlib_pins[uuid]      : the (Julia version, pinned-version spec) pairs.
+#   stdlib_pins[uuid]      : the (Julia version, bundled-version spec) pairs.
 #     Recorded so `registry_provider` can widen a stdlib's own `julia` compat
-#     to include the Julia versions that bundle each of its versions.
+#     to include the Julia versions that bundle each of its versions. Recorded
+#     for the upgradable stdlibs too, which are bundled without being pinned:
+#     the widening keeps a bundled version installable on its Julia either way.
 #
 # Split out of `registry_provider` because `bin/resolve.jl` needs the bundled
 # version sets too (see `bundled_versions`).
@@ -119,7 +140,6 @@ function julia_and_stdlib_versions(
         end
         for (uuid, stdlib_info) in last_stdlibs
             stdlib_ver = something(stdlib_info.version, julia_ver)
-            # matches the pin the JULIA_UUID branch emits below
             push!(get!(()->valtype(stdlib_pins)(), stdlib_pins, uuid),
                   (julia_ver, VersionSpec(stdlib_ver)))
             deps_u = get!(()->valtype(stdlibs)(), stdlibs, uuid)
@@ -216,9 +236,17 @@ function registry_provider(
                     v′ > Base.thispatch(v) && break
                     last_stdlibs = this_stdlibs
                 end
-                # add compat for all stdlibs of this version
+                # pin every stdlib this Julia bundles to its bundled version
+                # -- except the upgradable ones, which Julia bundles without
+                # pinning: for those the registry versions compete with the
+                # bundled one on their own `julia` compat, exactly as Pkg
+                # resolves them. "Pinned" here means pinned per candidate
+                # Julia: we resolve over Julia versions too, so each Julia
+                # version carries its own pins, and an upgradable stdlib
+                # simply carries none.
                 comp_v = get!(()->valtype(comp)(), comp, v)
                 for (stdlib_uuid, stdlib_info) in last_stdlibs
+                    stdlib_uuid in UPGRADABLE_STDLIBS_UUIDS && continue
                     stdlib_ver = something(stdlib_info.version, v)
                     comp_v[stdlib_uuid] = VersionSpec(stdlib_ver)
                 end
@@ -310,6 +338,10 @@ function registry_provider(
         # one Julia yet a resolvable dependency for another; for the latter the
         # registry bound must still govern, so dropping it outright would wrongly
         # make the version installable on Julias it isn't compatible with.
+        #
+        # The upgradable stdlibs get the same widening even though no pin makes
+        # them conflict: a bundled version must be installable on the Julia that
+        # bundles it whether or not that Julia insists on it.
         if uuid in keys(stdlib_pins)
             for (julia_ver, ver_spec) in stdlib_pins[uuid]
                 for v in vers

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -461,27 +461,14 @@ reg = registry_provider(
 # bound is not among them: it was consumed above, as the Julia version
 # universe.)
 #
-# bounds on the stdlibs Julia *pins* are widened to admit the bundled versions,
-# so that answers stay exactly what they were when the provider applied compat
-# itself: it applied compat to a package's registry versions and *then* patched
-# the bundled ones back in, so those were never subject to it. a pinned stdlib's
-# version is dictated by the chosen Julia, so a bound excluding it would only
-# make that Julia infeasible -- Pkg treats such a bound as inert too.
-#
-# the upgradable stdlibs are excluded from the widening: nothing pins them, so
-# their versions are resolved like any other package's, and a user bound on one
-# must be enforced strictly -- again matching Pkg.
-let compat = Dict{UUID,VersionSpec}(), bundled = bundled_versions(julia_versions, allow_pre)
-    for (uuid, spec) in project_compat
-        if uuid ∉ UPGRADABLE_STDLIBS_UUIDS
-            for v in get(bundled, uuid, ())
-                spec = spec ∪ VersionSpec(v)
-            end
-        end
-        compat[uuid] = spec
-    end
-    global const problem = Problem(reqs; compat)
-end
+# every bound is enforced strictly, stdlibs included. a bound on a stdlib is not
+# inert: a Julia version is compatible with exactly the stdlib versions it
+# bundles -- that is what its compat pins say -- so a bound that excludes those
+# versions excludes the Julia along with them, and the resolver *steers* the
+# Julia choice to satisfy it. If no admissible Julia bundles a version the bound
+# admits, and no registry version fits either, the requirements really are
+# unsatisfiable and saying so beats silently ignoring the bound.
+const problem = Problem(reqs; compat = project_compat)
 
 pkg_info = Resolver.pkg_info(reg, problem)
 sol = resolve(pkg_info, problem; by=sort_packages_by)

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -459,16 +459,24 @@ reg = registry_provider(
 # universe: they go into the `Problem`, which forbids the versions they exclude
 # by clause instead of deleting them from the provider's data. (the `julia`
 # bound is not among them: it was consumed above, as the Julia version
-# universe.) bounds on packages Julia bundles as stdlibs are widened to admit
-# the bundled versions, so that answers stay exactly what they were when the
-# provider applied compat itself: it applied compat to a package's registry
-# versions and *then* patched the bundled ones back in, so those were never
-# subject to it. (a bundled version is pinned by the Julia that bundles it, so
-# excluding it just makes that Julia infeasible.)
+# universe.)
+#
+# bounds on the stdlibs Julia *pins* are widened to admit the bundled versions,
+# so that answers stay exactly what they were when the provider applied compat
+# itself: it applied compat to a package's registry versions and *then* patched
+# the bundled ones back in, so those were never subject to it. a pinned stdlib's
+# version is dictated by the chosen Julia, so a bound excluding it would only
+# make that Julia infeasible -- Pkg treats such a bound as inert too.
+#
+# the upgradable stdlibs are excluded from the widening: nothing pins them, so
+# their versions are resolved like any other package's, and a user bound on one
+# must be enforced strictly -- again matching Pkg.
 let compat = Dict{UUID,VersionSpec}(), bundled = bundled_versions(julia_versions, allow_pre)
     for (uuid, spec) in project_compat
-        for v in get(bundled, uuid, ())
-            spec = spec ∪ VersionSpec(v)
+        if uuid ∉ UPGRADABLE_STDLIBS_UUIDS
+            for v in get(bundled, uuid, ())
+                spec = spec ∪ VersionSpec(v)
+            end
         end
         compat[uuid] = spec
     end
@@ -517,12 +525,25 @@ name_uuid_dict(d) = Dict{String,UUID}(uuid_to_name[u] => u for u in d) # >=1.14
 
 const info_map = Dict{UUID,ManifestEntry}()
 
+# is `uuid` recorded as a bundled stdlib of the resolved Julia, rather than as
+# an ordinary registry package? every pinned stdlib is; an upgradable one only
+# when it actually resolved to the version Julia bundles, since nothing pins it
+# and a registry version of it is an ordinary package -- tree hash and registry
+# deps -- exactly as Pkg records it. (`thispatch` drops the synthetic build
+# numbers the provider adds to tell same-numbered stdlib entries apart.)
+function bundled_stdlib(uuid::UUID, version::VersionNumber)
+    uuid in keys(stdlibs) || return false
+    uuid in UPGRADABLE_STDLIBS_UUIDS || return true
+    bundled = something(stdlibs[uuid].version, julia_version)
+    return Base.thispatch(version) == Base.thispatch(bundled)
+end
+
 for (uuid, version) in sol
     uuid === JULIA_UUID && continue
     # workspace packages become path entries in the manifest (written in the
     # manifest block below); they have no registry or stdlib info to record
     uuid in workspace_uuids && continue
-    if uuid in keys(stdlibs)
+    if bundled_stdlib(uuid, version)
         info = stdlibs[uuid]
         deps = Dict{String,UUID}()
         for dep in info.deps
@@ -615,7 +636,8 @@ if output == :print_versions
             name = info_map[uuid].name
             version = something(info_map[uuid].version, julia_version)
         end
-        optimal = uuid in keys(stdlibs) ||
+        # a pinned stdlib had no choice to make; an upgradable one did
+        optimal = uuid in keys(stdlibs) && uuid ∉ UPGRADABLE_STDLIBS_UUIDS ||
             version == best_version(uuid)
         try print(uuid, " ", rpad(name, width), " ", version)
             optimal || print(" ⊼")

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -142,10 +142,9 @@ end
     end
 
     # The provider offers a bundled stdlib version whatever the registries say,
-    # and it used to apply project compat to the registry versions only --
-    # before patching the bundled ones back in. `bundled_versions` is what lets
-    # bin/resolve.jl widen its Problem's bounds to reproduce that exactly.
-    # Julia 1.10.8 is frozen, so what it bundles never changes.
+    # so `bundled_versions` answers "which versions of this stdlib can I get on
+    # these Julias at all" -- the version sets the couplings below are stated
+    # in terms of. Julia 1.10.8 is frozen, so what it bundles never changes.
     @testset "bundled stdlib versions" begin
         bundled = bundled_versions(VersionSpec("1.10.8"))
         @test haskey(bundled, STATISTICS)
@@ -218,13 +217,42 @@ end
         old = resolve_versions("", ["--julia=1.8"]; deps = stat)
         @test !isnothing(old)
         @test old[STATISTICS] ∈ bundled_versions(VersionSpec("1.8"))[STATISTICS]
+    end
 
-        # a pinned stdlib is unaffected: nothing can move LinearAlgebra off the
-        # version its Julia bundles, so a bound excluding that version stays
-        # inert (widened away) rather than becoming unsatisfiable
-        pinned = resolve_versions("LinearAlgebra = \"1.11\"", ["--julia=1.10"];
-                                  deps = ["LinearAlgebra" => LINEAR_ALGEBRA])
-        @test !isnothing(pinned)
-        @test pinned[LINEAR_ALGEBRA] ∈ VersionSpec("1.10")
+    # A bound on a stdlib is not inert. A Julia version is compatible with
+    # exactly the stdlib versions it bundles -- its compat pins say so -- and a
+    # version that exists only as a bundled stdlib is installable only on the
+    # Julias that ship it. So a bound on a stdlib constrains the Julia choice
+    # through those couplings, and the resolver steers Julia to satisfy it or
+    # reports the requirements unsatisfiable.
+    @testset "stdlib bounds steer the julia choice" begin
+        linalg = ["LinearAlgebra" => LINEAR_ALGEBRA]
+        stat = ["Statistics" => STATISTICS]
+
+        # a bound on a pinned stdlib pushes Julia forward: only a Julia that
+        # bundles a LinearAlgebra ≥ 1.11 can satisfy it
+        steered = resolve_versions("LinearAlgebra = \"1.11\""; deps = linalg)
+        @test !isnothing(steered)
+        @test steered[LINEAR_ALGEBRA] ≥ v"1.11"
+        @test steered[JULIA_UUID] ≥ v"1.11"
+
+        # ... and when the Julia universe is restricted to versions that bundle
+        # no such LinearAlgebra, the bound is unsatisfiable rather than inert
+        @test isnothing(resolve_versions("LinearAlgebra = \"1.11\"",
+                                        ["--julia=1.10"]; deps = linalg))
+
+        # no Julia bundles a LinearAlgebra 99.x, and there is no registry copy
+        # of it either
+        @test isnothing(resolve_versions("LinearAlgebra = \"99\""; deps = linalg))
+
+        # a bundled-only version is admitted just by the Julias that bundle it,
+        # never by any other: Statistics 1.10.0 exists only as Julia 1.10's
+        # bundled copy (the registry starts at 1.11.0), so bounding Statistics
+        # to the 1.10 series steers Julia to 1.10 as well -- it must not pair
+        # 1.10.0 with a newer Julia that ships something else
+        tilde = resolve_versions("Statistics = \"~1.10\""; deps = stat)
+        @test !isnothing(tilde)
+        @test tilde[STATISTICS] ∈ bundled_versions(VersionSpec("1.10"))[STATISTICS]
+        @test tilde[JULIA_UUID] ∈ VersionSpec("1.10")
     end
 end

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -25,6 +25,7 @@ const COMPILER_SUPPORT_LIBRARIES_JLL = UUID("e66e0078-7015-5450-92f7-15fbd957f2a
 const LINEAR_ALGEBRA = UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e")
 const JSON = UUID("682c06a0-de6a-54ab-a142-c8b1cf79cde6")
 const STATISTICS = UUID("10745b16-79ce-11e8-11f9-7d13ad32a3b2")
+const DELIMITED_FILES = UUID("8bb1440f-4735-579b-a4ab-409b98df4dab")
 
 # Load packages from the installed registries (mirrors bin/resolve.jl).
 const packages = Dict{UUID,Vector{PkgEntry}}()
@@ -47,27 +48,41 @@ function resolves(reqs::Vector{UUID}; julia::VersionSpec)
     Resolver.resolve(info, reqs) !== nothing
 end
 
-# Resolve a one-dependency project with the given `[compat]` body and command
-# line flags, returning uuid => version. This drives the real `bin/resolve.jl`
-# in a subprocess, since that is where the project file is read and where the
-# option precedence lives. `--print-versions` (rather than manifest
-# generation) so it works on any host Julia, prerelease included.
+# Resolve a project with the given dependencies, `[compat]` body and command
+# line flags, returning uuid => version -- or `nothing` when the requirements
+# are unsatisfiable. This drives the real `bin/resolve.jl` in a subprocess,
+# since that is where the project file is read, where the option precedence
+# lives, and where the resolved versions are reported. `--print-versions`
+# (rather than manifest generation) so it works on any host Julia, prerelease
+# included.
 const RESOLVE_JL = normpath(joinpath(@__DIR__, "..", "resolve.jl"))
 const BIN_PROJECT = normpath(joinpath(@__DIR__, ".."))
 
-function resolve_versions(compat::AbstractString, flags::Vector{String} = String[])
+function resolve_versions(
+    compat :: AbstractString,
+    flags  :: Vector{String} = String[];
+    deps   :: Vector{Pair{String,UUID}} = ["JSON" => JSON],
+)
     dir = mktempdir()
     open(joinpath(dir, "Project.toml"), "w") do io
         println(io, "[deps]")
-        println(io, "JSON = \"$JSON\"")
+        for (name, uuid) in deps
+            println(io, "$name = \"$uuid\"")
+        end
         isempty(compat) && return
         println(io, "\n[compat]")
         println(io, compat)
     end
     out = IOBuffer()
+    err = IOBuffer()
     julia = Base.julia_cmd()[1]
     cmd = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions $flags`
-    success(pipeline(cmd; stdout = out)) || error("failed: $cmd")
+    if !success(pipeline(cmd; stdout = out, stderr = err))
+        # tell "no solution" apart from "the script broke"
+        occursin("Unsatisfiable", String(take!(err))) ||
+            error("failed: $cmd")
+        return nothing
+    end
     vers = Dict{UUID,VersionNumber}()
     for line in eachline(seekstart(out))
         m = match(r"^(\S{36})\s+\S+\s+(\S+)", line)
@@ -166,5 +181,50 @@ end
         flag = resolve_versions("julia = \"~1.10\"", ["--julia=1.9"])
         @test flag[JULIA_UUID] ∈ VersionSpec("1.9")
         @test flag == resolve_versions("", ["--julia=1.9"])
+    end
+
+    # Julia bundles a version of every stdlib, but it only *pins* some of them:
+    # `Pkg.Types.UPGRADABLE_STDLIBS` are bundled unpinned, so their registry
+    # versions compete like any other package's and a user bound on one is
+    # enforced strictly. We resolve over Julia versions too, so "pinned" here
+    # means pinned per candidate Julia -- each candidate carries its own pins,
+    # and an upgradable stdlib carries none from any of them.
+    @testset "upgradable stdlibs resolve like packages" begin
+        @test STATISTICS ∈ UPGRADABLE_STDLIBS_UUIDS
+        @test DELIMITED_FILES ∈ UPGRADABLE_STDLIBS_UUIDS
+        @test LINEAR_ALGEBRA ∉ UPGRADABLE_STDLIBS_UUIDS
+
+        stat = ["Statistics" => STATISTICS]
+
+        # Julia 1.10 bundles Statistics 1.10.0, but the registry's 1.11.0 and
+        # 1.11.1 declare `julia = "1.9.0 - 1"` / `"1.9.4 - 1"`, so they are
+        # installable there: a bound demanding 1.11 gets a registry version
+        # instead of being pinned to the bundled one. (Also covers the
+        # reporting path, which used to substitute the bundled version for any
+        # resolved stdlib.)
+        up = resolve_versions("Statistics = \"1.11\"", ["--julia=1.10"]; deps = stat)
+        @test !isnothing(up)
+        @test up[STATISTICS] ∈ VersionSpec("1.11")
+        @test up[JULIA_UUID] ∈ VersionSpec("1.10")
+
+        # no Statistics is 2.x, bundled or registered, so the bound is
+        # unsatisfiable rather than silently widened away
+        @test isnothing(
+            resolve_versions("Statistics = \"2\"", ["--julia=1.10"]; deps = stat))
+
+        # the bundled version remains a candidate: on Julia 1.8 every
+        # registered Statistics is ruled out by its own `julia` compat, so the
+        # answer is whatever 1.8 bundles
+        old = resolve_versions("", ["--julia=1.8"]; deps = stat)
+        @test !isnothing(old)
+        @test old[STATISTICS] ∈ bundled_versions(VersionSpec("1.8"))[STATISTICS]
+
+        # a pinned stdlib is unaffected: nothing can move LinearAlgebra off the
+        # version its Julia bundles, so a bound excluding that version stays
+        # inert (widened away) rather than becoming unsatisfiable
+        pinned = resolve_versions("LinearAlgebra = \"1.11\"", ["--julia=1.10"];
+                                  deps = ["LinearAlgebra" => LINEAR_ALGEBRA])
+        @test !isnothing(pinned)
+        @test pinned[LINEAR_ALGEBRA] ∈ VersionSpec("1.10")
     end
 end


### PR DESCRIPTION
**Stacked on #49** (`user-compat-clauses`), sibling to #50; GitHub retargets when #49 merges.

## What

Two commits that together make `bin/`'s stdlib handling match Pkg, generalized to multi-julia resolution.

**1. Upgradable stdlibs are not pinned** (`2af881b`). Pkg splits stdlibs: most are pinned to the running julia's bundled version, but `Pkg.Types.UPGRADABLE_STDLIBS = ["DelimitedFiles", "Statistics"]` resolve from the registry like any package. `bin/` pinned all of them, so a project asking for a newer Statistics than its julia ships silently got the bundled one. Now: no julia→stdlib pin for the two upgradable UUIDs; their bundled versions stay ordinary candidates; registry versions compete, governed by their own `julia` compat. This flushed out a real reporting bug: `bin/resolve.jl` was discarding the resolver's stdlib choice and emitting the bundled version with no tree hash — fixed with a `bundled_stdlib(uuid, version)` predicate (bundled wins ties, as in Pkg; genuinely upgraded stdlibs get real registry manifest entries, verified installable by Pkg).

**2. Stdlib compat bounds steer the julia choice** (`01f151f`, decided in review). A julia version is compatible with exactly the stdlib versions it bundles — its compat pins already say so — so a user bound on a *pinned* stdlib now excludes the julias whose bundled version violates it, instead of being silently ignored. The #49 bundled-versions widening is **removed entirely**; every bound is strict, stdlibs included. Complementarily, a **bundled-only version** (no registry entry) is now admitted exactly by the julias that bundle it, not `julia = "*"` — registry versions keep their compat ∪ bundling-julias reconciliation (the CompilerSupportLibraries_jll case, untouched). These two had to land together: with steering but without the tightening, `Statistics = "~1.10"` under unbounded julia resolved julia 1.12.6 paired with bundled-only Statistics 1.10.0 — an uninstallable, *unreportable* solution ("version resolved but no registry entries found").

## Semantics after this PR

| case | before | after |
|---|---|---|
| `Statistics = "1.11"`, `--julia=1.10` | Statistics 1.10.0 (bound ignored) | registry Statistics 1.11.1 on julia 1.10 |
| `LinearAlgebra = "1.11"`, `--julia=1.10` | resolves, bound inert | **unsatisfiable** (no admissible julia satisfies the bound) |
| `LinearAlgebra = "1.11"`, julia unbounded | newest julia (bound inert) | julia ≥ 1.11, now *because of* the bound |
| `Statistics = "~1.10"`, julia unbounded | crash (unreportable pairing) | julia 1.10.11 + Statistics 1.10.0 |
| downgrade-CI exact pins on upgradable stdlibs | silently violated | honored (or loudly unsatisfiable, as in Pkg) |

## The surprise mode, measured

A stale *upper-bounded* stdlib entry now silently caps julia. Real shape: `[compat] julia = "1.6"`, `LinearAlgebra = "~1.10"`, no flag → before: julia 1.12.6; now: **julia 1.10.11 ⊼** — the unrelated-looking LinearAlgebra bound decides the julia version, overriding the project's own declared julia range. Correct under the ruling (it's what compat *means*), and bounded in practice: caret bounds — what `pkg> compat` generates — only ever push julia *forward*; only tilde/exact/range upper bounds can pull it back. The `⊼` marker on the julia line is currently the only signal; #52 tracks making diagnostics explain "julia was held back by your compat on X" properly. In Pkg-default usage (julia pinned to the running version) the same situation is an ordinary unsatisfiable resolve, which UNSAT diagnostics (#30) already explains.

## Verification

Differential checks: projects that bound no stdlib are byte-identical throughout (downgrade-style Compat-4 project, 384-package registry project on 1.10 — one line differs, the Statistics upgrade from commit 1 — and its full 1.12 manifest). Bin testset 34/34 including the reversed inert-bound case; full suite green.

## Co-author

Implemented with [Claude Code](https://claude.com/claude-code): implementation and review by Claude, directed and reviewed by @StefanKarpinski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7