### PR TITLE
Diagnostics: goal-query resolve, verified fixes, and holdback analysis on the production SAT instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Resolver.jl separates *what* to optimize from *how* to solve, handing the solvin
     - a version's dependencies must be present, and
     - conflicting versions cannot both be chosen.
 - Before solving, the problem is shrunk by **reachability analysis** (keeping only versions that could appear in a solution) and **redundancy elimination** (dropping versions that are strictly dominated by others).
-- The solution is optimized **lexicographically, one package at a time**, against a caller-supplied priority order — the resolver returns the unique optimal resolution that order determines (`nothing` if the requirements are unsatisfiable), and it is **Pareto-optimal**: no valid resolution is strictly better.
+- The solution is optimized **lexicographically, one package at a time**, against a caller-supplied priority order — the resolver returns the unique optimal resolution that order determines, and it is **Pareto-optimal**: no valid resolution is strictly better.
 - Because the preference order is supplied per package, different strategies — newest, oldest/downgrade, prefer-installed, keep-current — can be mixed **within a single resolve**.
 
 The core resolver in [`src/`](src/) is generic: it knows nothing about Julia versions or registries. The [`bin/resolve.jl`](bin/resolve.jl) command-line tool adapts it to Julia's real registries and can emit a `Manifest.toml`.
@@ -38,7 +38,9 @@ The core resolver in [`src/`](src/) is generic: it knows nothing about Julia ver
 
 Experimental and research-stage. Resolver.jl is a standalone package rather than a part of `Pkg`, but the core resolver is complete, and `bin/resolve.jl` resolves real projects against the General registry today — it already backs [`julia-downgrade-compat`](https://github.com/julia-actions/julia-downgrade-compat), which uses it to compute minimum-version manifests in CI.
 
-A major in-progress goal is providing much better diagnostics when a manifest is **unresolvable** (unsatisfiable). The rich theory behind SAT problems helps here: rather than a bare failure, the resolver can compute
+An **unresolvable** manifest is explained rather than merely reported. The rich theory behind SAT problems is what makes that possible: instead of a bare failure, `resolve` returns a diagnosis computed from
 
 - **MUSes (minimal unsatisfiable subsets)** — smallest sets of requirements that already conflict on their own, explaining *why* resolution failed; and
-- **MCSes (minimal correction sets)** — smallest sets of requirements whose removal would make the manifest resolvable, pointing at *what to change* to fix it.
+- **MCSes (minimal correction sets)** — smallest sets of constraints whose removal would make the manifest resolvable, pointing at *what to change* to fix it.
+
+Both are computed on the very SAT instance the resolve failed on, which takes a theorem to justify — the filter that shrank that instance ran with all of those constraints in force. See the [diagnostics guide](docs/src/diagnostics.md) and the [theory](docs/src/theory/diagnostics.md) behind it, including the granularity below which the justification provably fails.

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,7 +1,7 @@
 module Registries
 
 export registry_provider, package_info, bundled_versions,
-    prerelease_exclusion, yanked_exclusion, is_yanked, is_registered, is_bundled,
+    prerelease_exclusion, is_yanked, is_registered, is_bundled,
     UPGRADABLE_STDLIBS_UUIDS
 
 import Base: UUID
@@ -262,12 +262,14 @@ prerelease_exclusion(allow_pre::Dict{UUID,Bool}) =
 
 ## yanked versions
 #
-# Yankedness is the same shape of fact as prerelease-ness: a property of a version
-# that a query may or may not be willing to accept. Nothing offers the user a way
-# to accept one yet -- this kind is always in force -- but modeling it as a
-# constraint rather than a deletion is what keeps the package universe shared, and
-# is what lets a diagnostic eventually say "the only version that satisfies this
-# is yanked" instead of "no such version".
+# Unlike prerelease-ness, yankedness is *not* a query knob: a yanked version is
+# one the registry has withdrawn, and the resolver must never produce one and
+# never propose one. Both are true by construction if the version is simply not
+# in the universe, so the provider filters yanked versions out (and
+# `--allow-yanked` rebuilds without the filter, which is rare and cheap). What
+# is lost that way is only the *story* -- "no such version" where "the versions
+# your compat admits are yanked" is the real answer -- so the provider records
+# the versions it dropped, as explanation data rather than as a constraint.
 #
 # A version is offered when *some* registry entry has it un-yanked, so it counts
 # as yanked only when every entry that has it says so -- and a version that no
@@ -289,8 +291,12 @@ function is_yanked(
     return found
 end
 
-yanked_exclusion(packages::Dict{UUID,Vector{PkgEntry}}) =
-    :yanked => (uuid::UUID, v::VersionNumber) -> is_yanked(packages, uuid, v)
+# `allow_yanked` mirrors `allow_pre`: keyed by package uuid with the zero uuid
+# holding the default, so `--allow-yanked` and `--allow-yanked=Foo` both work.
+# Accepting a yanked version is the user's call to make, and the way to make it
+# is to build a universe that has them in it.
+allows_yanked(allow_yanked::Dict{UUID,Bool}, uuid::UUID) =
+    get(allow_yanked, uuid, get(allow_yanked, UUID(0), false))
 
 # Do the registries have this version, as opposed to it existing only because
 # some Julia bundles it? (the provider's `bundled_only`, from the outside.) Only
@@ -314,10 +320,20 @@ end
 # (`workspace_pkgs` is not a query knob: a workspace's member packages are part of
 # the environment's package universe, fixed at their local versions, the way a
 # registry's packages are part of it at their registered versions.)
+#
+# `allow_yanked` is the one parameter that changes which versions *exist*: a
+# yanked version is withdrawn, not merely unwanted, so the universe leaves it out
+# unless asked (see "yanked versions" above). `yanked` is filled in as the
+# provider goes with the versions it dropped, per package — explanation data for
+# the reporting layer, which is where the difference between "no such version"
+# and "the versions your compat admits are yanked" is worth having.
 function registry_provider(
     packages       :: Dict{UUID,Vector{PkgEntry}};
     workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
                       Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
+    allow_yanked   :: Dict{UUID,Bool} = Dict{UUID,Bool}(),
+    yanked         :: Dict{UUID,Vector{VersionNumber}} =
+                      Dict{UUID,Vector{VersionNumber}}(),
 )
     stdlibs, bundlers, by_patch = STDLIB_VERSIONS, BUNDLERS, BUNDLERS_BY_PATCH
 
@@ -434,6 +450,21 @@ function registry_provider(
                 push!(vers, v)
                 push!(bundled_only, v)
                 deps[v] = info.deps
+            end
+        end
+        # drop the yanked versions from the universe, recording what was
+        # dropped. A version some Julia bundles is not the registry's to
+        # withdraw, so it stays whatever the registry says.
+        if uuid in keys(packages) && !allows_yanked(allow_yanked, uuid)
+            dropped = [v for v in vers
+                       if !is_bundled(uuid, v) && is_yanked(packages, uuid, v)]
+            if !isempty(dropped)
+                yanked[uuid] = sort!(dropped; rev = true)
+                setdiff!(vers, dropped)
+                for v in dropped
+                    delete!(deps, v)
+                    delete!(comp, v)
+                end
             end
         end
         # widen a stdlib package's `julia` compat to admit the Julias that bundle it

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -21,6 +21,9 @@ usage: $PROGRAM_FILE [options] [<project path>]
 
   --allow-pre[=<pkgs>]    allow prerelease versions
   --allow-yanked[=<pkgs>] allow yanked versions
+  --why[=<pkgs>]          explain packages that resolved below their newest
+                          version, all of them if given no list (julia is
+                          explained automatically)
   --extra-deps=<pkgs>     extra packages to require
   --prioritize=<pkgs>     package names/uuids to prioritize
 
@@ -51,7 +54,7 @@ Wherever <pkgs> appears you can specify a comma-separated list of:
 
 parse_opts!(ARGS, split("""
     print-manifest print-versions
-    julia allow-pre allow-yanked extra-deps prioritize
+    julia allow-pre allow-yanked extra-deps prioritize why
     fix fix-minor fix-major unfix
     max max-minor max-major
     min min-minor min-major
@@ -500,8 +503,11 @@ const problem = Problem(reqs;
     excludes = [prerelease_exclusion(allow_pre)],
 )
 
-pkg_info = Resolver.pkg_info(reg, problem)
-sol = resolve(pkg_info, problem; by=sort_packages_by, order=version_order)
+# prepared explicitly rather than through `resolve`, because the holdback
+# explanations below want the same universe the solution came from
+pkg_info = Resolver.prepare_pkg_info(
+    Resolver.pkg_info(reg, problem), problem; order=version_order)
+sol = Resolver.resolve_prepared(pkg_info, problem; by=sort_packages_by)
 
 # Yanked versions were left out of the universe, so a bound that admits only
 # yanked ones reads as admitting nothing at all -- "no versions", where the real
@@ -548,6 +554,55 @@ if sol isa Diagnosis
     println(stderr, "Unresolvable. Diagnosis:\n")
     println(stderr, report)
     exit(1)
+end
+
+## explain a resolution that succeeded and may still surprise
+
+# A user compat bound on a non-upgradable stdlib steers the julia choice, so a
+# stale `LinearAlgebra = "~1.10"` quietly pins the whole toolchain to julia 1.10
+# -- correctly, and until now without a word. julia is explained whenever it did
+# not land on its newest admissible version, because that is the surprise nobody
+# asked for; `--why` covers the rest, which nobody needs by default.
+const why_pkgs = Set{UUID}((JULIA_UUID,))
+const asked_why = Ref(false)
+const why_all = Ref(false)
+
+handle_opts(:why) do val::Union{String,Nothing}
+    asked_why[] = true
+    # bare `--why` means "everything that landed below its best version"; the
+    # probe budget bounds the cost, and the report says when it stopped short
+    isnothing(val) ? (why_all[] = true) : union!(why_pkgs, parse_packages(val))
+end
+
+let hs = Resolver.holdbacks(pkg_info, problem, sol,
+                            why_all[] ? keys(sol) :
+                                [u for u in why_pkgs if haskey(sol, u)];
+                            by = sort_packages_by)
+    names = Dict{String,String}(string(JULIA_UUID) => "julia")
+    for (u, entries) in packages, entry in entries
+        names[string(u)] = entry.name
+    end
+    for (_v, stdlib_set) in STDLIBS_BY_VERSION, (u, info) in stdlib_set
+        names[string(u)] = info.name
+    end
+    for (u, info) in UNREGISTERED_STDLIBS
+        names[string(u)] = info.name
+    end
+    uuid_re = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    named(s) = replace(s, uuid_re => m -> get(names, m, m))
+    for h in hs
+        # an unasked-for note stays to one line; what the user asked about gets
+        # the reasoning
+        if asked_why[]
+            print(stderr, named(sprint(show, MIME("text/plain"), h)))
+        else
+            println(stderr, "Note: ", named(Resolver.summarize(h)), ".")
+        end
+    end
+    # explaining a package costs solves, so the probe budget is real -- say
+    # when it stopped short rather than quietly reporting a partial answer
+    asked_why[] &&
+        print(stderr, sprint(Resolver.render_unexamined, hs))
 end
 
 ## output results

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -21,9 +21,13 @@ usage: $PROGRAM_FILE [options] [<project path>]
 
   --allow-pre[=<pkgs>]    allow prerelease versions
   --allow-yanked[=<pkgs>] allow yanked versions
-  --why[=<pkgs>]          explain packages that resolved below their newest
-                          version, all of them if given no list (julia is
-                          explained automatically)
+  --explain[=<targets>]   explain the resolution. Bare: every package that
+                          landed below its best version (julia is explained
+                          automatically either way). <targets> are <pkgs>,
+                          each answering the question that is not already
+                          answered -- what held it back if it is below its
+                          best version, whether you can have it at all if it
+                          is not -- or pkg@version to ask about a version
   --extra-deps=<pkgs>     extra packages to require
   --prioritize=<pkgs>     package names/uuids to prioritize
 
@@ -54,7 +58,7 @@ Wherever <pkgs> appears you can specify a comma-separated list of:
 
 parse_opts!(ARGS, split("""
     print-manifest print-versions
-    julia allow-pre allow-yanked extra-deps prioritize why
+    julia allow-pre allow-yanked extra-deps prioritize explain
     fix fix-minor fix-major unfix
     max max-minor max-major
     min min-minor min-major
@@ -533,26 +537,27 @@ function yanked_notes(d::Diagnosis)
     return notes
 end
 
+const names = Dict{String,String}(string(JULIA_UUID) => "julia")
+for (u, entries) in packages, entry in entries
+    names[string(u)] = entry.name
+end
+for (_v, stdlib_set) in STDLIBS_BY_VERSION, (u, info) in stdlib_set
+    names[string(u)] = info.name
+end
+for (u, info) in UNREGISTERED_STDLIBS
+    names[string(u)] = info.name
+end
+const uuid_re = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+named(s::AbstractString) = replace(s, uuid_re => m -> get(names, m, m))
+pkgname(u::UUID) = get(names, string(u), string(u))
+
 # an unsatisfiable resolve comes back explained: independent conflicts, the
 # facts behind each, and a menu of verified fixes. The diagnosis is keyed by
 # uuid, as everything here is, so substitute package names before printing it
 if sol isa Diagnosis
-    names = Dict{String,String}(string(JULIA_UUID) => "julia")
-    for (u, entries) in packages, entry in entries
-        names[string(u)] = entry.name
-    end
-    for (_v, stdlib_set) in STDLIBS_BY_VERSION, (u, info) in stdlib_set
-        names[string(u)] = info.name
-    end
-    for (u, info) in UNREGISTERED_STDLIBS
-        names[string(u)] = info.name
-    end
-    uuid_re = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-    text = string(sprint(show, MIME("text/plain"), sol),
-                  join(("Note: $note.\n" for note in yanked_notes(sol))))
-    report = replace(text, uuid_re => m -> get(names, m, m))
     println(stderr, "Unresolvable. Diagnosis:\n")
-    println(stderr, report)
+    println(stderr, named(string(sprint(show, MIME("text/plain"), sol),
+        join(("Note: $note.\n" for note in yanked_notes(sol))))))
     exit(1)
 end
 
@@ -562,34 +567,46 @@ end
 # stale `LinearAlgebra = "~1.10"` quietly pins the whole toolchain to julia 1.10
 # -- correctly, and until now without a word. julia is explained whenever it did
 # not land on its newest admissible version, because that is the surprise nobody
-# asked for; `--why` covers the rest, which nobody needs by default.
-const why_pkgs = Set{UUID}((JULIA_UUID,))
+# asked for; `--explain` covers the rest, which nobody needs by default.
+const explain_pkgs = UUID[]
+const explain_vers = Pair{UUID,VersionSpec}[]
 const asked_why = Ref(false)
 const why_all = Ref(false)
 
-handle_opts(:why) do val::Union{String,Nothing}
+# split "Foo@1.2" into its package and its version, if it has one
+partition_at(s::AbstractString, c::Char) =
+    (i = findfirst(==(c), s); isnothing(i) ?
+        (s, "", "") : (s[1:prevind(s, i)], "@", s[nextind(s, i):end]))
+
+handle_opts(:explain) do val::Union{String,Nothing}
     asked_why[] = true
-    # bare `--why` means "everything that landed below its best version"; the
-    # probe budget bounds the cost, and the report says when it stopped short
-    isnothing(val) ? (why_all[] = true) : union!(why_pkgs, parse_packages(val))
+    # bare `--explain` means "everything that landed below its best version";
+    # the probe budget bounds the cost, and the report says when it stopped
+    # short. A named target may carry a version: `--explain=DataFrames@1.8.2`
+    isnothing(val) && return (why_all[] = true)
+    for target in split(val, ',')
+        name, sep, ver = partition_at(target, '@')
+        isempty(sep) ?
+            append!(explain_pkgs, parse_packages(name)) :
+            for u in parse_packages(name)
+                push!(explain_vers, u => semver_spec(String(ver)))
+            end
+    end
+end
+
+# holdbacks: julia always, plus whatever was asked about that is below its best
+# version. A package already at its best has no holdback to report, so asking
+# about it means the other question -- see `explain_goal` below.
+const held_pkgs = UUID[JULIA_UUID]
+for u in explain_pkgs
+    u in held_pkgs || push!(held_pkgs, u)
 end
 
 let hs = Resolver.holdbacks(pkg_info, problem, sol,
                             why_all[] ? keys(sol) :
-                                [u for u in why_pkgs if haskey(sol, u)];
+                                [u for u in held_pkgs if haskey(sol, u)];
                             by = sort_packages_by)
-    names = Dict{String,String}(string(JULIA_UUID) => "julia")
-    for (u, entries) in packages, entry in entries
-        names[string(u)] = entry.name
-    end
-    for (_v, stdlib_set) in STDLIBS_BY_VERSION, (u, info) in stdlib_set
-        names[string(u)] = info.name
-    end
-    for (u, info) in UNREGISTERED_STDLIBS
-        names[string(u)] = info.name
-    end
-    uuid_re = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-    named(s) = replace(s, uuid_re => m -> get(names, m, m))
+    global const explained = Set{UUID}(h.pkg for h in hs)
     for h in hs
         # an unasked-for note stays to one line; what the user asked about gets
         # the reasoning
@@ -603,6 +620,37 @@ let hs = Resolver.holdbacks(pkg_info, problem, sol,
     # when it stopped short rather than quietly reporting a partial answer
     asked_why[] &&
         print(stderr, sprint(Resolver.render_unexamined, hs))
+end
+
+# The other half of `--explain=<target>`: the question a holdback did not
+# answer. If the package is not below its best version there is nothing holding
+# it back, so what the user must be asking is whether they can have it at all
+# (or at a named version) -- which is a goal, and `resolve` answers goals.
+function explain_goal(u::UUID, spec::Union{Nothing,VersionSpec})
+    want = spec === nothing ? "" : string(" at ", spec)
+    got = resolve(reg, problem; by = sort_packages_by, order = version_order,
+                  with = spec === nothing ? u : u => spec)
+    if got isa Diagnosis
+        println(stderr, "You cannot have ", pkgname(u), want, ":\n")
+        print(stderr, named(sprint(show, MIME("text/plain"), got)))
+        return
+    end
+    diff = Resolver.changes(sol, got)
+    isempty(diff) &&
+        return println(stderr, pkgname(u), want,
+                       " is what you already resolved to.")
+    println(stderr, "You can have ", pkgname(u), want, ", at this price:")
+    for c in diff
+        println(stderr, "  • ", named(sprint(show, c)))
+    end
+end
+
+for u in explain_pkgs
+    u in explained && continue          # the holdback above answered it
+    explain_goal(u, nothing)
+end
+for (u, spec) in explain_vers
+    explain_goal(u, spec)
 end
 
 ## output results

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -20,6 +20,7 @@ usage: $PROGRAM_FILE [options] [<project path>]
                           use registry compat syntax, not semver
 
   --allow-pre[=<pkgs>]    allow prerelease versions
+  --allow-yanked[=<pkgs>] allow yanked versions
   --extra-deps=<pkgs>     extra packages to require
   --prioritize=<pkgs>     package names/uuids to prioritize
 
@@ -50,7 +51,7 @@ Wherever <pkgs> appears you can specify a comma-separated list of:
 
 parse_opts!(ARGS, split("""
     print-manifest print-versions
-    julia allow-pre extra-deps prioritize
+    julia allow-pre allow-yanked extra-deps prioritize
     fix fix-minor fix-major unfix
     max max-minor max-major
     min min-minor min-major
@@ -92,7 +93,7 @@ end
 import Pkg.Registry: JULIA_UUID, PkgEntry, RegistryInstance,    init_package_info!, reachable_registries
 import Pkg.Types: Context, EnvCache, Manifest, PackageEntry, get_last_stdlibs, write_manifest
 import Pkg.Versions: VersionSpec, semver_spec
-import Resolver: Resolver, DepsProvider, PkgData, Problem, resolve
+import Resolver: Resolver, DepsProvider, PkgData, Problem, Diagnosis, resolve
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS
 import TOML
 
@@ -128,7 +129,6 @@ let proj = env.project
     global const project_names = merge(proj.deps, proj.weakdeps, proj.extras)
     project_names["julia"] = JULIA_UUID
     global const project_deps = collect(values(proj.deps))
-    push!(project_deps, JULIA_UUID)
     global const project_weakdeps = collect(values(proj.weakdeps))
     global const project_compat = Dict{UUID,VersionSpec}()
     for (name, comp) in proj.compat
@@ -310,6 +310,14 @@ function parse_packages(str::AbstractString)
 end
 
 ## options: additional requirements
+#
+# `julia` is deliberately *not* among them. Every package version the provider
+# offers depends on julia, so julia is in the solution because things need it --
+# which is the modelling convention the diagnostics ask for: a platform package
+# nobody chose should not be a requirement, or a report ends up offering to drop
+# it, and naming it on every "→ allows:" line as though the user had picked it.
+# The one project with no dependencies at all still needs a julia to write a
+# manifest for, so it gets one below.
 
 global const reqs = copy(project_deps)
 
@@ -323,6 +331,7 @@ const ZERO_UUID = UUID(0)
 
 # zero UUID used for defaults
 const allow_pre = Dict(ZERO_UUID => false)
+const allow_yanked = Dict(ZERO_UUID => false)
 const FIX_PATCH = Dict(ZERO_UUID => false)
 const FIX_MINOR = Dict(ZERO_UUID => false)
 const FIX_MAJOR = Dict(ZERO_UUID => false)
@@ -331,11 +340,15 @@ const ORDER_MAP = Dict(ZERO_UUID => :max)
 # list of all fixed packages
 const FIXED = UUID[]
 
-handle_opts(r"^(allow_pre|(un)?fix|max|min)") do opt, val
+handle_opts(r"^(allow_pre|allow_yanked|(un)?fix|max|min)") do opt, val
     pkgs = isnothing(val) ? [ZERO_UUID] : parse_packages(val)
     if opt == :allow_pre
         for uuid in pkgs
             allow_pre[uuid] = true
+        end
+    elseif opt == :allow_yanked
+        for uuid in pkgs
+            allow_yanked[uuid] = true
         end
     elseif opt == :fix
         for uuid in pkgs
@@ -457,7 +470,13 @@ end
 
 ## do an actual resolve
 
-reg = registry_provider(packages; workspace_pkgs)
+# the versions the provider withheld as yanked, per package: not a constraint,
+# just what the reporting layer needs to say "the versions your compat admits
+# are yanked" where it would otherwise say nothing at all
+const yanked_versions = Dict{UUID,Vector{VersionNumber}}()
+
+reg = registry_provider(packages;
+                        workspace_pkgs, allow_yanked, yanked = yanked_versions)
 
 # the project's compat bounds are user constraints, not part of the package
 # universe: they go into the `Problem`, which forbids the versions they exclude
@@ -472,25 +491,74 @@ reg = registry_provider(packages; workspace_pkgs)
 # admits, and no registry version fits either, the requirements really are
 # unsatisfiable and saying so beats silently ignoring the bound.
 #
-# the admission knobs ride along as exclusion kinds: `--allow-pre` says which
-# packages' prereleases the query accepts, and yanked versions are forbidden
-# outright (there is no option to accept one yet), each the same way a compat
-# bound forbids a version.
+# prerelease admission rides along as an exclusion kind: the versions exist
+# either way and `--allow-pre` says which of them this query accepts, the same
+# way a compat bound says which it accepts. Yankedness is not a kind at all --
+# the provider above left those versions out of the universe.
 const problem = Problem(reqs;
     compat = project_compat,
-    excludes = [
-        prerelease_exclusion(allow_pre),
-        yanked_exclusion(packages),
-    ],
+    excludes = [prerelease_exclusion(allow_pre)],
 )
 
 pkg_info = Resolver.pkg_info(reg, problem)
 sol = resolve(pkg_info, problem; by=sort_packages_by, order=version_order)
-sol === nothing && error("Unsatisfiable")
+
+# Yanked versions were left out of the universe, so a bound that admits only
+# yanked ones reads as admitting nothing at all -- "no versions", where the real
+# answer is "the ones you asked for were withdrawn". The provider kept the set
+# it dropped for exactly this: the story is recovered at the rendering layer,
+# from explanation data, without a constraint object anywhere.
+function yanked_notes(d::Diagnosis)
+    notes = String[]
+    seen = Set{UUID}()
+    for c in d.conflicts, f in c.chain
+        f isa Resolver.UserCompat && isempty(f.allowed) || continue
+        f.pkg in seen && continue
+        push!(seen, f.pkg)
+        spec = get(project_compat, f.pkg, nothing)
+        spec === nothing && continue
+        vers = [v for v in get(yanked_versions, f.pkg, VersionNumber[])
+                if v ∈ spec]
+        isempty(vers) && continue
+        push!(notes, string("the versions your compat on ", f.pkg,
+                            " admits are yanked (", join(vers, ", "),
+                            "); --allow-yanked accepts them anyway"))
+    end
+    return notes
+end
+
+# an unsatisfiable resolve comes back explained: independent conflicts, the
+# facts behind each, and a menu of verified fixes. The diagnosis is keyed by
+# uuid, as everything here is, so substitute package names before printing it
+if sol isa Diagnosis
+    names = Dict{String,String}(string(JULIA_UUID) => "julia")
+    for (u, entries) in packages, entry in entries
+        names[string(u)] = entry.name
+    end
+    for (_v, stdlib_set) in STDLIBS_BY_VERSION, (u, info) in stdlib_set
+        names[string(u)] = info.name
+    end
+    for (u, info) in UNREGISTERED_STDLIBS
+        names[string(u)] = info.name
+    end
+    uuid_re = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    text = string(sprint(show, MIME("text/plain"), sol),
+                  join(("Note: $note.\n" for note in yanked_notes(sol))))
+    report = replace(text, uuid_re => m -> get(names, m, m))
+    println(stderr, "Unresolvable. Diagnosis:\n")
+    println(stderr, report)
+    exit(1)
+end
 
 ## output results
 
-const julia_version = sol[JULIA_UUID]
+# a project that requires nothing pulls in no julia either, and still has to
+# be written out against one: take the newest the constraints admit
+const julia_version = get(sol, JULIA_UUID) do
+    vers = pkg_info[JULIA_UUID].versions
+    i = findfirst(v -> !Resolver.is_excluded(problem, JULIA_UUID, v), vers)
+    i === nothing ? error("no admissible julia version") : vers[i]
+end
 const stdlibs = let last_stdlibs = UNREGISTERED_STDLIBS
     for (v, this_stdlibs) in STDLIBS_BY_VERSION
         v > Base.thispatch(julia_version) && break

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -652,9 +652,9 @@ end
     end
     @test got == promised
 
-    # `--why` asks for the reasoning, and for the other packages too
+    # `--explain` asks for the reasoning, and for the other packages too
     err3 = IOBuffer()
-    cmd3 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions --why`
+    cmd3 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions --explain`
     @test success(pipeline(cmd3; stdout = devnull, stderr = err3))
     why = String(take!(err3))
     @test occursin("julia resolved to $(vers[JULIA_UUID])", why)
@@ -662,13 +662,49 @@ end
     @test occursin(r"julia \S+ works with LinearAlgebra only at", why)
     @test occursin("⇒ held back by your compat on LinearAlgebra.", why)
     @test occursin("relax your compat on LinearAlgebra → allows: julia", why)
-    # JSON is held back by its own bound, and only `--why` mentions it
+    # JSON is held back by its own bound, and only `--explain` mentions it
     @test occursin("JSON resolved to", why)
     @test !occursin("JSON resolved to", note)
-    # bare `--why` covers everything, so the probe budget bites -- and says so
+    # bare `--explain` covers everything, so the probe budget bites -- and says so
     # rather than quietly reporting a partial answer
     @test occursin(r"\(\d+ more packages? resolved below their best version, not examined\)",
                    why)
+
+    # `--explain=<pkg>` answers whichever question is not already answered:
+    # what held the package back if it is below its best version ...
+    err5 = IOBuffer()
+    cmd5 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions
+            --explain=JSON`
+    @test success(pipeline(cmd5; stdout = devnull, stderr = err5))
+    one = String(take!(err5))
+    @test occursin("JSON resolved to", one)
+    @test !occursin("LinearAlgebra resolved to", one)   # not asked about
+
+    # ... and whether you can have it at all if it is not. Statistics is not in
+    # this project's solution, so the question is presence, and the answer is a
+    # price rather than a holdback.
+    err6 = IOBuffer()
+    cmd6 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions
+            --explain=Statistics`
+    @test success(pipeline(cmd6; stdout = devnull, stderr = err6))
+    presence = String(take!(err6))
+    @test occursin("You can have Statistics, at this price:", presence)
+    @test occursin(r"Statistics \S+ added", presence)
+
+    # a version target asks about a version, and an impossible one is
+    # explained rather than merely refused
+    err7 = IOBuffer()
+    cmd7 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions
+            --explain=JSON@0.21`
+    @test success(pipeline(cmd7; stdout = devnull, stderr = err7))
+    @test occursin("JSON at 0.21", String(take!(err7)))
+    err8 = IOBuffer()
+    cmd8 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions
+            --explain=JSON@99`
+    @test success(pipeline(cmd8; stdout = devnull, stderr = err8))
+    nope = String(take!(err8))
+    @test occursin("You cannot have JSON at 99", nope)
+    @test occursin("Conflict 1: the goal", nope)
 
     # a project with nothing stale says nothing
     err4 = IOBuffer()

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -594,6 +594,89 @@ end
     end
 end
 
+@testset "holdback diagnostics (bin/resolve.jl)" begin
+    # A resolution that *succeeded* and still surprises: a user compat bound on
+    # a non-upgradable stdlib steers the julia choice, so a stale
+    # `LinearAlgebra = "~1.10"` quietly pins the toolchain to julia 1.10 even
+    # though the project asks only for julia 1.6+. julia is explained without
+    # being asked, because that is the surprise nobody went looking for.
+    julia = Base.julia_cmd()[1]
+    dir = mktempdir()
+    write(joinpath(dir, "Project.toml"), """
+        [deps]
+        JSON = "$JSON"
+        LinearAlgebra = "$LINEAR_ALGEBRA"
+
+        [compat]
+        julia = "1.6"
+        LinearAlgebra = "~1.10"
+        JSON = "0.21"
+        """)
+
+    out = IOBuffer(); err = IOBuffer()
+    cmd = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions`
+    @test success(pipeline(cmd; stdout = out, stderr = err))
+    note = String(take!(err))
+    vers = Dict{UUID,VersionNumber}()
+    for line in eachline(seekstart(out))
+        m = match(r"^(\S{36})\s+\S+\s+(\S+)", line)
+        isnothing(m) || (vers[UUID(m[1])] = VersionNumber(m[2]))
+    end
+    # the surprise itself, and the note naming its cause
+    @test vers[JULIA_UUID] < v"1.11"
+    @test occursin("Note: julia is held back to $(vers[JULIA_UUID])", note)
+    @test occursin("by your compat on LinearAlgebra", note)
+    m = match(r"relaxing it allows julia (\S+)", note)
+    @test m !== nothing
+    promised = VersionNumber(rstrip(m[1], '.'))
+    @test promised > vers[JULIA_UUID]
+    # ... and the promise is kept: dropping the bound really does get you that
+    same = mktempdir()
+    write(joinpath(same, "Project.toml"), """
+        [deps]
+        JSON = "$JSON"
+        LinearAlgebra = "$LINEAR_ALGEBRA"
+
+        [compat]
+        julia = "1.6"
+        JSON = "0.21"
+        """)
+    out2 = IOBuffer()
+    cmd2 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $same --print-versions`
+    @test success(pipeline(cmd2; stdout = out2, stderr = devnull))
+    got = nothing
+    for line in eachline(seekstart(out2))
+        m2 = match(r"^(\S{36})\s+\S+\s+(\S+)", line)
+        isnothing(m2) || UUID(m2[1]) != JULIA_UUID ||
+            (got = VersionNumber(m2[2]))
+    end
+    @test got == promised
+
+    # `--why` asks for the reasoning, and for the other packages too
+    err3 = IOBuffer()
+    cmd3 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions --why`
+    @test success(pipeline(cmd3; stdout = devnull, stderr = err3))
+    why = String(take!(err3))
+    @test occursin("julia resolved to $(vers[JULIA_UUID])", why)
+    @test occursin("your compat restricts LinearAlgebra", why)
+    @test occursin(r"julia \S+ works with LinearAlgebra only at", why)
+    @test occursin("⇒ held back by your compat on LinearAlgebra.", why)
+    @test occursin("relax your compat on LinearAlgebra → allows: julia", why)
+    # JSON is held back by its own bound, and only `--why` mentions it
+    @test occursin("JSON resolved to", why)
+    @test !occursin("JSON resolved to", note)
+    # bare `--why` covers everything, so the probe budget bites -- and says so
+    # rather than quietly reporting a partial answer
+    @test occursin(r"\(\d+ more packages? resolved below their best version, not examined\)",
+                   why)
+
+    # a project with nothing stale says nothing
+    err4 = IOBuffer()
+    cmd4 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $same --print-versions`
+    @test success(pipeline(cmd4; stdout = devnull, stderr = err4))
+    @test !occursin("held back", String(take!(err4)))
+end
+
 @testset "unsat diagnostics (bin/resolve.jl)" begin
     # bin/resolve.jl diagnoses an unsatisfiable resolve automatically: the
     # report comes back from `resolve` itself, so all the script does is

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -51,9 +51,11 @@ for reg in reachable_registries()
     end
 end
 
-# The one package universe: `registry_provider` has no query-dependent parameters
-# left, so there is nothing to vary here.
-const reg = registry_provider(packages)
+# The one package universe. `allow_yanked` is the only parameter left, and it is
+# not a query knob: a yanked version is withdrawn, so the default universe simply
+# does not contain one, and `yanked` collects what was left out.
+const yanked = Dict{UUID,Vector{VersionNumber}}()
+const reg = registry_provider(packages; yanked)
 
 # `--allow-pre`'s dictionary: the zero uuid holds the default
 no_pre = Dict(UUID(0) => false)
@@ -69,10 +71,8 @@ function make_problem(
 )
     c = Dict{UUID,Any}(compat)
     c[JULIA_UUID] = julia
-    Resolver.Problem(reqs; compat = c, excludes = [
-        prerelease_exclusion(allow_pre),
-        yanked_exclusion(packages),
-    ])
+    Resolver.Problem(reqs; compat = c,
+        excludes = [prerelease_exclusion(allow_pre)])
 end
 
 # The old baked path, for the knobs that used to be applied by deleting versions
@@ -89,11 +89,18 @@ function bake(data::AbstractDict{P}, prob::Resolver.Problem{P}) where {P}
     return baked
 end
 
+# `Resolver.resolve`, with the diagnosis of an unsatisfiable result skipped and
+# the result mapped back to `nothing`. These tests compare resolves against one
+# another and against baked-data references, which wants a value that compares
+# by content -- a `Diagnosis` is freshly built each time, and two of those are
+# not the same object. The diagnostics have their own tests below.
+bare_resolve(args...; kws...) = Resolver.resolve(args...; diagnose = false, kws...)
+
 # Is the requirement set resolvable for the given Julia spec?
 function resolves(reqs::Vector{UUID}; julia::VersionSpec)
     prob = make_problem(reqs; julia)
     info = Resolver.pkg_info(reg, prob)
-    Resolver.resolve(info, prob) !== nothing
+    bare_resolve(info, prob) !== nothing
 end
 
 # Resolve a project with the given dependencies, `[compat]` body and command
@@ -127,7 +134,7 @@ function resolve_versions(
     cmd = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions $flags`
     if !success(pipeline(cmd; stdout = out, stderr = err))
         # tell "no solution" apart from "the script broke"
-        occursin("Unsatisfiable", String(take!(err))) ||
+        occursin("Unresolvable", String(take!(err))) ||
             error("failed: $cmd")
         return nothing
     end
@@ -228,7 +235,7 @@ end
         prob = make_problem([JSON, JULIA_UUID]; julia = VersionSpec("1.10"),
             compat = Dict(JSON => VersionSpec("0.20")))
         info = Resolver.pkg_info(reg, prob)
-        sol = Resolver.resolve(info, prob)
+        sol = bare_resolve(info, prob)
         @test sol !== nothing
         @test sol[JSON] ∈ VersionSpec("0.20")
         # the provider still offers the newer versions and the filter keeps
@@ -260,20 +267,20 @@ end
             baked = Dict(u => Resolver.PkgData(
                             sort(collect(d.versions); lt), d.depends, d.compat)
                          for (u, d) in data)
-            @test Resolver.resolve(data, prob; order) ==
-                  Resolver.resolve(baked, prob)
+            @test bare_resolve(data, prob; order) ==
+                  bare_resolve(baked, prob)
             # ... and the one T1 artifact answers under any of them
-            @test Resolver.resolve(info, prob; order) ==
-                  Resolver.resolve(baked, prob)
+            @test bare_resolve(info, prob; order) ==
+                  bare_resolve(baked, prob)
         end
         # a per-package ordering: only julia reversed, everything else canonical
         order = u -> u == JULIA_UUID ? (<) : (>)
         baked = Dict(u => Resolver.PkgData(
                         sort(collect(d.versions); lt = order(u)),
                         d.depends, d.compat) for (u, d) in data)
-        @test Resolver.resolve(info, prob; order) == Resolver.resolve(baked, prob)
-        @test Resolver.resolve(info, prob; order)[JULIA_UUID] <
-              Resolver.resolve(info, prob)[JULIA_UUID]
+        @test bare_resolve(info, prob; order) == bare_resolve(baked, prob)
+        @test bare_resolve(info, prob; order)[JULIA_UUID] <
+              bare_resolve(info, prob)[JULIA_UUID]
     end
 
     # Prerelease admission is a query constraint, not a property of the package
@@ -296,8 +303,8 @@ end
             excludes = [prerelease_exclusion(allow_pre)]
             prob = Resolver.Problem(reqs; excludes)
             old = bake(data, prob) # the versions deleted, as the provider used to
-            @test Resolver.resolve(data, prob) == Resolver.resolve(old, reqs)
-            @test Resolver.resolve(info, prob) == Resolver.resolve(old, reqs)
+            @test bare_resolve(data, prob) == bare_resolve(old, reqs)
+            @test bare_resolve(info, prob) == bare_resolve(old, reqs)
         end
 
         # and it is not inert: every Wine_jll in the registry is a prerelease, so
@@ -313,60 +320,65 @@ end
                                       deps = wine)
     end
 
-    # Yankedness is the same shape of fact as prerelease-ness -- a property of a
-    # version that a query may or may not accept -- so it is modeled the same
-    # way, as an exclusion kind, even though nothing yet offers the user a way to
-    # turn it off. The oracle is the old path, where the provider deleted yanked
-    # versions outright.
-    @testset "yanked versions are constrained, not deleted" begin
+    # Unlike prerelease-ness, yankedness is not a query knob: a yanked version is
+    # withdrawn, and the resolver must neither produce one nor propose one. Both
+    # hold by construction once the version is not in the universe, so the
+    # provider filters yanked versions out -- and records what it dropped, since
+    # "the versions your compat admits are yanked" is a story the filtering would
+    # otherwise lose.
+    @testset "yanked versions are pre-filtered from the universe" begin
         reqs = sort([COMPAT, LIBSODIUM_JLL, JULIA_UUID])
-        data = Resolver.pkg_data(reg, reqs)
-        yanked = yanked_exclusion(packages)
-        forbids = last(yanked)
 
         # `is_yanked` reads the registries, not the version number: Compat 4.0.0
         # is yanked from General and libsodium_jll's newest version is too
-        @test forbids(COMPAT, v"4.0.0")
-        @test !forbids(COMPAT, v"4.1.0")
-        @test forbids(LIBSODIUM_JLL, v"1.0.22+0")
-        @test !forbids(LIBSODIUM_JLL, v"1.0.21+0")
-        @test !forbids(JSON, v"0.21.4")
-        @test !forbids(JULIA_UUID, v"1.10.0") # not a registered package at all
-        @test !forbids(COMPAT, v"99.0.0")     # no such version
+        @test is_yanked(packages, COMPAT, v"4.0.0")
+        @test !is_yanked(packages, COMPAT, v"4.1.0")
+        @test is_yanked(packages, LIBSODIUM_JLL, v"1.0.22+0")
+        @test !is_yanked(packages, LIBSODIUM_JLL, v"1.0.21+0")
+        @test !is_yanked(packages, JSON, v"0.21.4")
+        @test !is_yanked(packages, JULIA_UUID, v"1.10.0") # not registered at all
+        @test !is_yanked(packages, COMPAT, v"99.0.0")     # no such version
 
-        # the provider offers them and the one artifact keeps them
-        @test v"4.0.0" in data[COMPAT].versions
+        # so the provider does not offer them, and the T1 artifact has none
+        data = Resolver.pkg_data(reg, reqs)
+        @test v"4.0.0" ∉ data[COMPAT].versions
+        @test v"1.0.22+0" ∉ data[LIBSODIUM_JLL].versions
         info = Resolver.pkg_info(reg, reqs)
-        @test v"4.0.0" in info[COMPAT].versions
+        @test v"4.0.0" ∉ info[COMPAT].versions
+        @test v"1.0.22+0" ∉ info[LIBSODIUM_JLL].versions
 
-        prob = Resolver.Problem(reqs; excludes = [yanked])
-        old = bake(data, prob) # the versions deleted, as the provider used to
-        @test Resolver.resolve(data, prob) == Resolver.resolve(old, reqs)
-        @test Resolver.resolve(info, prob) == Resolver.resolve(old, reqs)
-        # ... together with the prerelease kind, and under a reversed ordering
+        # ... and what it dropped is recorded, as explanation data
+        @test v"4.0.0" in yanked[COMPAT]
+        @test v"1.0.22+0" in yanked[LIBSODIUM_JLL]
+        @test !haskey(yanked, JSON)
+
+        # `--allow-yanked` is not a constraint being lifted, it is a different
+        # universe: the same provider built with it has the versions back
+        loose = registry_provider(packages;
+                                  allow_yanked = Dict(UUID(0) => true))
+        @test v"4.0.0" in Resolver.pkg_data(loose, [COMPAT])[COMPAT].versions
+        # and per package, exactly as `--allow-yanked=Compat` parses
+        one = registry_provider(packages; allow_yanked = Dict(COMPAT => true))
+        @test v"4.0.0" in Resolver.pkg_data(one, [COMPAT])[COMPAT].versions
+        @test v"1.0.22+0" ∉
+              Resolver.pkg_data(one, [LIBSODIUM_JLL])[LIBSODIUM_JLL].versions
+
+        # the filtered universe is exactly the old constrained one: resolving
+        # with yankedness as an exclusion kind over the unfiltered data gives
+        # what resolving the filtered data gives, prereleases and orderings and
+        # all
+        raw = Resolver.pkg_data(loose, reqs)
+        excl = Pair{Symbol,Any}[
+            :yanked => (u, v) -> !is_bundled(u, v) && is_yanked(packages, u, v)]
+        prob = Resolver.Problem(reqs; excludes = excl)
+        @test bare_resolve(raw, prob) == bare_resolve(data, reqs)
         both = Resolver.Problem(reqs;
-            excludes = [yanked, prerelease_exclusion(no_pre)])
-        @test Resolver.resolve(info, both) ==
-              Resolver.resolve(bake(data, both), reqs)
+            excludes = [excl[1], prerelease_exclusion(no_pre)])
+        plain = Resolver.Problem(reqs; excludes = [prerelease_exclusion(no_pre)])
+        @test bare_resolve(raw, both) == bare_resolve(data, plain)
         order = u -> (<)
-        @test Resolver.resolve(info, both; order) ==
-              Resolver.resolve(bake(data, both), reqs; order)
-
-        # The selector map names the kind, so a diagnostic could one day say
-        # "the only version that satisfies this is yanked". libsodium_jll's
-        # yanked version is its *newest*, so nothing dominates it and the filter
-        # has to keep it -- it is ruled out by clause. Compat's is not, so
-        # redundancy elimination deletes it, which is the filter subsuming the
-        # deletion the provider used to do.
-        work = Resolver.prepare_pkg_info(info, prob)
-        sat = Resolver.SAT(work, prob)
-        try
-            @test (:yanked, LIBSODIUM_JLL) in values(sat.sels)
-            @test v"1.0.22+0" in work[LIBSODIUM_JLL].versions
-            @test v"4.0.0" ∉ work[COMPAT].versions
-        finally
-            Resolver.finalize(sat)
-        end
+        @test bare_resolve(raw, both; order) ==
+              bare_resolve(data, plain; order)
 
         # end to end: libsodium_jll's newest registered version is yanked, so the
         # resolve must land on the one below it
@@ -468,14 +480,14 @@ end
         for julia in (VersionSpec("1.9"), VersionSpec("1.10"), VersionSpec("1.11"),
                       VersionSpec("1"), VersionSpec("1.10.8"))
             prob = make_problem(reqs; julia)
-            sol = Resolver.resolve(info, prob)
+            sol = bare_resolve(info, prob)
             @test !isnothing(sol)
             @test sol[JULIA_UUID] ∈ julia
             @test isempty(sol[JULIA_UUID].prerelease)
-            @test sol == Resolver.resolve(reg, prob)
+            @test sol == bare_resolve(reg, prob)
         end
         # and a bound no Julia satisfies is unsatisfiable, not silently widened
-        @test isnothing(Resolver.resolve(info,
+        @test isnothing(bare_resolve(info,
             make_problem(reqs; julia = VersionSpec("99"))))
     end
 
@@ -580,4 +592,144 @@ end
         @test tilde[STATISTICS] ∈ bundled_versions(VersionSpec("1.10"))[STATISTICS]
         @test tilde[JULIA_UUID] ∈ VersionSpec("1.10")
     end
+end
+
+@testset "unsat diagnostics (bin/resolve.jl)" begin
+    # bin/resolve.jl diagnoses an unsatisfiable resolve automatically: the
+    # report comes back from `resolve` itself, so all the script does is
+    # substitute package names for uuids and print it. BulkSMS (HTTP 0.x) and
+    # AnthropicClient (HTTP 1.x) require disjoint majors of HTTP.
+    julia = Base.julia_cmd()[1]
+    dir = mktempdir()
+    write(joinpath(dir, "Project.toml"), "[deps]\n")
+
+    err = IOBuffer()
+    cmd = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir
+           --extra-deps=BulkSMS,AnthropicClient --julia=1.11`
+    ok = success(pipeline(cmd; stderr = err))
+    report = String(take!(err))
+    @test !ok                            # unsatisfiable -> nonzero exit
+    @test occursin("Unresolvable", report)
+    @test occursin("cannot be satisfied together", report)
+    # uuids are substituted for names, and the contested dependency is named
+    @test occursin("BulkSMS", report)
+    @test occursin("AnthropicClient", report)
+    @test occursin("HTTP", report)
+    @test !occursin(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+                    report)
+    @test occursin("Verified fixes:", report)
+    @test occursin("drop requirement", report)
+    @test occursin("Upstream fixes:", report)
+
+    # a project compat bound nothing can satisfy is blamed on the bound, and
+    # relaxing it is offered as a fix
+    dir2 = mktempdir()
+    write(joinpath(dir2, "Project.toml"), """
+        [deps]
+        JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+        [compat]
+        JSON = "0.10"
+        """)
+    err2 = IOBuffer()
+    cmd2 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir2 --julia=1.11`
+    ok2 = success(pipeline(cmd2; stderr = err2))
+    report2 = String(take!(err2))
+    @test !ok2
+    @test occursin("your compat restricts JSON", report2)
+    @test occursin("relax your compat on JSON", report2)
+
+    # the admission knobs are constraints like any other, so they get facts
+    # and fixes like any other. Wine_jll has never had a non-prerelease
+    # release, so requiring it fails on the prerelease knob alone -- and
+    # `--allow-pre` is exactly the fix the report names.
+    err3 = IOBuffer()
+    cmd3 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir
+            --extra-deps=Wine_jll --julia=1.11`
+    ok3 = success(pipeline(cmd3; stderr = err3))
+    report3 = String(take!(err3))
+    @test !ok3
+    @test occursin("every version of Wine_jll is a prerelease", report3)
+    @test occursin("allow prereleases of Wine_jll", report3)
+    # ... and passing it really does resolve, to the version the fix promised
+    m = match(r"allow prereleases of Wine_jll\n\s*→ allows: ([^\n]*)", report3)
+    @test m !== nothing
+    @test occursin("Wine_jll", m[1])
+    vers = resolve_versions("", ["--allow-pre", "--julia=1.11"];
+                            deps = ["Wine_jll" => WINE_JLL])
+    @test vers !== nothing && haskey(vers, WINE_JLL)
+    @test occursin(string(vers[WINE_JLL]), m[1])
+
+    # Yanked versions are not in the universe at all, so no fix can ever propose
+    # accepting one -- by construction, with no policy flag anywhere. What that
+    # costs is the story: a bound admitting only yanked versions admits nothing,
+    # and "no versions" is not the answer. The provider kept the set it dropped,
+    # so the reporting layer says what really happened. libsodium_jll's newest
+    # release is yanked, and `=1.0.22` admits only it.
+    dir4 = mktempdir()
+    write(joinpath(dir4, "Project.toml"), """
+        [deps]
+        libsodium_jll = "$LIBSODIUM_JLL"
+
+        [compat]
+        libsodium_jll = "=1.0.22"
+        """)
+    err4 = IOBuffer()
+    cmd4 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir4 --julia=1.11`
+    ok4 = success(pipeline(cmd4; stderr = err4))
+    report4 = String(take!(err4))
+    @test !ok4
+    @test occursin(
+        r"the versions your compat on libsodium_jll admits are yanked \(1\.0\.22\S*\)",
+        report4)
+    @test !occursin("allow the yanked", report4)
+    # what it does offer is relaxing the bound, whose witness is then a version
+    # that is not yanked
+    @test occursin("relax your compat on libsodium_jll", report4)
+    @test occursin(r"→ allows:.*libsodium_jll 1\.0\.21", report4)
+
+    # ... and `--allow-yanked` is there for the user to reach for themselves:
+    # not a constraint lifted, a universe rebuilt with the versions back in
+    vers4 = resolve_versions("libsodium_jll = \"=1.0.22\"",
+                             ["--allow-yanked", "--julia=1.11"];
+                             deps = ["libsodium_jll" => LIBSODIUM_JLL])
+    @test vers4 !== nothing
+    @test vers4[LIBSODIUM_JLL] == v"1.0.22+0"
+    # the per-package shape of the flag works the same way, and is not global:
+    # allowing another package's yanked versions leaves this one unresolvable
+    @test resolve_versions("libsodium_jll = \"=1.0.22\"",
+                           ["--allow-yanked=libsodium_jll", "--julia=1.11"];
+                           deps = ["libsodium_jll" => LIBSODIUM_JLL]) == vers4
+    @test isnothing(
+        resolve_versions("libsodium_jll = \"=1.0.22\"",
+                         ["--allow-yanked=Compat", "--julia=1.11"];
+                         deps = ["libsodium_jll" => LIBSODIUM_JLL]))
+
+    # julia is modelled as a dependency edge, never a requirement: it is in
+    # every solution because packages need it, so no fix can offer to drop it
+    # and no witness list names it unless a story blamed it
+    dir5 = mktempdir()
+    write(joinpath(dir5, "Project.toml"), """
+        [deps]
+        Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+
+        [extras]
+        ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+
+        [compat]
+        ColorTypes = "0.9"
+        """)
+    err5 = IOBuffer()
+    cmd5 = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir5 --julia=1.11`
+    ok5 = success(pipeline(cmd5; stderr = err5))
+    report5 = String(take!(err5))
+    @test !ok5
+    # the right fix, named first, at versions from this decade
+    @test occursin("1. relax your compat on ColorTypes", report5)
+    @test occursin(r"1\. relax your compat on ColorTypes\n\s*→ allows:[^\n]*Makie 0\.2",
+                   report5)
+    # julia appears in the story, since its bound really is part of why ...
+    @test occursin("restricts julia", report5)
+    # ... but is never something a fix offers to drop
+    @test !occursin("drop requirement julia", report5)
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,11 +10,13 @@ makedocs(
     ),
     pages = [
         "Home" => "index.md",
+        "Diagnostics" => "diagnostics.md",
         "API" => "api.md",
         "Theory" => [
             "Setting" => "theory/setting.md",
             "The layered solution & filtering" => "theory/layered.md",
             "Pareto front optimality" => "theory/front.md",
+            "Diagnosing unsatisfiability" => "theory/diagnostics.md",
         ],
     ],
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,7 @@
 
 ```@docs
 resolve
+issatisfiable
 Problem
 ```
 
@@ -23,6 +24,7 @@ Resolver.UserCompat
 Resolver.Pin
 Resolver.Admission
 Resolver.Bound
+Resolver.Dependency
 ```
 
 ## Explaining a surprising success
@@ -46,6 +48,8 @@ Resolver.version_permutations
 Resolver.class_representatives
 Resolver.find_reachable
 Resolver.exclusion_masks
+Resolver.prepare_goal_info
+Resolver.Goal
 Resolver.diagnose
 Resolver.Relaxation
 Resolver.bound_story

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,6 +25,17 @@ Resolver.Admission
 Resolver.Bound
 ```
 
+## Explaining a surprising success
+
+A resolve can succeed and still leave a package below the best version its
+universe admits. [`holdbacks`](@ref Resolver.holdbacks) says what held it there.
+
+```@docs
+Resolver.holdbacks
+Holdback
+Resolver.Holdbacks
+```
+
 ## Internals
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,6 +5,26 @@ resolve
 Problem
 ```
 
+## Diagnosing unsatisfiability
+
+An unsatisfiable resolve returns a [`Diagnosis`](@ref) rather than a bare
+"no". Its parts are plain data, so a caller can render its own report — see the
+[guide](diagnostics.md) — and the theory that licenses computing them is on the
+[diagnostics theory](theory/diagnostics.md) page.
+
+```@docs
+Diagnosis
+Resolver.Conflict
+Resolver.Fix
+Resolver.UpstreamFix
+Resolver.Requirement
+Resolver.Uninstallable
+Resolver.UserCompat
+Resolver.Pin
+Resolver.Admission
+Resolver.Bound
+```
+
 ## Internals
 
 ```@docs
@@ -15,4 +35,9 @@ Resolver.version_permutations
 Resolver.class_representatives
 Resolver.find_reachable
 Resolver.exclusion_masks
+Resolver.diagnose
+Resolver.Relaxation
+Resolver.bound_story
+Resolver.rank_upstream!
+Resolver.superseded
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -27,6 +27,28 @@ Resolver.Bound
 Resolver.Dependency
 ```
 
+## Rendering a report yourself
+
+The `Diagnosis` retains everything; every opinionated choice in the default
+output is a documented function, with `show` as merely its first client. See
+the [guide](diagnostics.md#Rendering-your-own-reports).
+
+```@docs
+report
+Resolver.render_fact
+Resolver.render_action
+Resolver.blame_phrase
+Resolver.rank_upstream!
+Resolver.superseded
+```
+
+## Comparing solutions
+
+```@docs
+changes
+Resolver.Change
+```
+
 ## Explaining a surprising success
 
 A resolve can succeed and still leave a package below the best version its
@@ -53,6 +75,4 @@ Resolver.Goal
 Resolver.diagnose
 Resolver.Relaxation
 Resolver.bound_story
-Resolver.rank_upstream!
-Resolver.superseded
 ```

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -145,7 +145,8 @@ Only *forced* edges appear: a path some other version choice could route
 around explains nothing, which is what separates this from `pkg> why
 FillArrays` printing every path there is. And when the package is avoidable,
 there is no conflict at all — `resolve` returns the optimal FillArrays-free
-solution.
+solution, and [`changes`](@ref Resolver.changes) against the plain resolve is
+how you price it.
 
 ### Three tiers of effort
 
@@ -173,6 +174,69 @@ page](theory/diagnostics.md#Goal-safety:-which-universe-answers-which-question)
 proves what survives — arc consistency and the interchangeability collapse are
 goal-safe, reachability and redundancy are not — and the counterexample above
 is a test.
+
+## Rendering your own reports
+
+The `Diagnosis` retains *everything*. Every opinionated choice in the output
+above is a documented function, and the default `show` is merely its first
+client — no policy parameter was passed into the resolver to produce it, which
+is the point of the design. Three tiers of control:
+
+**Tier 1 — the default.** `show(io, MIME("text/plain"), d)`. Zero
+configuration; what `bin/resolve.jl` prints.
+
+**Tier 2 — the knobs.** [`report`](@ref) is what `show` calls, with its choices
+as arguments:
+
+```julia
+report(io, d;
+       max_upstream = 3,          # cap + "(N more …)"; typemax(Int) for all
+       demote_incidental = true,  # fold the "likewise …" facts into an aside
+       trim_witnesses = true,     # "→ allows:" lists the contested packages
+       labels = Dict("DataFrames" => :requested))   # source wording
+```
+
+**Tier 3 — your own layout, our sentences** (or neither). The helpers `show`
+is built from are public:
+
+```julia
+result = resolve(info, prob)
+if result isa Diagnosis
+    for c in result.conflicts
+        print_header(c.reqs, c.goal)
+        for f in c.chain
+            f isa Resolver.Bound && f.incidental && continue  # drop, not demote
+            println(io, "  • ", sprint(Resolver.render_fact, f, result))
+        end
+    end
+    fixes = result.fixes                       # already verified, already optimal
+    ups = filter(u -> maintained(u.bound.pkg), result.upstream)  # your knowledge
+    Resolver.rank_upstream!(ups)
+end
+```
+
+  * [`render_fact`](@ref Resolver.render_fact) writes one bullet's sentence;
+    [`render_action`](@ref Resolver.render_action) writes a fix's imperative
+    ("relax your compat on B") and [`blame_phrase`](@ref Resolver.blame_phrase)
+    the same fact as a noun ("your compat on B"). A client that wants its own
+    sentences reads the `Fact` fields instead — they are everything the
+    sentences are generated from.
+  * [`rank_upstream!`](@ref Resolver.rank_upstream!) sorts suggestions by how
+    *current* the blamed versions are: a new release relaxing its latest bound
+    is plausible, resurrecting an ancient range is not. Every `UpstreamFix`
+    carries its `bound` and a verified `solution`, so a client with better
+    knowledge — Pkg knows which packages are maintained — re-sorts or filters
+    by its own criteria and ignores ours.
+  * `Bound.incidental` is set during MUS construction when every version on the
+    bound's own side is already excluded by the user's constraints: the fact's
+    only job is closing off versions they cannot have anyway. Minimality is
+    preserved by the remaining facts *for the versions that matter*, so a
+    renderer may drop them outright.
+  * [`superseded`](@ref Resolver.superseded) is the prerelease-supersession
+    predicate fix enumeration already consults; it is public so a client
+    filtering its own suggestion lists applies the same policy.
+  * [`changes`](@ref) diffs two solutions into `Change(pkg, from, to)`, which
+    is how a feasible goal query gets its price tag.
 
 ## Modelling platform packages
 
@@ -297,11 +361,26 @@ looking for — as a single note:
 Note: julia is held back to 1.10.11 by your compat on LinearAlgebra; relaxing it allows julia 1.12.6.
 ```
 
-`--why` gives the reasoning for everything that landed below its best version,
-and `--why=<pkgs>` for named packages. Explaining one costs several solves, so
-`max_probes` bounds how many are probed; the result carries how many candidates
-that left over and the report ends with `(N more packages resolved below their
-best version, not examined)` rather than quietly showing a partial answer.
+`--explain` gives the reasoning for everything that landed below its best
+version. Explaining one costs several solves, so `max_probes` bounds how many
+are probed; the result carries how many candidates that left over and the
+report ends with `(N more packages resolved below their best version, not
+examined)` rather than quietly showing a partial answer.
+
+`--explain=<pkg>` answers whichever question is not already answered. If the
+package is below its best version, that is the holdback above. If it is not —
+because it is at its best, or because it is not in the solution at all — the
+only question left is whether you can have it, which is the goal
+`with = pkg`, and the answer is a price:
+
+```
+$ resolve.jl --explain=Statistics
+You can have Statistics, at this price:
+  • Statistics 1.11.1 added
+```
+
+`--explain=<pkg>@<version>` asks the version goal instead, and an impossible
+one comes back as a full diagnosis rather than a bare refusal.
 
 ## Why this is trustworthy
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -95,9 +95,84 @@ Verified fixes:
 Yankedness is deliberately *not* one of them: see
 [below](#Modelling-withdrawn-versions).
 
-Computing a diagnosis costs several extra solves. When you only need the
-verdict — a satisfiability probe in a loop, say — pass `diagnose = false` and
-get back `nothing`.
+## Asking for something: goals
+
+`resolve` takes two more keywords, and they change the *question* rather than
+the problem:
+
+```julia
+resolve(info, prob; with = "AnthropicClient")          # can I have this?
+resolve(info, prob; with = "DataFrames" => v"1.8.2")   # ... at this version?
+resolve(info, prob; without = "FillArrays")            # can I avoid this?
+resolve(info, prob; with = ["CUDA", "MKL"], without = "FillArrays")
+```
+
+The return contract does not change: the optimal solution satisfying the
+problem *and* the goal, or a `Diagnosis` of what it would take.
+
+```
+resolve(info, prob; with = "AnthropicClient")     # project already has BulkSMS
+```
+```
+Unsatisfiable — 1 conflict, 1 fix:
+Conflict 1: the goal and BulkSMS cannot be satisfied together.
+  • you require BulkSMS
+  • AnthropicClient (all versions) works with HTTP only at 1.0.1–1.11.0
+  • BulkSMS (all versions) works with HTTP only at 0.8.19
+Verified fixes:
+  1. drop requirement BulkSMS
+     → allows: AnthropicClient 0.1.0, HTTP 1.11.0
+```
+
+The whole difference between `with = "AnthropicClient"` and adding it to
+`prob.reqs` is one line of that report: the problem's constraints are
+*negotiable*, and a fix may propose relaxing any of them; the goal is the
+*fixed ask*, so "drop requirement AnthropicClient" can never be offered. The
+header says which conflicts the goal is part of.
+
+A `without` goal's story is a chain of forced dependencies rather than of
+incompatible pairs — nothing conflicts with anything, the package is simply
+unavoidable:
+
+```
+Conflict 1: the goal and Makie cannot be satisfied together.
+  • you require Makie
+  • Makie (all versions) requires GeometryBasics
+  • GeometryBasics (all admissible versions) requires FillArrays
+```
+
+Only *forced* edges appear: a path some other version choice could route
+around explains nothing, which is what separates this from `pkg> why
+FillArrays` printing every path there is. And when the package is avoidable,
+there is no conflict at all — `resolve` returns the optimal FillArrays-free
+solution.
+
+### Three tiers of effort
+
+Computing a diagnosis costs several extra solves, and so does the optimizing
+descent. Three calls answer the same question with more or less work:
+
+| call | cost | answer |
+|:--|:--|:--|
+| [`issatisfiable(data, prob; with)`](@ref issatisfiable) | one solve | `Bool` |
+| `resolve(data, prob; with, diagnose = false)` | one solve + descent | the solution, or `nothing` |
+| `resolve(data, prob; with)` | + explanation | the solution, or a `Diagnosis` |
+
+Nothing but the effort separates them; the verdicts agree. A UI greying out an
+upgrade button wants the first, a caller that needs the versions the second,
+and only the one that will actually print a report pays for the third.
+
+### Which universe answers a goal
+
+A goal query runs on a sub-instance built from the T1 artifact, not on the
+per-resolve one, because the per-resolve filter prunes exactly the escape
+routes a goal needs. `A→B`, `B@3.1→X`, `B@2.3→∅`, no conflicts: reachability
+keeps only `B@3.1`, so the prepared instance calls X unavoidable while the raw
+problem avoids it via `B@2.3`. The [theory
+page](theory/diagnostics.md#Goal-safety:-which-universe-answers-which-question)
+proves what survives — arc consistency and the interchangeability collapse are
+goal-safe, reachability and redundancy are not — and the counterexample above
+is a test.
 
 ## Modelling platform packages
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -1,0 +1,204 @@
+# Diagnostics
+
+A resolve that fails does not just say so. `resolve` returns the
+[`Diagnosis`](@ref) itself, and printing it gives a report:
+
+```julia-repl
+julia> resolve(data, ["A", "B"])
+Unsatisfiable — 1 conflict, 2 fixes:
+Conflict 1: A, B cannot be satisfied together.
+  • you require A
+  • you require B
+  • A (all versions) works with C only at 1
+  • B (all versions) works with C only at 2
+
+Verified fixes:
+  1. drop requirement B
+     → allows: A 1, C 1
+  2. drop requirement A
+     → allows: B 1, C 2
+
+Upstream fixes:
+  • a release of A or C relaxing their compat on each other
+    → allows: A 1, B 1, C 2
+  • a release of B or C relaxing their compat on each other
+    → allows: A 1, B 1, C 1
+```
+
+Three sections, in decreasing order of how much you can do about them.
+
+**Conflicts** are independent: each is a minimal set of requirements that
+cannot be satisfied together, and fixing one does nothing for the others. The
+bullets tell that conflict's story, ordered from the requirements outward
+along the dependency graph.
+
+**Verified fixes** are global — each one repairs *every* conflict at once —
+and minimal: none of them relaxes a strict superset of what another does.
+Each was checked by re-resolving, and the versions after `→ allows:` are what
+you would actually get, restricted to the packages the conflicts implicate.
+(The complete assignment is on the `Fix`, for programmatic use.)
+
+**Upstream fixes** are the ones you cannot make yourself: a single new
+release loosening one incompatibility would resolve that conflict. A tangled
+conflict can produce a dozen of these, so they are ranked — by how current the
+blamed versions are, then by how good the result is — and at most three are
+printed, with a count of the rest. The structured `Diagnosis` keeps them all.
+
+A story line may also be followed by an indented `(likewise for …)`. Those are
+the facts a *minimal* conflict needs in order to close off versions your own
+constraints already exclude: real, but not what you are reading for.
+
+## The API
+
+```julia
+sol = resolve(data, reqs; compat, pins)
+if sol isa Diagnosis
+    show(stdout, MIME("text/plain"), sol)  # the report above
+    for fix in sol.fixes
+        # fix.actions  :: Vector{Fact}
+        # fix.solution :: Dict{P,V}
+    end
+end
+```
+
+Everything is plain data, so a caller — Pkg, say — can render its own report
+instead. The pieces:
+
+| type | what it is |
+|:--|:--|
+| [`Diagnosis`](@ref) | requirements, conflicts, fixes, and the version lists to render against |
+| [`Resolver.Conflict`](@ref) | one independent conflict: its requirement cluster, its fact chain, its upstream fixes |
+| [`Resolver.Fix`](@ref) | a set of `Fact`s to relax, and the resolution that follows |
+| [`Resolver.UpstreamFix`](@ref) | an incompatibility a new release could dissolve, and what would follow |
+
+and the `Fact` kinds a chain or a fix is built from:
+[`Resolver.Requirement`](@ref), [`Resolver.Uninstallable`](@ref),
+[`Resolver.Pin`](@ref), [`Resolver.UserCompat`](@ref),
+[`Resolver.Admission`](@ref), [`Resolver.Bound`](@ref).
+
+An [`Resolver.Admission`](@ref) is an *admission knob* — the `excludes` of a
+[`Problem`](@ref), which is where "no prereleases" lives. Those are constraints
+like any other, so they get facts and fixes like any other:
+
+```
+Conflict 1: Wine_jll cannot be satisfied.
+  • you require Wine_jll
+  • every version of Wine_jll is a prerelease, which is not allowed
+
+Verified fixes:
+  1. allow prereleases of Wine_jll
+     → allows: julia 1.11.9, Wine_jll 7.0.0-rc3+1
+  2. drop requirement Wine_jll
+     → allows: julia 1.11.9
+```
+
+Yankedness is deliberately *not* one of them: see
+[below](#Modelling-withdrawn-versions).
+
+Computing a diagnosis costs several extra solves. When you only need the
+verdict — a satisfiability probe in a loop, say — pass `diagnose = false` and
+get back `nothing`.
+
+## Modelling platform packages
+
+Some packages are not the user's choice: julia is present in every resolution
+whatever anyone wants, and "drop requirement julia" is not advice. That is a
+*modelling* question, not a policy knob — model such a package as a
+**dependency edge**, never as a requirement. `bin/resolve.jl` does: the
+registry provider gives every package version a dependency on `julia`, so
+julia is in the solution because things need it, and cannot be dropped because
+nothing "requires" it in the sense a fix could undo. Witness lists stay quiet
+about it for the same reason: a report names the requirements and the packages
+some story blames, and a dependency edge is neither.
+
+The one knob left is wording. `Problem(…; labels)` gives a compat entry a
+source flavour, so a bound from `Pkg.add(name, version)` reads "you requested
+DataFrames at 1.7" and "relax the version you requested for DataFrames"
+instead of calling it project compat. Unknown labels render neutrally.
+
+One suggestion is filtered without being asked for: admitting prereleases of a
+package is only proposed when the prerelease you would end up with has not been
+*superseded* by a release of the same base version — nobody should be told to
+install `1.2.3-alpha1` when `1.2.3` is out.
+
+## Modelling withdrawn versions
+
+A yanked version is the other thing no report should ever propose — and the way
+to guarantee that is not a policy flag either. Model a withdrawn version by
+**leaving it out of the universe**: the provider filters yanked versions before
+the resolver sees them, so no solution contains one and no fix can name one, by
+construction rather than by rule. `bin/resolve.jl` does exactly this, with
+`--allow-yanked[=<pkgs>]` rebuilding the universe with them back in for anyone
+who wants them.
+
+What pre-filtering costs is a *story*, and that is recovered at the rendering
+layer rather than by putting the constraint back. A bound admitting only yanked
+versions admits nothing at all, and "no versions" is not the answer anyone
+wants, so the provider keeps the set it dropped as explanation data:
+
+```
+Conflict 1: libsodium_jll cannot be satisfied.
+  • you require libsodium_jll
+  • your compat restricts libsodium_jll to no versions
+
+Verified fixes:
+  1. relax your compat on libsodium_jll
+     → allows: julia 1.11.9, libsodium_jll 1.0.21+0
+Note: the versions your compat on libsodium_jll admits are yanked (1.0.22+0);
+--allow-yanked accepts them anyway.
+```
+
+## Two things the report will not do
+
+**It relaxes a package's constraints together, not one at a time.** A compat
+bound, a pin and an admission knob on the same package are one relaxable unit.
+That is not conservatism: the three share one row in the resolver's
+bookkeeping, and relaxing part of it is exactly the counterexample of
+[Proposition D1′](theory/diagnostics.md#Below-column-closure-it-is-false) —
+the answer would be wrong. Packages with a single constraint source, which is
+almost all of them, are unaffected.
+
+A fix does still name only the sources that rule out a version the instance
+still has; one that forbids nothing there had no part in the relaxation, so
+asking you to change it would be noise. That is why the Wine_jll example above
+names nothing besides the prerelease knob.
+
+**It blames incompatible *pairs*, not compat declarations.** A report says
+"A (all versions) works with C only at 1", not "A declares compat C = 1", and
+an upstream suggestion names both sides. Two reasons, and either alone would
+be decisive: package info records compatibility symmetrically, so by the time
+a problem reaches the resolver's instance which side declared a bound is no
+longer recoverable; and per-declaration relaxation is not
+[column-closed](theory/diagnostics.md#Relaxation-stability) either.
+
+## Why this is trustworthy
+
+The diagnosis runs on the very SAT instance the resolve failed on — the
+prepared one, collapsed to interchangeability-class representatives and then
+filtered, with the user's constraints popped back into assumptions. That
+instance was built for a different question, so the
+[theory page](theory/diagnostics.md) proves it answers this family of
+questions correctly: satisfiability verdicts *and* layered answers are
+preserved under every relaxation of the kind a diagnosis performs. The
+verified solutions attached to fixes are a consequence of the stronger,
+answer-preserving half.
+
+The collapse is part of what has to be justified, not a complication to be
+waved away: it deletes versions, and diagnosis then asks questions in which
+some of the constraints that motivated those deletions are switched off.
+Refining the classes by the exclusion mask before choosing representatives is
+what keeps a forbidden version in the instance, so that relaxing its constraint
+can bring it back.
+
+Bound-level detail needs to relax conflicts the production instance keeps as
+hard clauses, so it runs on a small sub-instance restricted to the conflict's
+dependency closure. That restriction is exact, not an approximation
+([Lemma D3](theory/diagnostics.md#Closure-exactness)). It costs a solve per
+incompatibility, so very large closures are skipped rather than paid for: the
+report then stops at requirement level, which for a hub package's conflict is
+usually the whole story anyway.
+
+## From the command line
+
+`bin/resolve.jl` diagnoses automatically. An unresolvable project prints the
+report to stderr, with uuids replaced by package names, and exits nonzero.

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -171,6 +171,63 @@ a problem reaches the resolver's instance which side declared a bound is no
 longer recoverable; and per-declaration relaxation is not
 [column-closed](theory/diagnostics.md#Relaxation-stability) either.
 
+## When the resolve *succeeds* and still surprises
+
+A resolution can be correct and still not be what you expected. A user compat
+bound on a non-upgradable stdlib steers the julia choice — a julia release is
+compatible with exactly the stdlib versions it bundles — so a leftover
+`LinearAlgebra = "~1.10"` quietly pins the whole toolchain to julia 1.10, and
+nothing in a successful resolve says so.
+
+[`holdbacks`](@ref Resolver.holdbacks) explains that:
+
+```julia
+info = prepare_pkg_info(pkg_info(data, prob), prob)
+sol  = resolve_prepared(info, prob)
+for h in holdbacks(info, prob, sol, ["julia"])
+    show(stdout, MIME("text/plain"), h)
+end
+```
+
+```
+julia resolved to 1.10.11; 1.12.6 is available.
+  • you require LinearAlgebra
+  • your compat restricts LinearAlgebra to 1.10.0–1.10.11
+  • julia 1.12.6 works with LinearAlgebra only at 1.12.0
+  ⇒ held back by your compat on LinearAlgebra.
+  relax your compat on LinearAlgebra → allows: julia 1.12.6, LinearAlgebra 1.12.0
+```
+
+It is the satisfiable-side sibling of everything above, and reuses it: assume
+the better version on the instance, get an unsatisfiable answer, and the same
+biased group-MUS names the responsible constraints. The fix is verified by the
+same optimizing descent, so its versions are the ones you would really get —
+`Resolver.summarize` gives the same thing as one line.
+
+Three things it will not do. It does not report a package whose version is
+merely what the priority order settled on — if the better version was feasible
+all along there is no constraint to blame, and inventing one would be worse
+than silence. It measures "best" against the versions the problem *admits*, not
+against the raw universe: a prerelease this query would never accept is not an
+option being missed, and advertising it would bury the bound that is the real
+story. And when nothing the user set is to blame — the version is held back by a
+bound only an upstream release could move — it says `nothing you can change
+would move it` rather than manufacturing a fix.
+
+From the command line, `bin/resolve.jl` explains julia automatically whenever
+it lands below its best admissible version — that is the surprise nobody went
+looking for — as a single note:
+
+```
+Note: julia is held back to 1.10.11 by your compat on LinearAlgebra; relaxing it allows julia 1.12.6.
+```
+
+`--why` gives the reasoning for everything that landed below its best version,
+and `--why=<pkgs>` for named packages. Explaining one costs several solves, so
+`max_probes` bounds how many are probed; the result carries how many candidates
+that left over and the report ends with `(N more packages resolved below their
+best version, not examined)` rather than quietly showing a partial answer.
+
 ## Why this is trustworthy
 
 The diagnosis runs on the very SAT instance the resolve failed on — the

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,8 +3,11 @@
 A package version resolver built on a real SAT solver (PicoSAT). Given
 package data — versions, dependencies, and compatibility constraints — and a
 set of required packages, [`resolve`](@ref) returns a single optimal solution
-mapping each needed package to a version, or `nothing` when the requirements
-cannot be satisfied.
+mapping each needed package to a version.
+
+When the requirements cannot be satisfied it returns a [`Diagnosis`](@ref)
+instead: the independent conflicts, the facts behind each of them, and a menu
+of verified fixes. See the [diagnostics guide](diagnostics.md).
 
 What "optimal" means, precisely, and why the resolver's aggressive problem
 filtering provably does not change the answer, is worked out in the Theory
@@ -19,6 +22,9 @@ section:
   declarative notion of optimality that was fully worked out and ultimately
   set aside; its theorems and counterexamples illuminate why the layered
   semantics and its filter fit together as well as they do.
+- [Diagnosing unsatisfiability](theory/diagnostics.md) — how far the filtered
+  instance may be re-interrogated once a resolve has failed, and the exact
+  granularity at which that stops being sound.
 
 For the package's motivation and project status, see the
 [README](https://github.com/StefanKarpinski/Resolver.jl).

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -393,6 +393,88 @@ is generally larger than the support of any single solution — and for a
 cluster rooted at a hub package it can be a substantial fraction of the
 universe. Exactness is not the same as smallness.
 
+## Goal safety: which universe answers which question
+
+Everything above licenses relaxation queries on the *prepared* universe
+``F(D)`` — and every one of those queries asks about **optimal** solutions,
+which is what preparation preserves. A goal does not.
+
+A goal query asks whether some solution has a property: that a package is
+present, absent, or at a named version. It does not ask about optimal
+solutions, and the two preparation passes that shrink hardest each delete
+versions on the grounds that no optimal solution uses them.
+
+!!! warning "Reachability and redundancy are not goal-safe"
+    Take ``A \to B``, ``B@3.1 \to X``, ``B@2.3 \to \varnothing``, with no
+    conflicts anywhere and ``R_0 = \{A\}``. Reach seeds ``B@3.1`` and nothing
+    degrades it, so ``F(D)`` has only ``B@3.1`` and *every* solution of
+    ``F(D)`` contains ``X``. In ``D`` the solution ``\{A@1, B@2.3\}`` avoids
+    it. So on ``F(D)`` the goal ``\lnot X`` is unsatisfiable and on ``D`` it
+    is satisfiable: not a worse answer, a wrong one.
+
+    Redundancy fails the same way in the other direction. If ``A@2`` (better)
+    depends on nothing and ``A@1`` depends on ``X``, then ``A@2`` dominates
+    ``A@1`` and elimination deletes it — after which the goal ``X`` present is
+    unsatisfiable, though ``\{A@1, X\}`` witnesses it in ``D``.
+
+    Both are Lemma R and the redundancy theorem behaving exactly as stated.
+    Neither ever claimed to preserve non-optimal solutions, and a goal is a
+    question about the whole solution set.
+
+What *is* goal-safe is the T1 half of preparation, and it is safe for a
+reason, not by luck:
+
+!!! note "Proposition G (T1 preserves every goal's witnesses)"
+    Let ``T_1(D)`` be ``D`` with (i) arc-consistency applied, and (ii) each
+    package's versions collapsed to one representative per
+    interchangeability class, plus any versions named by value. Then a
+    solution of ``D`` witnessing a presence or absence goal exists iff one of
+    ``T_1(D)`` does, and a solution assigning a named version ``v`` exists iff
+    one of ``T_1(D)`` does.
+
+    *Proof.* (i) Arc consistency deletes ``p@v`` only when ``p@v`` occurs in
+    no solution at all — it depends, transitively, on a package with no
+    installable version. A version in no solution witnesses no goal, and
+    deleting it removes no solution.
+
+    (ii) Two versions are in one interchangeability class when their rows in
+    the conflict matrix are equal, and the matrix's columns include the
+    *dependency* columns. So class members have identical dependency sets:
+    swapping ``p@v`` for its representative ``p@v'`` in a solution changes
+    nothing about which packages the solution contains, and preserves
+    conflict-freedom by row equality (Theorem 3's swap argument). A solution
+    containing (or avoiding) ``X`` therefore maps to one containing (or
+    avoiding) ``X``. A package that avoids ``X`` can never hide inside a class
+    whose representative needs it, because that would be two rows differing
+    in a dependency column.
+
+    For a goal naming a version by value the swap argument is exactly what
+    does *not* apply — the sibling is indistinguishable to every constraint
+    but it is not the version asked for — so those versions are excluded from
+    the collapse and survive as representatives of their own. ∎
+
+Composing Proposition G with Lemma D3: a goal query runs on ``T_1(D)``
+restricted to the closure of ``R_0`` together with the goal's own packages.
+That is `prepare_goal_info` plus the closure the T1 artifact is already built
+over. The sub-instance is bigger than the per-resolve one — the two hardest
+passes are off — which is the price of asking a different question.
+
+Two consequences worth stating plainly:
+
+- **Better-version goals are the exception**, and they are why the holdback
+  probe needs none of this. Reach keeps version *prefixes*: if the resolve
+  landed on ``p@i``, every version better than ``p@i`` is present in ``F(D)``
+  by construction. "Is a better ``p`` possible" is therefore answerable on the
+  instance the resolve already has in hand, which is what makes the automatic
+  julia check nearly free.
+- **The bound-level sub-instances follow the same rule.** With a goal in
+  force, `bound_story`'s per-cluster instance keeps the filter only when the
+  goal is a pure presence ask — whose packages it has already made
+  requirements of, so reach keeps their prefix. Anything else turns the two
+  passes off there too, and the closure budget may then decline the
+  sub-instance; the report stops at requirement level rather than answering
+  from the wrong universe.
+
 ## What the implementation does with this
 
 - The production instance asserts the user-constraint selectors as unit

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -1,0 +1,445 @@
+# Diagnosing unsatisfiability
+
+When a resolve fails, the resolver explains why: which requirements clash,
+which constraints are implicated, and what relaxations would make the
+problem solvable. Every one of those questions is answered by *more SAT
+queries on the very instance that just failed* — the prepared production
+instance, with the user's constraints turned back into assumptions.
+
+That is a strong claim, because the instance was built for one purpose (to
+resolve one problem) and is now being asked a family of different
+questions. This page works out exactly how far it is allowed. The answer is
+not "always": preparation is stable under relaxations of a certain
+*granularity* and demonstrably unstable below it, and that boundary is what
+determines the units a diagnosis is allowed to blame.
+
+Three results:
+
+1. **Requirement-subset queries** are already licensed by the existing
+   [requirement-monotonicity proposition](layered.md#Preprocessing-for-caching).
+2. **Relaxation stability** (new here) covers switching off *constraint
+   groups* — but only column-closed ones. A companion proposition shows the
+   finer granularity really does fail, with a four-version counterexample.
+3. **Closure exactness** licenses answering a cluster's questions on a
+   sub-instance restricted to that cluster's dependency closure.
+
+## Relaxations
+
+Fix a problem ``D`` as in the [setting](setting.md), with requirements
+``\mathrm{reqs}``. Designate a finite family ``G`` of **relaxable conflict
+groups**: each ``g \in G`` is a set of conflicting version pairs. Conflicts
+in no group are **permanent**.
+
+A **relaxation** is a pair ``\sigma = (\mathrm{reqs}_0, G_0)`` with
+``\mathrm{reqs}_0 \subseteq \mathrm{reqs}`` and ``G_0 \subseteq G``. The
+**relaxed problem** ``D|\sigma`` has the same packages, versions and
+dependency sets as ``D``; its requirements are ``\mathrm{reqs}_0``; and its
+conflict relation is the permanent conflicts together with
+``\bigcup_{g \in G_0} g``. Groups may overlap: a pair asserted by two groups
+survives until both are switched off, which is exactly what the
+selector-guarded encoding does.
+
+Two families of group matter in practice:
+
+- **User-constraint groups.** A compat bound or a pin is read as a *virtual
+  package* with one always-present version whose conflict rows are the
+  versions the constraint forbids (see `Problem`). Switching one off is
+  "what if the user relaxed this?".
+- **Third-party bound groups.** A registry compatibility declaration
+  contributes a rectangle of conflicting pairs. Switching one off is "what
+  if upstream released a version that loosened this?".
+
+Write ``\mathrm{Lay}(D, \sigma)`` for the layered solution of ``D|\sigma``
+(undefined when ``D|\sigma`` is unsatisfiable), and ``F`` for **preparation**
+— everything between the raw universe and the SAT instance, run **once**, with
+the full requirement set and every group active. Following
+[`pkg_info`](@ref Resolver.pkg_info) and
+[`prepare_pkg_info`](@ref Resolver.prepare_pkg_info), that is four steps:
+
+1. **arc consistency**, deleting versions one of whose dependencies has no
+   versions at all;
+2. the **interchangeability collapse**, keeping one representative of each
+   class of versions nothing can tell apart (refined by ``\sigma``'s own
+   exclusions — see below);
+3. **reachability**, keeping a prefix of each package's versions; and
+4. **redundancy elimination**, deleting dominated versions,
+
+with 3 and 4 alternating to a fixpoint. Each deletes versions and nothing
+else, which is what lets them be treated uniformly below.
+
+## Requirement subsets
+
+The existing
+[proposition on filtering for a larger requirement set](layered.md#Preprocessing-for-caching)
+and its corollary already say that filtering seeded with ``\mathrm{reqs}``
+preserves the layered answer — and hence the satisfiability verdict — of
+every ``\mathrm{reqs}_0 \subseteq \mathrm{reqs}``. That licenses the
+requirement-level half of a diagnosis: clustering the requirements into
+independent conflicts, and testing whether dropping some of them helps.
+Nothing new is needed.
+
+What it does not cover is the other half — lifting a compat bound, a pin or
+a registry bound. Those change the *conflict relation*, which is what the
+preparation's reachability prefixes and domination tests are computed
+against — and, in the case of the collapse, what its class representatives are
+chosen from.
+
+## Reachability is stable; redundancy is the delicate half
+
+!!! note "Lemma R (reachability is monotone in seeds and conflicts)"
+    Let ``D`` and ``D'`` have the same packages, versions and dependency
+    sets, with conflict relation ``\otimes' \subseteq \otimes`` and
+    requirement seeds ``\mathrm{reqs}' \subseteq \mathrm{reqs}``. Then
+    ``r'(p) \le r(p)`` for every package ``p``, where ``r`` is the reach
+    prefix map and saturation counts as ``+\infty``.
+
+    *Proof.* The reach set is the least fixpoint of the derivation system of
+    [Filtering](layered.md#Filtering): seed requirements' first versions;
+    first versions of kept dependencies; conflict-driven degradation of both
+    sides of a conflict between reachable versions; and the saturation rule
+    pushing dependents of a saturated package. Every rule instance of the
+    primed system is a rule instance of the unprimed one — the seeds are a
+    subset, the conflict premises are a subset, and the dependency premises
+    are identical. So every primed derivation replays verbatim, and the
+    primed least fixpoint is contained in the unprimed one. ∎
+
+The exclusion rule for user constraints ("a reachable excluded version can
+never be a resting point") is the ordinary conflict rule applied to the
+virtual package's always-present version, so the same argument covers it.
+Lemma R asks nothing of the *shape* of the removed conflicts: it holds for
+**arbitrary** group removal.
+
+Redundancy elimination does not. It deletes ``q@j`` when some better kept
+``q@i`` has a *subset* of its constraints, and a relaxation that clears a
+constraint of ``q@i`` without clearing the corresponding constraint of
+``q@j`` destroys the inclusion. Whether that can happen depends entirely on
+the shape of the group:
+
+!!! note "Definition (column-closed group)"
+    Redundancy compares two versions of a package column by column of that
+    package's constraint matrix: one column per dependency, one per
+    ``(\text{partner package}, \text{partner version})`` pair, and one for
+    the user-constraint virtual package. A group ``g`` is **column-closed**
+    if switching it off clears, in every package's matrix, a set of *whole
+    columns* — never part of one.
+
+Two natural granularities are column-closed, and they are the coarsest
+sensible ones:
+
+- **Per package, for user constraints.** All of a package's user
+  constraints together — its compat bound *and* its pin — are exactly its
+  exclusion column.
+- **Per interacting pair, for third-party bounds.** All conflicts between
+  packages ``p`` and ``q`` are exactly ``q``'s whole column block in ``p``'s
+  matrix and ``p``'s whole block in ``q``'s.
+
+!!! note "Theorem D1 (relaxation stability)"
+    Suppose every group in ``G`` is column-closed. Then for every relaxation
+    ``\sigma``,
+
+    ```math
+    \mathrm{Lay}(F(D), \sigma) \;=\; \mathrm{Lay}(D, \sigma),
+    ```
+
+    both sides being undefined together. In particular ``F(D)|\sigma`` is
+    satisfiable iff ``D|\sigma`` is.
+
+    *Proof.* If ``D|\sigma`` is unsatisfiable, so is ``F(D)|\sigma``: its
+    models are a subset. So assume ``D|\sigma`` is satisfiable. We show each
+    pass of preparation — each of which deletes versions from ``D``, and
+    hence induces the same deletion on ``D|\sigma`` — keeps every version of
+    the current ``\sigma``-answer, and conclude with
+    [Theorem 4](layered.md#Theorem-4:-reduction-invariance-—-the-optimization-license)
+    applied to ``D|\sigma`` after each pass.
+
+    *Arc consistency.* The pass deactivates a version exactly when one
+    of its dependencies has no version at all, iterated to a fixpoint. The
+    criterion mentions no conflicts and no requirements, so it is
+    ``\sigma``-independent, and such a version appears in no model of
+    ``D|\sigma`` either — dependency edges must be satisfied whatever the
+    conflict relation.
+
+    *The collapse.* The pass keeps, of each interchangeability class, the
+    member the active order ranks best — where the classes are the registry's
+    row-equality classes
+    ([`version_classes`](@ref Resolver.version_classes)) *refined by the
+    exclusion mask*, so that a class splits into its forbidden and its
+    admissible members and each half keeps a representative
+    ([`class_representatives`](@ref Resolver.class_representatives)).
+
+    Two things have to hold. First, the deletion is answer-preserving on the
+    unrelaxed problem: class members have identical constraint rows, hence
+    dominate each other, so Theorem 6 applies — this is the
+    [interchangeability lemma](layered.md#Preprocessing-for-caching), and it is
+    why the pass is legitimate at all.
+
+    Second, it survives ``\sigma``. Let ``L`` be a class of ``D|\sigma``'s
+    partition — the partition of the *relaxed* problem, refined by ``\sigma``'s
+    exclusion mask. Two claims:
+
+    * ``L`` is a union of classes of the unrelaxed refined partition. The
+      registry-level classes coarsen under ``\sigma`` (removing conflict
+      columns can only merge row-equality classes, never split them), and the
+      exclusion refinement coarsens too, because ``\sigma`` clears the mask
+      for whole packages at a time — the mask is one column, and column-closure
+      is exactly the hypothesis that ``\sigma`` takes all of it or none of it.
+    * Hence the best member of ``L`` in the active order is the best member of
+      one of those finer classes, and is therefore kept.
+
+    So every ``\sigma``-class retains its best member, and the members that
+    are gone are dominated by it *under ``\sigma``* (they are in the same
+    ``\sigma``-class, so their rows agree there too). Theorem 6 applied to
+    ``D|\sigma`` says the ``\sigma``-layered trace never chooses them.
+
+    Note where column-closure did the work: were ``\sigma`` allowed to clear
+    *part* of a package's exclusion column, the refinement could split a
+    ``\sigma``-class between a forbidden and an admissible half whose
+    representative is the wrong one, and the best ``\sigma``-admissible member
+    could be gone. That is the collapse's version of Proposition D1′ below, and
+    it has the same cause.
+
+    *Reachability.* Let ``r`` be the prefix map the pass computes with the
+    full seed set and every group active, and ``r_\sigma`` the map it would
+    compute on ``D|\sigma``. By Lemma R, ``r_\sigma \le r``. By
+    [Theorem 5](layered.md#Theorem-5:-the-filter-preserves-the-answer)
+    applied to ``D|\sigma``, every version of the ``\sigma``-answer lies
+    within ``r_\sigma``, hence within ``r``.
+
+    *Redundancy elimination.* The pass deletes ``q@j`` when some kept
+    ``q@i`` with ``i < j`` satisfies ``X[i,c] \Rightarrow X[j,c]`` for every
+    active column ``c``. Because every group is column-closed, passing to
+    ``\sigma`` clears a set ``C_\sigma`` of whole columns — *the same*
+    columns for ``i`` and for ``j``. Restricting an implication that holds
+    columnwise to a subset of the columns leaves it holding, so ``q@j`` is
+    dominated in ``D|\sigma`` too, and
+    [Theorem 6](layered.md#Theorem-5:-the-filter-preserves-the-answer)
+    applied to ``D|\sigma`` says the ``\sigma``-layered trace never chooses
+    it. The test's dropped-partner exemption — conflicts whose partner
+    version reachability already deleted are ignored — is
+    ``\sigma``-independent, since which versions were deleted is decided by
+    the full-constraint filter and not by ``\sigma``; it drops the same
+    columns on both sides.
+
+    *Iteration.* Each pass preserves the ``\sigma``-answer of the problem it
+    runs on, so Theorem 4 applies after each and the answers chain — through
+    the collapse as much as through the filter proper, the collapse being
+    handed to the filter as marks and materialized by its first deletion round
+    rather than as a separate rebuild — exactly as they do in the unrelaxed
+    composition at the end of
+    [Theorem 6](layered.md#Theorem-5:-the-filter-preserves-the-answer). ∎
+
+### Below column-closure it is false
+
+It is tempting to relax at the granularity of the *sources* a report would
+like to name: this compat bound as against this pin, this one compat
+declaration as against another. Neither is column-closed — a constraint
+source clears part of a package's exclusion column, and a single compat
+declaration clears part of a partner's block — and neither is safe.
+
+!!! warning "Proposition D1′ (finer relaxations are not stable)"
+    Relaxing user constraints per *source*, or third-party bounds per
+    *declaration*, does not preserve satisfiability verdicts. One package
+    with two versions suffices for the first.
+
+    *Counterexample (source granularity).* A single package ``p`` with two
+    versions and no dependencies. The user's compat bound on ``p`` admits
+    only ``p@2``; the user's pin holds ``p`` at ``p@1``. Requirement
+    ``\{p\}``.
+
+    Together the two sources forbid everything, so ``p``'s exclusion column
+    is *full*: ``p@1`` and ``p@2`` have identical constraint rows, ``p@1``
+    dominates, and redundancy deletes ``p@2``. The filtered instance carries
+    only ``p@1``.
+
+    Now take ``\sigma``: drop the pin, keep the compat. The raw problem is
+    satisfiable, at ``p@2``. The filtered instance no longer has ``p@2`` and
+    reports unsatisfiable. ∎
+
+    *Counterexample (declaration granularity).* Packages ``p`` and ``q``,
+    two versions each, ``p@2`` depending on ``q``; ``q@1`` declares compat
+    on ``p`` admitting only ``p@1``, and ``q@2`` declares compat on ``p``
+    admitting nothing. Those are two declarations, hence two groups.
+    Dropping only ``q@2``'s leaves ``q@1``'s in force, clearing part of
+    ``p``'s column block in ``q``'s matrix and not the rest — and the same
+    collapse follows.
+
+    The general shape is what the proof needs: ``\sigma`` cleared a cell of
+    the *dominating* version without clearing the corresponding cell of the
+    dominated one, and the domination evaporated.
+
+    Neither is a rare corner. Sweeping small random instances over **every**
+    relaxation:
+
+    | preparation | group granularity | σ swept | wrong |
+    |:--|:--|--:|--:|
+    | full | source + declaration | 212,664 | 1.358% |
+    | full | package + declaration | 916,020 | 0.401% |
+    | full, collapsed | package + pair | 629,740 | **0** |
+    | full, uncollapsed | package + pair | 629,740 | **0** |
+    | full, collapsed, reordered | package + pair | 629,740 | **0** |
+    | reach only | source + declaration | 3,177,516 | **0** |
+
+    The operative rows are the middle three and the last: column-closure is
+    what makes the difference; the collapse neither helps nor hurts, in the
+    canonical version order or a reversed one; and redundancy elimination is
+    the entire source of the instability.
+
+The two results localize the damage precisely: by Lemma R, reachability is
+stable at *every* granularity, so the entire instability is redundancy
+elimination — the last row of the table above is the empirical face of
+Lemma R. A diagnosis that needed source-level relaxations could therefore
+buy them back, at the cost of a second, redundancy-free filtered universe.
+The implementation does not: it stays at column-closed granularity and
+keeps one instance.
+
+### What transfers, and at what granularity
+
+!!! note "Corollary D2 (cores, corrections and enumeration transfer)"
+    Let ``\Sigma`` be the lattice of relaxations over a column-closed family
+    ``G``, and ``\mathrm{sat} : \Sigma \to \{0,1\}`` the satisfiability
+    verdict. Theorem D1 says the verdict functions of ``D`` and ``F(D)`` are
+    the same function on ``\Sigma``. Therefore, computed on ``F(D)``: a
+    minimal unsatisfiable relaxation is one of ``D``; a minimal correction
+    set is one of ``D``; and an enumeration of either is complete for ``D``
+    exactly when it is complete for ``F(D)``.
+
+    *Proof.* All three notions are defined purely in terms of
+    ``\mathrm{sat}`` on ``\Sigma``, and the two verdict functions
+    coincide. ∎
+
+Because Theorem D1 preserves the layered *answer* and not merely the
+verdict, the solution reported alongside a fix — obtained by re-resolving
+the filtered instance with the fix's groups switched off — is the answer the
+raw problem would give under that fix, not an artifact of filtering.
+
+The price of column-closure is paid in the report's vocabulary, and it is
+small:
+
+- A fix relaxes **all** of a package's constraints at once — compat bound,
+  pin and admission knobs together. For the overwhelming majority of packages,
+  which carry one source, that is the same thing as naming it. When a package
+  carries several, the fix names each of them that still forbids a version the
+  instance has; the ones that forbid nothing there are exactly the ones the
+  relaxation does not depend on, so leaving them unnamed keeps the advice both
+  minimal and honest.
+- A bound-level conflict is blamed on an **incompatible pair of packages**
+  rather than on one compat declaration, and an upstream suggestion names
+  both sides. That was going to be true anyway: package info records
+  compatibility symmetrically, so which side declared a bound is not
+  recoverable from the filtered instance (see the boundary note below).
+
+!!! warning "Relaxations only"
+    Every diagnostic query must be a relaxation over a column-closed family.
+    Assuming a subset of the requirements and a subset of the selector
+    variables is one; adding a *clause* is not.
+
+    This is why fix enumeration is done MARCO-style with assumption-subset
+    queries — force-keeping a previously dropped group and re-running the
+    greedy pass — rather than by adding a blocking clause
+    ``\bigvee_{g \in \mathrm{MCS}} s_g`` over the selectors after each fix.
+    A blocking clause is an added constraint; the resulting instance is
+    outside the ``\sigma``-family and Theorem D1 licenses nothing about it.
+
+## Closure exactness
+
+Bound-level questions are asked per cluster, on a sub-instance covering only
+the packages that cluster can reach. That restriction is exact.
+
+!!! note "Lemma D3 (closure exactness)"
+    Fix requirements ``R_0`` and let ``C`` be the least set containing
+    ``R_0`` and closed under
+
+    ```math
+    p \in C \;\Longrightarrow\; \bigcup_{v} \mathrm{deps}(p, v) \subseteq C
+    ```
+
+    — the union over **all** of ``p``'s versions, not just a chosen one. Let
+    ``D[C]`` be ``D`` restricted to ``C``: packages outside ``C`` deleted,
+    dependencies and conflicts among ``C`` unchanged. Then ``D`` has a
+    solution covering ``R_0`` iff ``D[C]`` does, and the tight solutions
+    covering ``R_0`` are literally the same set.
+
+    *Proof.* (⇒) Let ``s`` be a solution of ``D`` covering ``R_0`` and
+    ``\pi(s)`` its pruning, a tight solution with support ``C(s)``
+    ([pruning lemma](setting.md#Tightness-and-pruning)). Then
+    ``C(s) \subseteq C``: ``R_0 \subseteq C``, and if ``p \in C(s)`` then
+    ``\mathrm{deps}(p, s(p)) \subseteq \bigcup_v \mathrm{deps}(p, v)
+    \subseteq C``. So ``\pi(s)`` lives inside ``C`` and is a solution of
+    ``D[C]`` — coverage, closure and conflict-freedom all inherited.
+
+    (⇐) Let ``t`` be a solution of ``D[C]`` covering ``R_0``. Read as a
+    partial assignment on ``D`` that assigns nothing outside ``C``, it is
+    still a solution: coverage is unchanged; dependency closure holds
+    because every dependency of an assigned version lies in ``C`` and is
+    assigned by ``t``; conflict freedom is inherited, since ``t`` assigns no
+    version outside ``C`` to conflict with. ∎
+
+    At the level of the SAT encoding the extension is even more transparent:
+    every clause an outside package occurs in is guarded by one of its own
+    literals — dependency clauses ``\lnot p@i \lor q``, conflict clauses
+    ``\lnot p@i \lor \lnot q@j`` — so setting the whole package false
+    satisfies them vacuously. Outside packages are never *forced*, because
+    only dependency edges force packages and every edge out of ``C`` stays
+    inside ``C``.
+
+Composing with Theorem D1: a per-cluster sub-instance built from the
+filtered universe ``F(D)``, restricted to the closure of the cluster's
+requirements, and equipped with selectors for the column-closed groups it
+contains, answers every relaxation query for that cluster exactly as the raw
+problem would.
+
+One honest caveat: ``C`` unions over *all* versions' dependency sets, so it
+is generally larger than the support of any single solution — and for a
+cluster rooted at a hub package it can be a substantial fraction of the
+universe. Exactness is not the same as smallness.
+
+## What the implementation does with this
+
+- The production instance asserts the user-constraint selectors as unit
+  clauses inside a single `sat_push` frame. One `sat_pop` turns every user
+  constraint into an assumable selector, converting the failed instance into
+  the diagnostic instance in place — no rebuild, no second copy of the
+  universe.
+- Diagnosis relaxes user constraints **per package**, never per source, and
+  third-party bounds **per interacting pair**, never per declaration. That
+  is Theorem D1's hypothesis, and Proposition D1′ is what happens if it is
+  ignored. "Per package" covers every source at once — the compat bound, the
+  pin, and every admission knob (`:prerelease`, `:yanked`, …) that touches the
+  package — because they all write into the one exclusion column.
+- Clustering and fix enumeration run on the converted instance with
+  assumption-only queries.
+- Each fix's reported solution comes from re-resolving the same instance
+  with the fix's groups switched off inside a temporary frame; the answer
+  half of Theorem D1 makes those versions the real ones.
+
+!!! warning "Formalization boundary"
+    Theorem D1 and Lemma R are proved against the same hand-made rule set as
+    Theorems 2–6 on the [previous page](layered.md) — a faithful reading of
+    `find_reachable` and `mark_necessary!`, checked against the code by
+    review and by the test suite rather than mechanically. Lemma D3 is
+    proved against the abstract [setting](setting.md), and its SAT-level
+    restatement against the encoding described there.
+
+    Everything on this page has a direct empirical check, in the same spirit
+    as the brute-force reference-resolve tests that back Theorems 4–6. The
+    suite sweeps small random instances and, for **every** relaxation
+    ``\sigma`` — every subset of the requirements crossed with every subset
+    of the constraint groups, not a sample — asserts that resolving the
+    filtered instance under ``\sigma`` gives exactly what a brute-force
+    reference resolve of the raw data with those groups deleted gives,
+    verdict and answer alike. It asserts stability at package-and-pair
+    granularity, reproduces Proposition D1′'s counterexample at source
+    granularity — with the collapse on and off, and in a non-canonical version
+    order — and confirms Lemma R by sweeping a reach-only universe at the finer
+    granularity where full preparation fails. A separate testset pins the
+    property the collapse case of the proof turns on: that refining classes by
+    the exclusion mask leaves a forbidden version in the instance for every
+    kind of source, so switching that source off can bring it back.
+
+    One representational caveat, orthogonal to the theorems: package info
+    records compatibility *symmetrically*, so by the time a problem reaches
+    the filtered instance the resolver no longer knows which side of an
+    incompatibility declared it. Bound facts in a diagnosis therefore name
+    an incompatible pair of version groups rather than a directed "``X``
+    requires ``Y`` at …" declaration, and upstream suggestions name both
+    sides.

--- a/src/Closure.jl
+++ b/src/Closure.jl
@@ -373,21 +373,28 @@ function rank_upstream!(
     ups  :: Vector{UpstreamFix{P,V}},
     info :: Dict{P,PkgInfo{P,V}},
 ) where {P,V}
-    rank(p, v) = something(findfirst(==(v), info[p].versions), typemax(Int))
+    rank_upstream!(ups, Dict{P,Vector{V}}(p => i.versions for (p, i) in info))
+end
+
+# the version lists are all this needs, so a client holding only a `Diagnosis`
+# -- which carries exactly those -- can rank with the same function
+rank_upstream!(ups::Vector{UpstreamFix{P,V}}, d::Diagnosis{P,V}) where {P,V} =
+    rank_upstream!(ups, d.versions)
+
+function rank_upstream!(
+    ups      :: Vector{UpstreamFix{P,V}},
+    versions :: AbstractDict{P,<:AbstractVector{V}},
+) where {P,V}
+    vers(p) = get(versions, p, V[])
+    rank(p, v) = something(findfirst(==(v), vers(p)), typemax(Int))
     best(p, vs) = isempty(vs) ? typemax(Int) : minimum(rank(p, v) for v in vs)
     function key(u::UpstreamFix{P,V})
         b = u.bound
         blamed = min(best(b.pkg, b.versions),
-                     best(b.dep, V[v for v in info[b.dep].versions
-                                   if v ∉ b.allowed]))
+                     best(b.dep, V[v for v in vers(b.dep) if v ∉ b.allowed]))
         got = sum(haskey(u.solution, p) ? rank(p, u.solution[p]) : 0
                   for p in (b.pkg, b.dep))
         (blamed, got, b.pkg, b.dep)
     end
     return sort!(ups; by = key)
 end
-
-rank_upstream!(ups::Vector{UpstreamFix{P,V}}, d) where {P,V} =
-    rank_upstream!(ups, Dict{P,PkgInfo{P,V}}(
-        p => PkgInfo(vs, P[], Dict{P,Int}(), falses(length(vs), 1))
-        for (p, vs) in d.versions))

--- a/src/Closure.jl
+++ b/src/Closure.jl
@@ -1,0 +1,366 @@
+# Phase B of a diagnosis: bound-level detail, on per-cluster closure
+# sub-instances.
+#
+# The production instance keeps third-party bounds as hard clauses -- selector
+# overhead on the hot path is not worth paying for a case that almost never
+# happens -- so relaxing one needs a separate instance. Two results make that
+# cheap and exact:
+#
+#   * Lemma D3 (closure exactness): a query assuming only a cluster's
+#     requirements is decided by the sub-problem on their dependency closure,
+#     so the sub-instance can be tiny compared to the universe.
+#
+#   * Theorem D1: the closure of the *filtered* universe answers as the raw
+#     problem would -- but only for column-closed groups. For conflicts that
+#     means an unordered *pair* of packages, never a single compat
+#     declaration: Proposition D1' is what happens at finer granularity. So a
+#     bound-level story blames incompatible pairs, and an upstream suggestion
+#     names both sides.
+#
+# The queries themselves are plain satisfiability checks on a rebuilt
+# instance: with the closure restricted, an instance costs microseconds, and a
+# cluster needs one per pair. That is far simpler than guarding every conflict
+# with a selector, and the sub-instances are small by construction.
+
+# Phase B rebuilds its sub-instance once per probe, and needs one probe per
+# incompatibility to shrink the story plus one per survivor to test it against
+# an upstream release. A probe costs about one SAT build over the closure, so
+# the work goes as (incompatibilities × versions in the closure) -- measured at
+# roughly 3 µs a unit on the General registry, where every closure carries
+# `julia` and its couple of thousand versions along with it.
+#
+# The budget below is therefore about a second of probing, which is a fair
+# price on a path that has already failed. Beyond it the report stops at
+# requirement level rather than spend minutes: a conflict whose closure is that
+# big belongs to a hub package, and those are nearly always explained by the
+# user's own constraints anyway.
+#
+# (The ceiling is an artifact of rebuilding the instance per probe. Guarding
+# each pair's conflicts with a selector, the way the production instance guards
+# the user constraints, would make a probe one solve instead of one build and
+# retire the budget entirely; it needs SAT.jl's rectangle encoder factored out
+# to share, which is why it is not done here.)
+const BOUND_STORY_BUDGET = 400_000
+
+# every package reachable from `reqs` along *any* version's dependency edges
+function dep_closure(info::Dict{P,<:PkgInfo{P}}, reqs) where {P}
+    seen = Set{P}(p for p in reqs if haskey(info, p))
+    queue = collect(seen)
+    while !isempty(queue)
+        p = pop!(queue)
+        for q in info[p].depends
+            q ∈ seen && continue
+            push!(seen, q)
+            push!(queue, q)
+        end
+    end
+    return seen
+end
+
+# `info` restricted to `keep`: same versions and dependencies (the closure is
+# dependency-closed, so none dangle), conflicts with packages outside dropped.
+# Lemma D3 says that loses nothing -- an outside package is never forced, and
+# a model of the restriction extends by leaving it out.
+function restrict_info(
+    info :: Dict{P,PkgInfo{P,V}},
+    keep :: AbstractSet{P},
+) where {P,V}
+    out = Dict{P,PkgInfo{P,V}}()
+    for p in keep
+        info_p = info[p]
+        m = length(info_p.versions)
+        D = copy(info_p.depends)
+        parts = sort!(P[q for q in keys(info_p.interacts) if q ∈ keep])
+        T = Dict{P,Int}()
+        off = length(D)
+        for q in parts
+            T[q] = off
+            off += length(info[q].versions)
+        end
+        X = falses(padded_rows(m), off + 1)
+        Y = info_p.conflicts
+        for k = 1:length(D), i = 1:m
+            X[i, k] = Y[i, k]
+        end
+        for q in parts
+            b = info_p.interacts[q]
+            c = T[q]
+            for j = 1:length(info[q].versions), i = 1:m
+                X[i, c+j] = Y[i, b+j]
+            end
+        end
+        X[1:m, end] .= true   # every version active
+        X[m+1, 1:off] .= true # every column active
+        # every version survives and only columns go, and dropping columns can
+        # only *merge* row-equality classes, so carrying the partition over is
+        # sound (possibly finer than the truth, which is all `classes` promises)
+        out[p] = PkgInfo{P,V}(copy(info_p.versions), D, T, X,
+                              copy(info_p.classes))
+    end
+    return out
+end
+
+# the unordered pairs of packages with a conflict between them: the finest
+# column-closed conflict groups there are
+function interacting_pairs(info::Dict{P,<:PkgInfo{P}}) where {P}
+    pairs = Tuple{P,P}[]
+    for (p, info_p) in info, q in keys(info_p.interacts)
+        p < q || continue
+        m = length(info_p.versions)
+        b = info_p.interacts[q]
+        n = length(info[q].versions)
+        any(info_p.conflicts[i, b+j] for i = 1:m, j = 1:n) || continue
+        push!(pairs, (p, q))
+    end
+    return sort!(pairs)
+end
+
+# restore (`on`) or clear (`off`) pair (p, q)'s conflict block in `work`,
+# reading the original bits from the pristine `src`; the two have the same
+# layout, `work` being a copy
+function set_pair!(
+    work :: Dict{P,PkgInfo{P,V}},
+    src  :: Dict{P,PkgInfo{P,V}},
+    p    :: P,
+    q    :: P,
+    on   :: Bool,
+) where {P,V}
+    for (a, b) in ((p, q), (q, p))
+        Xw = work[a].conflicts
+        Xs = src[a].conflicts
+        off = work[a].interacts[b]
+        for j = 1:length(work[b].versions), i = 1:length(work[a].versions)
+            Xw[i, off+j] = on && Xs[i, off+j]
+        end
+    end
+end
+
+copy_info(info::Dict{P,PkgInfo{P,V}}) where {P,V} =
+    Dict{P,PkgInfo{P,V}}(
+        p => PkgInfo{P,V}(copy(i.versions), copy(i.depends),
+                          copy(i.interacts), copy(i.conflicts), copy(i.classes))
+        for (p, i) in info)
+
+# `prob` as it applies inside a closure sub-instance, with the constraints of
+# the packages in `on` in force and everything else's relaxed. Admission knobs
+# have to be masked rather than dropped: a knob is stated about versions, not
+# about a package, so switching it off for one package means excusing that
+# package from its predicate.
+function closure_problem(
+    prob :: Problem{P},
+    reqs :: AbstractVector{P},
+    on   :: AbstractSet{P},
+) where {P}
+    is_constrained(prob) && !isempty(on) || return Problem(reqs)
+    compat = Dict{P,valtype(prob.compat)}(
+        p => s for (p, s) in prob.compat if p ∈ on)
+    pins = Dict{P,valtype(prob.pins)}(
+        p => v for (p, v) in prob.pins if p ∈ on)
+    excludes = Pair{Symbol,Any}[
+        kind => ((p, v) -> p ∈ on && forbids(p, v)::Bool)
+        for (kind, forbids) in prob.excludes]
+    Problem(reqs; compat, pins, excludes)
+end
+
+# A pair's conflicts, as facts: group one side's versions by which versions of
+# the other they rule out, so the report reads as a handful of statements rather
+# than a cell-by-cell dump.
+#
+# Most of those statements are about versions the query already excludes. A
+# minimal conflict needs them -- something has to close off the old versions of
+# a package, or the conflict would not be a conflict -- but a reader wants the
+# one line about versions they could actually get, not five siblings at the same
+# level. So each group is marked `incidental` when every version of `p` in it is
+# already forbidden, and reports demote those. If *every* group is incidental
+# nothing is demoted: better a verbose explanation than none.
+function pair_facts(
+    info :: Dict{P,PkgInfo{P,V}},
+    prob :: Problem{P},
+    p    :: P,
+    q    :: P,
+) where {P,V}
+    info_p = info[p]
+    vers_q = info[q].versions
+    b = info_p.interacts[q]
+    m = length(info_p.versions)
+    n = length(vers_q)
+    groups = Dict{Vector{Int},Vector{Int}}() # pattern over q => versions of p
+    for i = 1:m
+        pat = Int[j for j = 1:n if info_p.conflicts[i, b+j]]
+        isempty(pat) && continue
+        push!(get!(() -> Int[], groups, pat), i)
+    end
+    pats = sort!(collect(keys(groups)))
+    live = Dict{Vector{Int},Bool}(
+        pat => any(!is_excluded(prob, p, info_p.versions[i])
+                   for i in groups[pat])
+        for pat in pats)
+    demote = any(values(live))
+    facts = Fact[]
+    for pat in pats
+        bad = Set(pat)
+        push!(facts, Bound{P,V}(
+            p, V[info_p.versions[i] for i in groups[pat]],
+            q, V[vers_q[j] for j = 1:n if j ∉ bad],
+            demote && !live[pat]))
+    end
+    return facts
+end
+
+# the pair-level bound: which versions of `p` conflict with something of `q`
+# at all, and which versions of `q` survive all of them
+function pair_bound(info::Dict{P,PkgInfo{P,V}}, p::P, q::P) where {P,V}
+    info_p = info[p]
+    vers_q = info[q].versions
+    b = info_p.interacts[q]
+    m = length(info_p.versions)
+    n = length(vers_q)
+    pv = V[info_p.versions[i] for i = 1:m
+           if any(info_p.conflicts[i, b+j] for j = 1:n)]
+    qa = V[vers_q[j] for j = 1:n
+           if !any(info_p.conflicts[i, b+j] for i = 1:m)]
+    Bound{P,V}(p, pv, q, qa)
+end
+
+"""
+    bound_story(info, prob, creqs, users, by) -> (facts, upstream, kept)
+
+Bound-level detail for one conflict cluster: which package-pair
+incompatibilities and which of the user's own constraints are needed to make
+`creqs` unsatisfiable, and which incompatibilities a single upstream release
+could dissolve.
+
+Runs on a sub-instance restricted to `creqs`' dependency closure, relaxing
+conflicts one *pair* at a time — the finest granularity Theorem D1 covers. The
+deletion order is actionability-biased: incompatibilities only an upstream
+release can move go first, so a conflict tellable either way keeps the
+explanation the user can act on. `kept` is the subset of `users` that survived;
+it is `nothing` when the closure was too big to be worth the solves, and the
+caller has to shrink the user groups itself.
+"""
+function bound_story(
+    info  :: Dict{P,PkgInfo{P,V}},
+    prob  :: Problem{P},
+    creqs :: Vector{P},
+    users :: Vector{P},
+    by    :: Function,
+) where {P,V}
+    none = (Fact[], UpstreamFix{P,V}[], nothing)
+    keep = dep_closure(info, creqs)
+    isempty(keep) && return none
+    src = restrict_info(info, keep)
+    userset = Set{P}(p for p in users if p ∈ keep)
+    # filter the sub-problem for *this cluster's* requirements before probing
+    # it. The universe was prepared for all of them at once, and a cluster is
+    # usually a couple of packages, so reachability prunes hard here -- which
+    # matters a lot, since every probe below rebuilds an instance over whatever
+    # is left. Filtering with a subset of the requirements is licensed by the
+    # requirement-monotonicity proposition, and doing it with every group in
+    # force is what puts the result back under Theorem D1.
+    filter_pkg_info!(src, closure_problem(prob, creqs, userset))
+    all(p -> haskey(src, p), creqs) || return none
+    pairs = interacting_pairs(src)
+    nvers = sum(length(i.versions) for i in values(src); init = 0)
+    length(pairs) * nvers ≤ BOUND_STORY_BUDGET || return none
+    work = copy_info(src)
+
+    # is the cluster satisfiable with these pairs in force? leaves `work`
+    # holding exactly the relaxation it tested, so the caller can resolve on it.
+    # `subprob` is hoisted because it is constant across a deletion pass and
+    # rebuilding its constraint dictionaries per probe is pure overhead
+    function probe(on::AbstractVector{Bool}, subprob::Problem{P})
+        for (k, (p, q)) in enumerate(pairs)
+            set_pair!(work, src, p, q, on[k])
+        end
+        sat = SAT(work, subprob)
+        try is_satisfiable(sat, creqs)
+        finally
+            finalize(sat)
+        end
+    end
+
+    # Every constraint the query really has stays in force for the probes and
+    # for the solutions they report: an upstream release is only worth
+    # suggesting if it fixes the conflict under the constraints the user
+    # actually gave, and a solution that quietly ignored one -- a julia bound,
+    # say, or the ban on prereleases -- would be no solution at all. Shrinking
+    # the user set is a separate question, about which facts the *story* needs.
+    subprob = closure_problem(prob, creqs, userset)
+
+    # everything on must reproduce the failure; closure exactness says it does
+    on = trues(length(pairs))
+    probe(on, subprob) && return none
+
+    # group MUS by a single biased deletion pass: the incompatibilities first,
+    # so a conflict the user's own constraints can explain is blamed on them
+    for k in eachindex(pairs)
+        on[k] = false
+        probe(on, subprob) && (on[k] = true)
+    end
+    story = copy(userset)
+    for p in sort!(collect(userset))
+        delete!(story, p)
+        probe(on, closure_problem(prob, creqs, story)) &&
+            push!(story, p) # needed: keep it
+    end
+
+    facts = Fact[]
+    for (k, (p, q)) in enumerate(pairs)
+        on[k] || continue
+        append!(facts, pair_facts(src, prob, p, q))
+    end
+
+    # single-pair probes: with every other incompatibility and every surviving
+    # user constraint still in force, would dissolving just this one resolve
+    # the cluster? if so, one upstream release on either side would do it.
+    #
+    ups = UpstreamFix{P,V}[]
+    for (k, (p, q)) in enumerate(pairs)
+        on[k] || continue
+        on[k] = false
+        if probe(on, subprob)
+            sol = resolve_prepared(work, subprob; by, diagnose = false)
+            sol === nothing ||
+                push!(ups, UpstreamFix{P,V}(pair_bound(src, p, q), sol))
+        end
+        on[k] = true
+    end
+    kept = P[p for p in users if p ∈ story]
+    return facts, rank_upstream!(ups, src), kept
+end
+
+"""
+    rank_upstream!(ups, info) -> ups
+
+Order upstream suggestions by how plausible they are to act on, most first.
+
+Two keys, in order:
+
+1. **How current the blamed versions are.** A release that relaxes a bound its
+   *newest* versions carry is a thing a maintainer might actually do; asking
+   them to reach back and loosen a range that only ancient versions had is not.
+   Measured as the best rank the incompatibility touches on either side —
+   versions are listed best-first, so smaller is newer.
+2. **How good the result is.** Between two plausible asks, the one that gets you
+   newer packages is the better suggestion. Measured on the witness, which is an
+   optimal layered solution, over the two packages named.
+
+Ties break on the package names, so the order is deterministic.
+"""
+function rank_upstream!(
+    ups  :: Vector{UpstreamFix{P,V}},
+    info :: Dict{P,PkgInfo{P,V}},
+) where {P,V}
+    rank(p, v) = something(findfirst(==(v), info[p].versions), typemax(Int))
+    best(p, vs) = isempty(vs) ? typemax(Int) : minimum(rank(p, v) for v in vs)
+    function key(u::UpstreamFix{P,V})
+        b = u.bound
+        blamed = min(best(b.pkg, b.versions),
+                     best(b.dep, V[v for v in info[b.dep].versions
+                                   if v ∉ b.allowed]))
+        got = sum(haskey(u.solution, p) ? rank(p, u.solution[p]) : 0
+                  for p in (b.pkg, b.dep))
+        (blamed, got, b.pkg, b.dep)
+    end
+    return sort!(ups; by = key)
+end

--- a/src/Closure.jl
+++ b/src/Closure.jl
@@ -237,16 +237,31 @@ release can move go first, so a conflict tellable either way keeps the
 explanation the user can act on. `kept` is the subset of `users` that survived;
 it is `nothing` when the closure was too big to be worth the solves, and the
 caller has to shrink the user groups itself.
+
+`goal` puts the caller's fixed ask into every probe here as well, and widens the
+closure to cover the packages it names. A goal that is more than a presence ask
+also turns off the sub-instance's reachability and redundancy passes, which are
+not goal-safe (see [`prepare_goal_info`](@ref Resolver.prepare_goal_info)) — the
+sub-instance is then bigger, and the closure budget may decline it, which is the
+honest outcome rather than a wrong one.
 """
 function bound_story(
     info  :: Dict{P,PkgInfo{P,V}},
     prob  :: Problem{P},
     creqs :: Vector{P},
     users :: Vector{P},
-    by    :: Function,
+    by    :: Function;
+    goal  :: Union{Nothing,Goal{P}} = nothing,
 ) where {P,V}
     none = (Fact[], UpstreamFix{P,V}[], nothing)
-    keep = dep_closure(info, creqs)
+    # a `with` goal's packages are present by fiat, so they are requirements as
+    # far as the closure and its probes are concerned; a `without` goal's are in
+    # the closure because the story is about how they get pulled in
+    creqs = goal === nothing ? creqs :
+        sort!(unique!(P[creqs; P[p for (p, _) in goal.with]]))
+    roots = goal === nothing ? creqs :
+        sort!(unique!(P[creqs; goal.without]))
+    keep = dep_closure(info, roots)
     isempty(keep) && return none
     src = restrict_info(info, keep)
     userset = Set{P}(p for p in users if p ∈ keep)
@@ -257,7 +272,8 @@ function bound_story(
     # is left. Filtering with a subset of the requirements is licensed by the
     # requirement-monotonicity proposition, and doing it with every group in
     # force is what puts the result back under Theorem D1.
-    filter_pkg_info!(src, closure_problem(prob, creqs, userset))
+    filter_pkg_info!(src, closure_problem(prob, creqs, userset);
+                     reach = goal_reach_safe(goal))
     all(p -> haskey(src, p), creqs) || return none
     pairs = interacting_pairs(src)
     nvers = sum(length(i.versions) for i in values(src); init = 0)
@@ -272,7 +288,7 @@ function bound_story(
         for (k, (p, q)) in enumerate(pairs)
             set_pair!(work, src, p, q, on[k])
         end
-        sat = SAT(work, subprob)
+        sat = SAT(work, subprob, goal)
         try is_satisfiable(sat, creqs)
         finally
             finalize(sat)
@@ -319,7 +335,7 @@ function bound_story(
         on[k] || continue
         on[k] = false
         if probe(on, subprob)
-            sol = resolve_prepared(work, subprob; by, diagnose = false)
+            sol = resolve_prepared(work, subprob; by, diagnose = false, goal)
             sol === nothing ||
                 push!(ups, UpstreamFix{P,V}(pair_bound(src, p, q), sol))
         end
@@ -346,6 +362,12 @@ Two keys, in order:
    optimal layered solution, over the two packages named.
 
 Ties break on the package names, so the order is deterministic.
+
+`rank_upstream!(ups, d::Diagnosis)` reads the version lists off the diagnosis,
+which is the form a client that only has the report's structured data can use.
+Every `UpstreamFix` carries its `bound` and a verified `solution`, so a client
+with better knowledge — Pkg knows which packages are actively maintained — is
+free to filter first, or to sort by its own criteria and ignore this one.
 """
 function rank_upstream!(
     ups  :: Vector{UpstreamFix{P,V}},
@@ -364,3 +386,8 @@ function rank_upstream!(
     end
     return sort!(ups; by = key)
 end
+
+rank_upstream!(ups::Vector{UpstreamFix{P,V}}, d) where {P,V} =
+    rank_upstream!(ups, Dict{P,PkgInfo{P,V}}(
+        p => PkgInfo(vs, P[], Dict{P,Int}(), falses(length(vs), 1))
+        for (p, vs) in d.versions))

--- a/src/Diagnose.jl
+++ b/src/Diagnose.jl
@@ -111,6 +111,27 @@ Bound{P,V}(pkg, versions, dep, allowed) where {P,V} =
 Bound(pkg::P, versions::Vector{V}, dep::P, allowed::Vector{V}) where {P,V} =
     Bound{P,V}(pkg, versions, dep, allowed, false)
 
+"""
+    Dependency(pkg, versions, dep, admissible)
+
+The listed `versions` of `pkg` all depend on `dep`, so choosing `pkg` at any of
+them drags `dep` in. `admissible` is true when `versions` is the subset the
+query's own constraints leave available rather than the whole list, which is
+the difference between "all versions" and "all admissible versions" in a report.
+
+This is the fact a `without` goal's story is made of: nothing conflicts with
+anything, the banned package is simply unavoidable. Only a chain of *forced*
+edges is ever emitted — a path some other version choice could route around
+explains nothing, which is what separates this from printing every dependency
+path.
+"""
+struct Dependency{P,V} <: Fact
+    pkg        :: P
+    versions   :: Vector{V}
+    dep        :: P
+    admissible :: Bool
+end
+
 fact_pkg(f::Fact) = f.pkg
 
 # value equality for facts (immutable, compared field-wise)
@@ -132,6 +153,7 @@ kind_rank(::Pin)           = 3
 kind_rank(::UserCompat)    = 4
 kind_rank(::Admission)     = 5
 kind_rank(::Bound)         = 6
+kind_rank(::Dependency)    = 7
 
 order_facts(fs::Vector{Fact}) =
     sort(fs; by = f -> (kind_rank(f), fact_pkg(f)))
@@ -160,18 +182,27 @@ struct UpstreamFix{P,V}
 end
 
 """
-    Conflict(reqs, chain, upstream)
+    Conflict(reqs, chain, upstream, goal = false)
 
 One independent reason the problem is unsatisfiable: `reqs` is a minimal set of
 requirements that cannot be satisfied together, `chain` tells the story as an
 ordered list of facts, and `upstream` lists bounds whose relaxation would
 resolve this conflict.
+
+`goal` says whether the caller's `with`/`without` ask is part of *this*
+conflict — true when `reqs` alone is satisfiable and only the goal makes it
+fail, which is what the report's header says out loud. A conflict with `goal`
+true and no `reqs` is the goal against the user's own constraints.
 """
 struct Conflict{P,V}
     reqs     :: Vector{P}
     chain    :: Vector{Fact}
     upstream :: Vector{UpstreamFix{P,V}}
+    goal     :: Bool
 end
+
+Conflict{P,V}(reqs, chain, upstream) where {P,V} =
+    Conflict{P,V}(reqs, chain, upstream, false)
 
 """
     Diagnosis(reqs, conflicts, fixes, versions)
@@ -283,18 +314,33 @@ licenses and the only one anything here asks for.
 No group is assumed implicitly: a group left out of an assumption set is
 *free*, and the solver will happily switch it off, so each caller names exactly
 the context its query means to hold.
+
+`goal` is the exception, and the only one: the goal's selector literals, which
+every probe holds on whether or not it says so. A goal is the query's fixed ask,
+so no MUS may shrink it away and no fix may propose dropping it — it is *not* a
+relaxable group, just an assumption the machinery carries.
 """
 struct Relaxation{P}
     rel  :: Vector{Relaxable{P}}
     reqs :: Vector{Int}
     user :: Vector{Int}
+    goal :: Vector{Int}
 end
 
+Relaxation{P}(rel, reqs, user) where {P} = Relaxation{P}(rel, reqs, user, Int[])
+
 # switch exactly the given groups on and test satisfiability; everything else is
-# free, and the solver may set it false
-function relax_sat(sat::SAT, R::Relaxation, on)
+# free, and the solver may set it false. The goal rides along unless a caller
+# explicitly asks what happens without it — which is how a conflict is told to
+# be the goal's doing rather than the requirements'.
+function relax_sat(sat::SAT, R::Relaxation, on; goal::Bool = true)
     for i in on, l in R.rel[i].lits
         sat_assume_var(sat, l)
+    end
+    if goal
+        for l in R.goal
+            sat_assume_var(sat, l)
+        end
     end
     is_satisfiable(sat)
 end
@@ -370,7 +416,14 @@ function fix_solution(
                 sat_add(sat)
             end
         end
-        sol = resolve_core(sat, sort!(reqs); by, restore = false)
+        # the goal holds over the fix's own resolve, so the witness is a
+        # solution the caller would actually accept
+        for l in R.goal
+            sat_add_var(sat, l)
+            sat_add(sat)
+        end
+        sol = resolve_core(sat, descent_roots(sat, sort!(reqs)); by,
+                           restore = false)
         sol === nothing ? Dict{P,V}() :
             Dict{P,V}(p => sat.info[p].versions[i] for (p, i) in sol)
     end
@@ -492,7 +545,7 @@ function relaxation(sat::SAT{P,V}, reqs::AbstractVector{P}) where {P,V}
         push!(rel, Relaxable{P}(:user, p, sort!(bypkg[p])))
         push!(uids, length(rel))
     end
-    return Relaxation{P}(rel, rids, uids)
+    return Relaxation{P}(rel, rids, uids, copy(sat.goals))
 end
 
 """
@@ -511,6 +564,7 @@ function diagnose(
     by   :: Function = identity,
     max_fixes :: Integer = 8,
 ) where {P,V}
+    goal = sat.goal
     # a requirement the filter dropped has no installable version at all, so it
     # is not in the instance and cannot be reasoned about there: it is its own
     # conflict, and every fix has to drop it
@@ -528,8 +582,18 @@ function diagnose(
         prob = something(sat.prob, Problem(P[]))
         # the whole-column group of each constrained package, for story facts
         bygroup = Dict{P,Int}(rel[i].pkg => i for i in R.user)
-        for cluster in cluster_reqs(sat, R, R.reqs)
+        clusters = cluster_reqs(sat, R, R.reqs)
+        # a goal can be unsatisfiable against the user's own constraints with no
+        # requirement involved at all, and requirement-level clustering has
+        # nothing to return for that: one conflict, no reqs, the goal's story
+        isempty(clusters) && !isempty(R.goal) && push!(clusters, Int[])
+        for cluster in clusters
             creqs = sort!(P[rel[i].pkg for i in cluster])
+            # did this conflict need the goal? with the goal off the same
+            # assumptions are satisfiable exactly when the goal is what breaks
+            # them -- the one thing the report's header turns on
+            ingoal = !isempty(R.goal) &&
+                relax_sat(sat, R, Int[cluster; R.user]; goal = false)
             # Phase B: which package-pair incompatibilities tell this story,
             # and which single upstream release would end it. Third-party
             # bounds are hard clauses here -- no selector overhead on the hot
@@ -537,7 +601,8 @@ function diagnose(
             # which also lets it shrink the user groups in the right order:
             # bounds first, so the actionable explanation survives
             bfacts, ups, kept = bound_story(
-                sat.info, prob, creqs, P[rel[i].pkg for i in R.user], by)
+                sat.info, prob, creqs, P[rel[i].pkg for i in R.user], by;
+                goal = ingoal ? goal : nothing)
             if kept === nothing
                 # the closure was too big to explore: shrink the columns
                 # against the production instance instead, without the bias
@@ -567,8 +632,14 @@ function diagnose(
                 append!(facts, group_facts(sat, rel[i]))
             end
             append!(facts, bfacts)
-            push!(conflicts,
-                  Conflict{P,V}(creqs, order_chain(facts, P, V), ups))
+            chain = order_chain(facts, P, V)
+            # a `without` goal's story is a chain of forced dependencies, not
+            # of incompatible pairs: nothing conflicts with anything, the
+            # package is simply unavoidable. It is already in story order, so
+            # it goes on the end rather than through `order_chain`
+            ingoal &&
+                append!(chain, forced_chain(sat.info, prob, creqs, goal))
+            push!(conflicts, Conflict{P,V}(creqs, chain, ups, ingoal))
         end
         order = Int[R.reqs; R.user]
         fixes = enumerate_fixes(sat, R, order, forced; max_fixes, by,
@@ -581,12 +652,62 @@ function diagnose(
             (vers[p] = copy(sat.info[p].versions))
         for c in conflicts, f in c.chain
             record(fact_pkg(f))
-            f isa Bound && record(f.dep)
+            f isa Union{Bound,Dependency} && record(f.dep)
         end
         fixes, vers
     end
     sort!(conflicts; by = c -> c.reqs)
     return Diagnosis{P,V}(sort!(collect(reqs)), conflicts, fixes, versions)
+end
+
+# One forcing chain from the requirements to a package a `without` goal bans:
+# a breadth-first walk over edges every admissible version of a package has, so
+# each step is "there is no version of this that does without it". Read off the
+# dependency columns, so it costs no solve and cannot be wrong — and when no
+# fully forced path exists it returns nothing at all, which is honest: the
+# package is avoidable somewhere along the way and the conflict is elsewhere.
+function forced_chain(
+    info  :: Dict{P,PkgInfo{P,V}},
+    prob  :: Problem{P},
+    creqs :: Vector{P},
+    goal  :: Union{Nothing,Goal{P}},
+) where {P,V}
+    (goal === nothing || isempty(goal.without)) && return Fact[]
+    banned = Set{P}(goal.without)
+    from = Dict{P,Dependency{P,V}}()
+    seen = Set{P}(creqs)
+    queue = copy(creqs)
+    target = nothing
+    while target === nothing && !isempty(queue)
+        p = popfirst!(queue)
+        haskey(info, p) || continue
+        info_p = info[p]
+        vers = info_p.versions
+        live = Int[i for (i, v) in enumerate(vers)
+                   if !is_excluded(prob, p, v)]
+        isempty(live) && continue
+        for (j, q) in enumerate(info_p.depends)
+            q ∈ seen && continue
+            all(info_p.conflicts[i, j] for i in live) || continue
+            push!(seen, q)
+            from[q] = Dependency{P,V}(p, V[vers[i] for i in live], q,
+                                      length(live) < length(vers))
+            if q ∈ banned
+                target = q
+                break
+            end
+            push!(queue, q)
+        end
+    end
+    target === nothing && return Fact[]
+    chain = Fact[]
+    q = target
+    while haskey(from, q)
+        f = from[q]
+        push!(chain, f)
+        q = f.pkg
+    end
+    return reverse!(chain)
 end
 
 """
@@ -666,6 +787,21 @@ end
 # rendering a fact needs the package's version list and nothing else
 versions_of(d, p) = get(d.versions, p, valtype(d.versions)())
 
+"""
+    render_fact(io, f::Fact, d)
+
+Write one story bullet's sentence for `f` — "you require A", "your compat
+restricts B to 1.7", "A (all versions) works with C only at 1". `d` is whatever
+carries the version lists to compress against: a [`Diagnosis`](@ref) or a
+[`Holdback`](@ref).
+
+One method per `Fact` kind, and the sentence layer of the default report. A
+client that wants these sentences under its own layout — Pkg's indentation, its
+own terminal markup — calls this per fact instead of
+[`report`](@ref Resolver.report); a client that wants its own sentences reads
+the `Fact` fields (`pkg`, `versions`, `dep`, `allowed`, `incidental`, …), which
+are everything the sentence is generated from.
+"""
 render_fact(io::IO, f::Requirement, d) =
     print(io, "you require ", f.pkg)
 render_fact(io::IO, f::Uninstallable, d) =
@@ -716,6 +852,22 @@ function render_fact(io::IO, f::Bound, d)
           format_versions(versions_of(d, f.dep), f.allowed))
 end
 
+function render_fact(io::IO, f::Dependency, d)
+    all_p = versions_of(d, f.pkg)
+    src = length(f.versions) == length(all_p) ? "(all versions)" :
+          f.admissible ? "(all admissible versions)" :
+          format_versions(all_p, f.versions)
+    print(io, f.pkg, " ", src, " requires ", f.dep)
+end
+
+"""
+    render_action(f::Fact) :: String
+
+The imperative form of relaxing `f`, as a fix's menu line reads it: "drop
+requirement A", "relax your compat on B", "unpin C", "allow prereleases of D".
+The counterpart of [`blame_phrase`](@ref Resolver.blame_phrase), which is the
+same fact as a noun.
+"""
 render_action(f::Requirement) = string("drop requirement ", f.pkg)
 render_action(f::UserCompat)  =
     f.label === :requested ? string("relax the version you requested for ", f.pkg) :
@@ -746,7 +898,7 @@ function story_pkgs(d::Diagnosis{P,V}) where {P,V}
     rel = Set{P}()
     for c in d.conflicts, f in c.chain
         push!(rel, fact_pkg(f))
-        f isa Bound && push!(rel, f.dep)
+        f isa Union{Bound,Dependency} && push!(rel, f.dep)
     end
     return rel
 end
@@ -786,6 +938,18 @@ function Base.show(io::IO, d::Diagnosis)
     print(io, "Diagnosis(", summary_counts(d), ")")
 end
 
+# "A, B cannot be satisfied together." -- and with the caller's `with`/`without`
+# ask in the conflict, "the goal and A". The goal is named rather than spelled
+# out: what it asked for is the one thing the caller already knows.
+function conflict_header(c::Conflict)
+    isempty(c.reqs) && !c.goal && return "the requirements cannot be satisfied."
+    isempty(c.reqs) && return "the goal cannot be satisfied."
+    rs = join(c.reqs, ", ")
+    c.goal && return string("the goal and ", rs, " cannot be satisfied together.")
+    string(rs, length(c.reqs) == 1 ? " cannot be satisfied." :
+               " cannot be satisfied together.")
+end
+
 # "1 conflict, 2 fixes" -- the shape of the answer, for either show
 function summary_counts(d::Diagnosis)
     nc = length(d.conflicts)
@@ -802,10 +966,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis)
             isempty(d.conflicts) ? "" : ":")
     for (n, c) in enumerate(d.conflicts)
         n > 1 && println(io)
-        rs = join(c.reqs, ", ")
-        println(io, "Conflict ", n, ": ", rs,
-                length(c.reqs) == 1 ? " cannot be satisfied." :
-                " cannot be satisfied together.")
+        println(io, "Conflict ", n, ": ", conflict_header(c))
         for f in c.chain
             f isa Bound && f.incidental && continue
             print(io, "  • ")
@@ -850,6 +1011,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis)
             " not shown)")
     end
 end
+
 
 # How many upstream suggestions a report prints. A tangled conflict can produce
 # a dozen, all true and most useless -- ten for one real project -- and

--- a/src/Diagnose.jl
+++ b/src/Diagnose.jl
@@ -1,0 +1,856 @@
+# UNSAT diagnostics: explain why a resolution problem is unsatisfiable and list
+# verified fixes.
+#
+# The vocabulary below is the whole public surface of a diagnosis: a `Diagnosis`
+# is a list of independent `Conflict`s — each a requirement-level cluster, a
+# chain of `Fact`s telling that cluster's story, and any upstream suggestions —
+# plus a global list of verified `Fix`es. Everything is structured data;
+# rendering is a separate layer at the bottom of this file, so a caller (Pkg,
+# say) can render its own.
+
+# facts — the vocabulary of explanations and fixes
+
+abstract type Fact end
+
+"""
+    Requirement(pkg)
+
+The user asked for `pkg`. Relaxing it means dropping the requirement.
+"""
+struct Requirement{P} <: Fact
+    pkg :: P
+end
+
+"""
+    Uninstallable(pkg)
+
+`pkg` has no installable version at all — every version of it depends,
+transitively, on a package with no versions. Nothing the user can relax fixes
+this; the only correction is to stop requiring `pkg`.
+"""
+struct Uninstallable{P} <: Fact
+    pkg :: P
+end
+
+"""
+    UserCompat(pkg, allowed, [label])
+
+The user's compat bound on `pkg`, as the list of that package's versions it
+admits. Relaxing it means loosening (or deleting) the bound.
+
+`label` says what kind of restriction it was, for reports: `:compat` (the
+default) reads as "your compat restricts …", `:requested` as "you requested …".
+A caller sets it through [`Problem`](@ref)'s `labels`, because "your compat" is
+wrong when the bound came from `Pkg.add(name, version)` rather than a compat
+section. Unknown labels get a neutral phrasing rather than an error.
+"""
+struct UserCompat{P,V} <: Fact
+    pkg     :: P
+    allowed :: Vector{V}
+    label   :: Symbol
+end
+
+UserCompat{P,V}(pkg, allowed) where {P,V} =
+    UserCompat{P,V}(pkg, allowed, :compat)
+UserCompat(pkg::P, allowed::Vector{V}) where {P,V} =
+    UserCompat{P,V}(pkg, allowed, :compat)
+
+"""
+    Pin(pkg, version)
+
+`pkg` is pinned at `version`. Relaxing it means unpinning.
+"""
+struct Pin{P,V} <: Fact
+    pkg     :: P
+    version :: V
+end
+
+"""
+    Admission(kind, pkg, forbidden)
+
+An *admission knob* ruling versions of `pkg` out: `kind` names the source
+(`:prerelease`, `:yanked`, …) and `forbidden` lists the versions it excludes.
+Unlike a compat bound or a pin, a knob is stated about versions rather than
+about a package, so the same one appears once per package it touches.
+
+Relaxing it means admitting that class of version — passing `--allow-pre`, say.
+"""
+struct Admission{P,V} <: Fact
+    kind      :: Symbol
+    pkg       :: P
+    forbidden :: Vector{V}
+end
+
+"""
+    Bound(pkg, versions, dep, allowed)
+
+A third-party compatibility bound: the listed `versions` of `pkg` are
+incompatible with every version of `dep` outside `allowed`. Only an upstream
+release can relax one.
+
+The resolver's package info records compatibility symmetrically — a conflict
+between `pkg@v` and `dep@w` is one fact, not two directed ones — so a `Bound`
+names an incompatible *pair* of version groups rather than saying which side
+declared the bound. See the manual's diagnostics page.
+"""
+struct Bound{P,V} <: Fact
+    pkg      :: P
+    versions :: Vector{V}
+    dep      :: P
+    allowed  :: Vector{V}
+    # true when every version of `pkg` this fact is about is one the query's own
+    # constraints already rule out. Such a fact is needed for the conflict to be
+    # *minimal* -- something has to close off the old versions -- but it is not
+    # what a reader wants at the same level as the lines that name versions they
+    # could actually get. Reports demote them; see `pair_facts`.
+    incidental :: Bool
+end
+
+Bound{P,V}(pkg, versions, dep, allowed) where {P,V} =
+    Bound{P,V}(pkg, versions, dep, allowed, false)
+Bound(pkg::P, versions::Vector{V}, dep::P, allowed::Vector{V}) where {P,V} =
+    Bound{P,V}(pkg, versions, dep, allowed, false)
+
+fact_pkg(f::Fact) = f.pkg
+
+# value equality for facts (immutable, compared field-wise)
+Base.:(==)(a::F, b::F) where {F<:Fact} =
+    all(getfield(a, i) == getfield(b, i) for i = 1:nfields(a))
+function Base.hash(a::Fact, h::UInt)
+    for i = 1:nfields(a)
+        h = hash(getfield(a, i), h)
+    end
+    hash(typeof(a), h)
+end
+
+# deterministic ordering: actionability first, then by package. requirements
+# lead (dropping one is always available), uninstallability follows its
+# requirement, then the user's own knobs, then the bounds only upstream can move
+kind_rank(::Requirement)   = 1
+kind_rank(::Uninstallable) = 2
+kind_rank(::Pin)           = 3
+kind_rank(::UserCompat)    = 4
+kind_rank(::Admission)     = 5
+kind_rank(::Bound)         = 6
+
+order_facts(fs::Vector{Fact}) =
+    sort(fs; by = f -> (kind_rank(f), fact_pkg(f)))
+
+"""
+    Fix(actions, solution)
+
+A verified minimal correction: relaxing every fact in `actions` — dropping a
+`Requirement`, loosening a `UserCompat`, lifting a `Pin` — makes the problem
+solvable, and `solution` is the resolution it then produces.
+"""
+struct Fix{P,V}
+    actions  :: Vector{Fact}
+    solution :: Dict{P,V}
+end
+
+"""
+    UpstreamFix(bound, solution)
+
+A conflict that a new upstream release could fix on its own: were `bound`
+relaxed, the conflict would go away and `solution` is what would resolve.
+"""
+struct UpstreamFix{P,V}
+    bound    :: Bound{P,V}
+    solution :: Dict{P,V}
+end
+
+"""
+    Conflict(reqs, chain, upstream)
+
+One independent reason the problem is unsatisfiable: `reqs` is a minimal set of
+requirements that cannot be satisfied together, `chain` tells the story as an
+ordered list of facts, and `upstream` lists bounds whose relaxation would
+resolve this conflict.
+"""
+struct Conflict{P,V}
+    reqs     :: Vector{P}
+    chain    :: Vector{Fact}
+    upstream :: Vector{UpstreamFix{P,V}}
+end
+
+"""
+    Diagnosis(reqs, conflicts, fixes, versions)
+
+Why a resolution problem is unsatisfiable: the `conflicts` are independent, the
+`fixes` are global (each one repairs every conflict at once), and `versions`
+records the version list of every package the report mentions, so a renderer
+can compress version sets into ranges.
+
+An empty `fixes` means there is nothing to propose: every correction would have
+to drop a requirement that dropping does not help, which happens when only an
+upstream release could resolve the conflict.
+"""
+struct Diagnosis{P,V}
+    reqs      :: Vector{P}
+    conflicts :: Vector{Conflict{P,V}}
+    fixes     :: Vector{Fix{P,V}}
+    versions  :: Dict{P,Vector{V}}
+end
+
+# a fix dominates another if it relaxes a proper subset of what the other
+# relaxes; dominated fixes carry no information and are suppressed
+function filter_dominated(fixes::Vector{Fix{P,V}}) where {P,V}
+    sets = [Set{Fact}(fix.actions) for fix in fixes]
+    keep = [!any(sets[j] ⊊ sets[i] for j in eachindex(sets))
+            for i in eachindex(sets)]
+    return fixes[keep]
+end
+
+# order a cluster's facts into story order: requirements first (sorted), then a
+# BFS from the required packages along package links — introducing a package
+# emits its uninstallability, pin and compat facts, then its bounds (each bound
+# introduces the package on its other side). Deterministic: the queue is
+# processed in sorted order.
+function order_chain(facts::Vector{Fact}, ::Type{P}, ::Type{V}) where {P,V}
+    reqfacts = sort!(Fact[f for f in facts if f isa Requirement]; by = fact_pkg)
+    Uby = Dict{P,Uninstallable{P}}()
+    Cby = Dict{P,UserCompat{P,V}}()
+    Hby = Dict{P,Pin{P,V}}()
+    Aby = Dict{P,Vector{Admission{P,V}}}()
+    Bby = Dict{P,Vector{Bound{P,V}}}()
+    for f in facts
+        f isa Uninstallable && (Uby[f.pkg] = f)
+        f isa UserCompat    && (Cby[f.pkg] = f)
+        f isa Pin           && (Hby[f.pkg] = f)
+        f isa Admission     && push!(get!(() -> Admission{P,V}[], Aby, f.pkg), f)
+        f isa Bound         && push!(get!(() -> Bound{P,V}[], Bby, f.pkg), f)
+    end
+    foreach(v -> sort!(v; by = a -> a.kind), values(Aby))
+    foreach(v -> sort!(v; by = b -> (b.dep, b.versions)), values(Bby))
+    chain = copy(reqfacts)
+    visited = Set{P}()
+    queue = P[fact_pkg(f) for f in reqfacts]
+    while !isempty(queue)
+        sort!(queue)
+        p = popfirst!(queue)
+        p in visited && continue
+        push!(visited, p)
+        haskey(Uby, p) && push!(chain, Uby[p])
+        haskey(Hby, p) && push!(chain, Hby[p])
+        haskey(Cby, p) && push!(chain, Cby[p])
+        append!(chain, get(Aby, p, Admission{P,V}[]))
+        for b in get(Bby, p, Bound{P,V}[])
+            push!(chain, b)
+            push!(queue, b.dep)
+        end
+    end
+    # emit any facts the BFS didn't reach (deterministically)
+    for f in order_facts(Fact[f for f in facts if f ∉ chain])
+        push!(chain, f)
+    end
+    return chain
+end
+
+# diagnosis on the failed production instance
+#
+# The instance `resolve` just failed on is convertible in place: one `sat_pop`
+# frees every user-constraint selector, and from then on a diagnostic query is
+# an assumption set -- some requirement package variables, some selectors --
+# and nothing else. That matters: the theory licensing all of this (see the
+# manual's diagnostics page) covers *relaxations* only, so no query may add a
+# clause. Fix enumeration force-keeps assumptions instead of blocking.
+#
+# It also fixes the granularity. Theorem D1 holds for column-closed groups, and
+# a package's user constraints are column-closed only taken *together* -- its
+# compat bound and its pin share one exclusion column, and relaxing half of one
+# is exactly the counterexample of Proposition D1'. So the relaxable unit here
+# is a package: a fix touching a package with both sources relaxes both.
+
+# one relaxable group: the assumption literals that switch it on
+struct Relaxable{P}
+    kind :: Symbol       # :req or :user
+    pkg  :: P
+    lits :: Vector{Int}
+end
+
+"""
+    Relaxation
+
+The knobs a diagnosis may turn on the failed instance: `rel` is every group,
+`reqs` the requirement groups a fix may drop, and `user` the constraint groups
+a fix may relax.
+
+`user` is one group per constrained package, holding all of its selectors --
+its whole exclusion column. Switching a whole column off is a column-closed
+relaxation whatever the sources in it, which is the granularity Theorem D1
+licenses and the only one anything here asks for.
+
+No group is assumed implicitly: a group left out of an assumption set is
+*free*, and the solver will happily switch it off, so each caller names exactly
+the context its query means to hold.
+"""
+struct Relaxation{P}
+    rel  :: Vector{Relaxable{P}}
+    reqs :: Vector{Int}
+    user :: Vector{Int}
+end
+
+# switch exactly the given groups on and test satisfiability; everything else is
+# free, and the solver may set it false
+function relax_sat(sat::SAT, R::Relaxation, on)
+    for i in on, l in R.rel[i].lits
+        sat_assume_var(sat, l)
+    end
+    is_satisfiable(sat)
+end
+
+# group MUS with an actionability-biased deletion order.
+#
+# `on` are the groups switched on; `shrink` is the (ordered) subset we may
+# delete, least actionable first, so that when the same conflict can be told
+# two ways the surviving MUS keeps the explanation the user can act on. Groups
+# in `on ∖ shrink` are context and stay on.
+#
+# A single ordered pass suffices -- no restart after deletions. Satisfiability
+# is monotone under removing assumptions: if deleting `g` once made the
+# instance satisfiable (so `g` was kept), any later deletion of `g` would test
+# a subset of that satisfiable assumption set, which is still satisfiable. Kept
+# groups provably stay needed, and the result is minimal for the same reason.
+# We start from the full assumption set rather than the failed-assumption core,
+# which is nondeterministic and can drop the actionable explanation before the
+# biased order gets to prefer it.
+function group_mus(
+    sat    :: SAT,
+    R      :: Relaxation,
+    on     :: AbstractVector{Int},
+    shrink :: AbstractVector{Int},
+)
+    relax_sat(sat, R, on) && return Int[]
+    mus = collect(on)
+    for g in shrink
+        k = findfirst(==(g), mus)
+        k === nothing && continue
+        deleteat!(mus, k)
+        relax_sat(sat, R, mus) && insert!(mus, k, g) # needed: keep it
+    end
+    return sort!(mus)
+end
+
+# partition the requirements into independent conflicts (requirement-level
+# MICE): repeatedly extract a requirement-level MUS with every user group held
+# on as context, remove its members, repeat until what is left is satisfiable.
+# Each disjoint MUS is one cluster, and one story.
+function cluster_reqs(sat::SAT, R::Relaxation, reqs::Vector{Int})
+    remaining = copy(reqs)
+    reqset = Set(reqs)
+    clusters = Vector{Int}[]
+    while !isempty(remaining)
+        mus = group_mus(sat, R, Int[remaining; R.user], remaining)
+        rmus = filter(in(reqset), mus)
+        isempty(rmus) && break
+        push!(clusters, rmus)
+        setdiff!(remaining, rmus)
+    end
+    return clusters
+end
+
+# the resolution a fix produces: re-resolve this same instance with the kept
+# groups asserted and the dropped ones denied, inside a frame that unwinds
+# afterwards. Theorem D1 preserves the layered *answer*, not just the verdict,
+# so these are the versions the raw problem would give under the fix.
+function fix_solution(
+    sat  :: SAT{P,V},
+    R    :: Relaxation{P},
+    kept :: AbstractVector{Int},
+    by   :: Function,
+) where {P,V}
+    keptset = Set(kept)
+    reqs = P[R.rel[i].pkg for i in kept if R.rel[i].kind === :req]
+    with_temp_clauses(sat) do
+        for (i, r) in enumerate(R.rel)
+            r.kind === :user || continue
+            on = i in keptset
+            for l in r.lits
+                sat_add_var(sat, on ? l : -l)
+                sat_add(sat)
+            end
+        end
+        sol = resolve_core(sat, sort!(reqs); by, restore = false)
+        sol === nothing ? Dict{P,V}() :
+            Dict{P,V}(p => sat.info[p].versions[i] for (p, i) in sol)
+    end
+end
+
+# enumerate verified fixes as minimal correction sets, MARCO-style.
+#
+# A greedy pass over the relaxables in keep-order (requirements first, then the
+# user's own knobs) yields a maximal satisfiable subset; its complement is a
+# minimal correction set. To get the *next* fix we force-keep one of the groups
+# a previous fix dropped -- an assumption, not a clause -- and run the greedy
+# pass again. Working through the force-keep sets breadth-first enumerates
+# undominated alternatives without ever adding a constraint to the instance,
+# which is what the licensing theorem requires.
+function enumerate_fixes(
+    sat   :: SAT{P,V},
+    R     :: Relaxation{P},
+    order :: Vector{Int}, # keep-order over the relaxable group ids
+    extra :: Vector{Fact}; # actions every fix must take (uninstallable reqs)
+    max_fixes :: Integer = 8,
+    by :: Function = identity,
+    acceptable :: Function = (actions, sol) -> true,
+) where {P,V}
+    seed = Int[]
+    fixes = Fix{P,V}[]
+    found = Set{Vector{Int}}()
+    queued = Set{Vector{Int}}([seed])
+    queue = Vector{Int}[seed]
+    # most force-keep sets yield a fix, but an infeasible one yields none and
+    # costs a solve, so bound the passes rather than the fixes alone
+    passes = 0
+    while !isempty(queue) && length(fixes) < max_fixes && passes < 16max_fixes
+        passes += 1
+        force = popfirst!(queue)
+        # nothing can be fixed while keeping all of `force`
+        relax_sat(sat, R, force) || continue
+        # greedy maximal satisfiable subset in keep-order
+        kept = copy(force)
+        for g in order
+            g in force && continue
+            push!(kept, g)
+            relax_sat(sat, R, kept) || pop!(kept)
+        end
+        mcs = sort!(setdiff(order, kept))
+        # an empty correction set is still a fix when there are forced actions
+        # (uninstallable requirements); with none it means nothing was broken
+        isempty(mcs) && isempty(extra) && continue
+        if mcs ∉ found
+            push!(found, mcs)
+            actions = copy(extra)
+            for i in mcs
+                append!(actions, group_facts(sat, R.rel[i]))
+            end
+            actions = order_facts(actions)
+            sol = fix_solution(sat, R, kept, by)
+            # a correction the caller will not stand behind is not a fix: the
+            # BFS still expands past it, so the alternatives get found
+            acceptable(actions, sol) && push!(fixes, Fix{P,V}(actions, sol))
+        end
+        # the next fixes keep something this one dropped
+        for g in mcs
+            next = sort!(push!(copy(force), g))
+            next ∈ queued && continue
+            push!(queued, next)
+            push!(queue, next)
+        end
+    end
+    return filter_dominated(fixes)
+end
+
+# the facts a relaxable group stands for.
+#
+# A group is a whole package's constraints -- compat bound, pin, and every
+# admission knob that touches it -- because they share one exclusion column and
+# Theorem D1 only licenses moving a column as a whole. What the facts name is
+# the sources that put a cell in that column: a source forbidding no version
+# this instance still has contributes nothing to it, so relaxing the group
+# neither needs it nor is affected by it, and naming it would ask the user to
+# make a change that had no part in the verification. (`SAT` decides which
+# sources get a selector by the same test, so facts and selectors agree.)
+function group_facts(sat::SAT{P,V}, r::Relaxable{P}) where {P,V}
+    r.kind === :req && return Fact[Requirement(r.pkg)]
+    facts = Fact[]
+    prob = sat.prob
+    prob === nothing && return facts
+    p = r.pkg
+    vers = sat.info[p].versions
+    # driven by the same enumeration `SAT` builds its selectors from, so the
+    # facts and the things they stand for cannot drift apart
+    for (kind, forbids) in exclusion_sources(prob, p)
+        forbidden = V[v for v in vers if forbids(v)]
+        isempty(forbidden) && continue
+        push!(facts,
+            kind === :pin    ? Pin{P,V}(p, prob.pins[p]) :
+            kind === :compat ? UserCompat{P,V}(p,
+                                   V[v for v in vers if v ∈ prob.compat[p]],
+                                   get(prob.labels, p, :compat)) :
+                               Admission{P,V}(kind, p, forbidden))
+    end
+    return facts
+end
+
+# the groups of a failed instance, in keep-order: requirements first (dropping
+# one is the coarsest change a user can make), then the packages whose
+# constraints the selectors guard.
+function relaxation(sat::SAT{P,V}, reqs::AbstractVector{P}) where {P,V}
+    rel = Relaxable{P}[]
+    rids = Int[]
+    for p in reqs
+        push!(rel, Relaxable{P}(:req, p, Int[sat.vars[p]]))
+        push!(rids, length(rel))
+    end
+    bypkg = Dict{P,Vector{Int}}()
+    for (sel, (_, p)) in sat.sels
+        push!(get!(() -> Int[], bypkg, p), sel)
+    end
+    uids = Int[]
+    for p in sort!(collect(keys(bypkg)))
+        push!(rel, Relaxable{P}(:user, p, sort!(bypkg[p])))
+        push!(uids, length(rel))
+    end
+    return Relaxation{P}(rel, rids, uids)
+end
+
+"""
+    diagnose(sat, reqs; by = identity, max_fixes = 8) :: Diagnosis
+
+Explain why `reqs` cannot be satisfied on `sat`, and list verified fixes.
+
+Must be called on an instance whose satisfiability check has just failed, with
+no clauses added since: the frame holding the user-constraint selectors is
+popped for the duration and re-asserted afterwards, so the instance is left
+exactly as it was found and can be reused.
+"""
+function diagnose(
+    sat  :: SAT{P,V},
+    reqs :: AbstractVector{P} = collect(keys(sat.info));
+    by   :: Function = identity,
+    max_fixes :: Integer = 8,
+) where {P,V}
+    # a requirement the filter dropped has no installable version at all, so it
+    # is not in the instance and cannot be reasoned about there: it is its own
+    # conflict, and every fix has to drop it
+    absent = sort!(P[p for p in reqs if !haskey(sat.info, p)])
+    present = sort!(P[p for p in reqs if haskey(sat.info, p)])
+    conflicts = Conflict{P,V}[
+        Conflict{P,V}([p], Fact[Requirement(p), Uninstallable(p)],
+                      UpstreamFix{P,V}[])
+        for p in absent]
+    forced = Fact[Requirement(p) for p in absent]
+
+    fixes, versions = with_relaxed_selectors(sat) do
+        R = relaxation(sat, present)
+        rel = R.rel
+        prob = something(sat.prob, Problem(P[]))
+        # the whole-column group of each constrained package, for story facts
+        bygroup = Dict{P,Int}(rel[i].pkg => i for i in R.user)
+        for cluster in cluster_reqs(sat, R, R.reqs)
+            creqs = sort!(P[rel[i].pkg for i in cluster])
+            # Phase B: which package-pair incompatibilities tell this story,
+            # and which single upstream release would end it. Third-party
+            # bounds are hard clauses here -- no selector overhead on the hot
+            # path -- so it runs on a closure sub-instance (see Closure.jl),
+            # which also lets it shrink the user groups in the right order:
+            # bounds first, so the actionable explanation survives
+            bfacts, ups, kept = bound_story(
+                sat.info, prob, creqs, P[rel[i].pkg for i in R.user], by)
+            if kept === nothing
+                # the closure was too big to explore: shrink the columns
+                # against the production instance instead, without the bias
+                mus = group_mus(sat, R, Int[cluster; R.user], R.user)
+                kept = P[rel[i].pkg for i in mus if rel[i].kind === :user]
+            end
+            # the packages this story is about: the cluster's requirements, the
+            # ones whose constraints the MUS needs, and the ones the
+            # incompatibilities name
+            told = Set{P}(creqs)
+            union!(told, kept)
+            for f in bfacts
+                push!(told, fact_pkg(f))
+                f isa Bound && push!(told, f.dep)
+            end
+            facts = Fact[Requirement(p) for p in creqs]
+            # A package the story already blames shows every source that rules a
+            # version of it out, the firm ones included: "the version that would
+            # have worked is yanked" explains something, it just cannot be
+            # offered as a fix. A package the story does *not* mention shows
+            # nothing -- there are plenty of yanked versions in a registry and
+            # none of them are news. Emitted once per package, since
+            # `group_facts` enumerates all of a package's sources at once.
+            for p in sort!(collect(told))
+                i = get(bygroup, p, 0)
+                i == 0 && continue
+                append!(facts, group_facts(sat, rel[i]))
+            end
+            append!(facts, bfacts)
+            push!(conflicts,
+                  Conflict{P,V}(creqs, order_chain(facts, P, V), ups))
+        end
+        order = Int[R.reqs; R.user]
+        fixes = enumerate_fixes(sat, R, order, forced; max_fixes, by,
+                                acceptable = fix_acceptable(sat))
+        # the version lists a renderer needs to compress fact version sets
+        # against: only the packages the report actually names, so a
+        # registry-scale diagnosis doesn't carry the whole universe around
+        vers = Dict{P,Vector{V}}()
+        record(p) = haskey(sat.info, p) &&
+            (vers[p] = copy(sat.info[p].versions))
+        for c in conflicts, f in c.chain
+            record(fact_pkg(f))
+            f isa Bound && record(f.dep)
+        end
+        fixes, vers
+    end
+    sort!(conflicts; by = c -> c.reqs)
+    return Diagnosis{P,V}(sort!(collect(reqs)), conflicts, fixes, versions)
+end
+
+"""
+    superseded(v, versions) :: Bool
+
+Is `v` a prerelease that a release has already replaced — a version `x.y.z-…`
+for which `x.y.z` itself is in `versions`?
+
+Telling someone to accept `1.2.3-alpha1` when `1.2.3` exists is not advice, so
+admitting prereleases is only ever suggested for versions this returns `false`
+for. The test is deliberately restricted to the *same base version*: the
+generalization that a newer release supersedes an older prerelease across base
+versions was considered and left out, pending evidence that it is what people
+want (an unreleased `2.0.0-rc1` is a real thing to want even when `1.9.0` is
+out).
+
+Version types with no notion of a prerelease are never superseded, so this costs
+nothing outside the `VersionNumber` world.
+"""
+superseded(v, versions) = false
+
+function superseded(v::VersionNumber, versions)
+    isempty(v.prerelease) && return false
+    any(versions) do w
+        isempty(w.prerelease) && w.major == v.major &&
+            w.minor == v.minor && w.patch == v.patch
+    end
+end
+
+# Would this correction be advice worth giving? A prerelease admission whose
+# newly-chosen version has since been released should not be offered. Checked
+# against the witness, since that is the version the user would actually end up
+# with.
+fix_acceptable(sat::SAT) = function (actions, sol)
+    for a in actions
+        a isa Admission && a.kind === :prerelease || continue
+        haskey(sol, a.pkg) || continue
+        superseded(sol[a.pkg], sat.info[a.pkg].versions) && return false
+    end
+    return true
+end
+
+# rendering
+
+# compress a subset of a package's versions into runs against the full list,
+# e.g. [1,2,3,5] against 1:5 → "1–3, 5"; the whole list → "all versions"
+function format_versions(whole::AbstractVector, subset::AbstractVector)
+    isempty(subset) && return "no versions"
+    idx = sort!(Int[i for i in (findfirst(==(v), whole) for v in subset)
+                    if i !== nothing])
+    isempty(idx) && return "no versions"
+    length(idx) == length(whole) && return "all versions"
+    # compress consecutive-in-`whole` versions into runs, then order the runs
+    # and each run's endpoints by version value -- independent of whether
+    # `whole` is sorted ascending or descending (the registry provider sorts
+    # versions descending, which otherwise prints ranges backwards, e.g.
+    # "1.11.0–1.0.0")
+    runs = Tuple{eltype(whole),eltype(whole)}[]
+    i = 1
+    while i ≤ length(idx)
+        j = i
+        while j < length(idx) && idx[j+1] == idx[j] + 1
+            j += 1
+        end
+        a, b = whole[idx[i]], whole[idx[j]]
+        push!(runs, (min(a, b), max(a, b)))
+        i = j + 1
+    end
+    sort!(runs; by = first)
+    return join((lo == hi ? string(lo) : string(lo, "–", hi)
+                 for (lo, hi) in runs), ", ")
+end
+
+# the version list to compress against; a package the diagnosis never recorded
+# (possible only for hand-built facts) falls back to the subset itself
+versions_of(d::Diagnosis{P,V}, p::P) where {P,V} = get(d.versions, p, V[])
+
+render_fact(io::IO, f::Requirement, d::Diagnosis) =
+    print(io, "you require ", f.pkg)
+render_fact(io::IO, f::Uninstallable, d::Diagnosis) =
+    print(io, "no version of ", f.pkg, " is installable")
+function render_fact(io::IO, f::UserCompat, d::Diagnosis)
+    vers = format_versions(versions_of(d, f.pkg), f.allowed)
+    f.label === :requested ?
+        print(io, "you requested ", f.pkg, " at ", vers) :
+    f.label === :compat ?
+        print(io, "your compat restricts ", f.pkg, " to ", vers) :
+        print(io, f.label, " restricts ", f.pkg, " to ", vers)
+end
+render_fact(io::IO, f::Pin, d::Diagnosis) =
+    print(io, f.pkg, " is pinned at ", f.version)
+# admission knobs get a sentence apiece where one reads better than the
+# generic phrasing; an unknown kind still renders sensibly
+function render_fact(io::IO, f::Admission, d::Diagnosis)
+    whole = versions_of(d, f.pkg)
+    n = length(f.forbidden)
+    # "all versions" is what `format_versions` says when the set is everything,
+    # which does not fit inside these sentences -- give those their own
+    if !isempty(whole) && n == length(whole)
+        f.kind === :prerelease ?
+            print(io, "every version of ", f.pkg,
+                  " is a prerelease, which is not allowed") :
+        f.kind === :yanked ?
+            print(io, "every version of ", f.pkg, " is yanked") :
+            print(io, "every version of ", f.pkg, " is ", f.kind,
+                  ", which is not allowed")
+        return
+    end
+    vers = format_versions(whole, f.forbidden)
+    if f.kind === :prerelease
+        print(io, "prereleases of ", f.pkg, " are not allowed (", vers, ")")
+    elseif f.kind === :yanked
+        print(io, n == 1 ? "version " : "versions ", vers, " of ", f.pkg,
+              n == 1 ? " is yanked" : " are yanked")
+    else
+        print(io, f.kind, " versions of ", f.pkg,
+              " are not allowed (", vers, ")")
+    end
+end
+function render_fact(io::IO, f::Bound, d::Diagnosis)
+    all_p = versions_of(d, f.pkg)
+    src = length(f.versions) == length(all_p) ? "(all versions)" :
+          format_versions(all_p, f.versions)
+    print(io, f.pkg, " ", src, " works with ", f.dep, " only at ",
+          format_versions(versions_of(d, f.dep), f.allowed))
+end
+
+render_action(f::Requirement) = string("drop requirement ", f.pkg)
+render_action(f::UserCompat)  =
+    f.label === :requested ? string("relax the version you requested for ", f.pkg) :
+    f.label === :compat    ? string("relax your compat on ", f.pkg) :
+                             string("relax the ", f.label, " on ", f.pkg)
+render_action(f::Pin)         = string("unpin ", f.pkg)
+render_action(f::Admission)   =
+    f.kind === :prerelease ? string("allow prereleases of ", f.pkg) :
+    f.kind === :yanked ?
+        string("allow the yanked version", length(f.forbidden) == 1 ? " " : "s ",
+               join(f.forbidden, ", "), " of ", f.pkg) :
+        string("allow ", f.kind, " versions of ", f.pkg)
+
+# packages worth naming in a fix's resulting solution: the requirements plus the
+# dependencies actually implicated in some conflict. A verified solution lists
+# the entire transitive closure at whatever versions it happened to pick, which
+# is mostly noise -- the contested packages are what a fix meaningfully changes.
+# The complete assignment is still available on `Fix.solution` /
+# `UpstreamFix.solution` for programmatic use (e.g. emitting a manifest).
+function relevant_pkgs(d::Diagnosis{P,V}) where {P,V}
+    rel = Set{P}(d.reqs)
+    union!(rel, story_pkgs(d))
+    return rel
+end
+
+# just the packages some conflict's story names
+function story_pkgs(d::Diagnosis{P,V}) where {P,V}
+    rel = Set{P}()
+    for c in d.conflicts, f in c.chain
+        push!(rel, fact_pkg(f))
+        f isa Bound && push!(rel, f.dep)
+    end
+    return rel
+end
+
+# Packages worth naming in a witness: the requirements, and the ones some
+# conflict's story is about. A platform package the user never chose -- julia --
+# stays out of this by being modelled as a dependency edge rather than a
+# requirement, which is the convention integrators are asked to follow; it then
+# appears only when a story actually blames it.
+function witness_pkgs(d::Diagnosis{P,V}, sol::AbstractDict{P,V}) where {P,V}
+    rel = relevant_pkgs(d)
+    P[p for p in keys(sol) if p ∈ rel]
+end
+
+function render_solution(d::Diagnosis{P,V}, sol::AbstractDict{P,V}) where {P,V}
+    pkgs = witness_pkgs(d, sol)
+    isempty(pkgs) && return "nothing"
+    reqset = Set(d.reqs)
+    sort!(pkgs)
+    sort!(pkgs; by = p -> p ∉ reqset) # requirements first (stable)
+    join((string(p, " ", sol[p]) for p in pkgs), ", ")
+end
+
+# the demoted bound facts of a conflict, as package => versions, in a
+# deterministic order
+function incidental_versions(c::Conflict{P,V}) where {P,V}
+    byp = Dict{P,Vector{V}}()
+    for f in c.chain
+        f isa Bound && f.incidental || continue
+        append!(get!(() -> V[], byp, f.pkg), f.versions)
+    end
+    return [p => sort!(unique!(byp[p])) for p in sort!(collect(keys(byp)))]
+end
+
+# compact summary
+function Base.show(io::IO, d::Diagnosis)
+    print(io, "Diagnosis(", summary_counts(d), ")")
+end
+
+# "1 conflict, 2 fixes" -- the shape of the answer, for either show
+function summary_counts(d::Diagnosis)
+    nc = length(d.conflicts)
+    nf = length(d.fixes)
+    string(nc, nc == 1 ? " conflict, " : " conflicts, ",
+           nf, nf == 1 ? " fix" : " fixes")
+end
+
+# full report. It opens by saying what it is: a `Diagnosis` *is* the answer
+# `resolve` gives to requirements it cannot satisfy, so one showing up at the
+# REPL has to read as that answer and not as a stray object.
+function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis)
+    println(io, "Unsatisfiable — ", summary_counts(d),
+            isempty(d.conflicts) ? "" : ":")
+    for (n, c) in enumerate(d.conflicts)
+        n > 1 && println(io)
+        rs = join(c.reqs, ", ")
+        println(io, "Conflict ", n, ": ", rs,
+                length(c.reqs) == 1 ? " cannot be satisfied." :
+                " cannot be satisfied together.")
+        for f in c.chain
+            f isa Bound && f.incidental && continue
+            print(io, "  • ")
+            render_fact(io, f, d)
+            println(io)
+        end
+        # the facts that only close off versions the query already excludes:
+        # one summary line per package, rather than a bullet apiece competing
+        # with the lines that name versions the reader could actually get
+        for (p, vs) in incidental_versions(c)
+            println(io, "    (likewise for ", p, " ",
+                    format_versions(versions_of(d, p), vs),
+                    ", which your constraints already rule out)")
+        end
+    end
+    ups = [u for c in d.conflicts for u in c.upstream]
+    if !isempty(d.fixes)
+        println(io)
+        println(io, "Verified fixes:")
+        for (n, fix) in enumerate(d.fixes)
+            println(io, "  ", n, ". ",
+                    join(map(render_action, fix.actions), " and "))
+            println(io, "     → allows: ", render_solution(d, fix.solution))
+        end
+    elseif !isempty(d.conflicts)
+        println(io)
+        println(io, isempty(ups) ?
+            "There is nothing you can change that would fix this." :
+            "There is nothing you can change that would fix this — only an upstream release could.")
+    end
+    if !isempty(ups)
+        println(io)
+        println(io, "Upstream fixes:")
+        for u in Iterators.take(ups, MAX_UPSTREAM_SHOWN)
+            println(io, "  • a release of ", u.bound.pkg, " or ", u.bound.dep,
+                    " relaxing their compat on each other")
+            println(io, "    → allows: ", render_solution(d, u.solution))
+        end
+        extra = length(ups) - MAX_UPSTREAM_SHOWN
+        extra > 0 && println(io, "  (", extra,
+            " more possible upstream fix", extra == 1 ? "" : "es",
+            " not shown)")
+    end
+end
+
+# How many upstream suggestions a report prints. A tangled conflict can produce
+# a dozen, all true and most useless -- ten for one real project -- and
+# they are ranked (see `rank_upstream!`), so the tail is the least plausible.
+# The structured `Diagnosis` keeps every one of them.
+const MAX_UPSTREAM_SHOWN = 3

--- a/src/Diagnose.jl
+++ b/src/Diagnose.jl
@@ -619,12 +619,10 @@ function diagnose(
                 f isa Bound && push!(told, f.dep)
             end
             facts = Fact[Requirement(p) for p in creqs]
-            # A package the story already blames shows every source that rules a
-            # version of it out, the firm ones included: "the version that would
-            # have worked is yanked" explains something, it just cannot be
-            # offered as a fix. A package the story does *not* mention shows
-            # nothing -- there are plenty of yanked versions in a registry and
-            # none of them are news. Emitted once per package, since
+            # A package the story already blames shows every source that rules
+            # a version of it out -- a prerelease ban explains something even
+            # where relaxing it is not the fix on offer. A package the story
+            # does *not* mention shows nothing. Emitted once per package, since
             # `group_facts` enumerates all of a package's sources at once.
             for p in sort!(collect(told))
                 i = get(bygroup, p, 0)
@@ -958,24 +956,66 @@ function summary_counts(d::Diagnosis)
            nf, nf == 1 ? " fix" : " fixes")
 end
 
-# full report. It opens by saying what it is: a `Diagnosis` *is* the answer
-# `resolve` gives to requirements it cannot satisfy, so one showing up at the
-# REPL has to read as that answer and not as a stray object.
-function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis)
+"""
+    report(io, d::Diagnosis; max_upstream = 3, demote_incidental = true,
+                             trim_witnesses = true, labels = nothing)
+
+Render `d` as the report `show` prints, with the opinionated parts turned into
+arguments. `show(io, MIME("text/plain"), d)` is `report(io, d)` and nothing
+else, so every default here is a documented choice rather than a hidden one.
+
+  * `max_upstream` — how many upstream suggestions to print before the
+    "(N more …)" line. They are ranked (see
+    [`rank_upstream!`](@ref Resolver.rank_upstream!)), so the tail is the least
+    plausible; `typemax(Int)` prints all of them.
+  * `demote_incidental` — fold the [`Bound`](@ref Resolver.Bound)s whose
+    `incidental` flag is set into the one-line "(likewise for …)" aside instead
+    of giving each a bullet. They are needed for the conflict to be *minimal*
+    but they only close off versions the query already excludes.
+  * `trim_witnesses` — restrict each "→ allows:" line to the requirements and
+    the packages some story names. A verified solution is the whole transitive
+    closure; the contested packages are what a fix meaningfully changes, and
+    the complete assignment is on `Fix.solution` either way.
+  * `labels` — override the source wording per package, as
+    [`Problem`](@ref)'s `labels` does at diagnosis time: `:requested` reads
+    "you requested X at 1.7", `:compat` (the default) "your compat restricts X
+    to 1.7". Unknown labels render neutrally. Pass this when the wording is a
+    property of the caller rather than of the problem.
+
+A client that wants a different layout entirely builds it from the structured
+`Diagnosis` with the same sentence helpers this uses —
+[`render_fact`](@ref Resolver.render_fact),
+[`render_action`](@ref Resolver.render_action) and
+[`blame_phrase`](@ref Resolver.blame_phrase) — or reads the `Fact` fields and
+writes its own sentences.
+"""
+function report(
+    io :: IO,
+    d  :: Diagnosis;
+    max_upstream :: Integer = MAX_UPSTREAM_SHOWN,
+    demote_incidental :: Bool = true,
+    trim_witnesses :: Bool = true,
+    labels = nothing,
+)
+    lab(f) = relabel(f, labels)
+    sol_str(sol) = trim_witnesses ? render_solution(d, sol) :
+        (isempty(sol) ? "nothing" :
+         join((string(p, " ", sol[p]) for p in sort!(collect(keys(sol)))), ", "))
     println(io, "Unsatisfiable — ", summary_counts(d),
             isempty(d.conflicts) ? "" : ":")
     for (n, c) in enumerate(d.conflicts)
         n > 1 && println(io)
         println(io, "Conflict ", n, ": ", conflict_header(c))
         for f in c.chain
-            f isa Bound && f.incidental && continue
+            demote_incidental && f isa Bound && f.incidental && continue
             print(io, "  • ")
-            render_fact(io, f, d)
+            render_fact(io, lab(f), d)
             println(io)
         end
         # the facts that only close off versions the query already excludes:
         # one summary line per package, rather than a bullet apiece competing
         # with the lines that name versions the reader could actually get
+        demote_incidental || continue
         for (p, vs) in incidental_versions(c)
             println(io, "    (likewise for ", p, " ",
                     format_versions(versions_of(d, p), vs),
@@ -988,8 +1028,8 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis)
         println(io, "Verified fixes:")
         for (n, fix) in enumerate(d.fixes)
             println(io, "  ", n, ". ",
-                    join(map(render_action, fix.actions), " and "))
-            println(io, "     → allows: ", render_solution(d, fix.solution))
+                    join(map(render_action ∘ lab, fix.actions), " and "))
+            println(io, "     → allows: ", sol_str(fix.solution))
         end
     elseif !isempty(d.conflicts)
         println(io)
@@ -1000,21 +1040,79 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis)
     if !isempty(ups)
         println(io)
         println(io, "Upstream fixes:")
-        for u in Iterators.take(ups, MAX_UPSTREAM_SHOWN)
+        for u in Iterators.take(ups, max_upstream)
             println(io, "  • a release of ", u.bound.pkg, " or ", u.bound.dep,
                     " relaxing their compat on each other")
-            println(io, "    → allows: ", render_solution(d, u.solution))
+            println(io, "    → allows: ", sol_str(u.solution))
         end
-        extra = length(ups) - MAX_UPSTREAM_SHOWN
+        extra = length(ups) - max_upstream
         extra > 0 && println(io, "  (", extra,
             " more possible upstream fix", extra == 1 ? "" : "es",
             " not shown)")
     end
 end
 
+# a report-time `labels` override, applied to the one fact kind that carries a
+# source flavour; everything else passes through untouched
+relabel(f::Fact, labels) = f
+relabel(f::UserCompat{P,V}, labels::AbstractDict) where {P,V} =
+    haskey(labels, f.pkg) ?
+        UserCompat{P,V}(f.pkg, f.allowed, Symbol(labels[f.pkg])) : f
+relabel(f::UserCompat, ::Nothing) = f
+
+# full report. It opens by saying what it is: a `Diagnosis` *is* the answer
+# `resolve` gives to requirements it cannot satisfy, so one showing up at the
+# REPL has to read as that answer and not as a stray object.
+Base.show(io::IO, ::MIME"text/plain", d::Diagnosis) = report(io, d)
 
 # How many upstream suggestions a report prints. A tangled conflict can produce
 # a dozen, all true and most useless -- ten for one real project -- and
 # they are ranked (see `rank_upstream!`), so the tail is the least plausible.
 # The structured `Diagnosis` keeps every one of them.
 const MAX_UPSTREAM_SHOWN = 3
+
+## solution diffs
+
+"""
+    Change(pkg, from, to)
+
+One package's difference between two solutions: `from` is `nothing` when the
+package is new, `to` is `nothing` when it is gone, and otherwise both are
+versions and they differ.
+"""
+struct Change{P,V}
+    pkg  :: P
+    from :: Union{Nothing,V}
+    to   :: Union{Nothing,V}
+end
+
+function Base.show(io::IO, c::Change)
+    c.from === nothing && return print(io, c.pkg, " ", c.to, " added")
+    c.to === nothing && return print(io, c.pkg, " ", c.from, " removed")
+    print(io, c.pkg, " ", c.from, " → ", c.to)
+end
+
+"""
+    changes(sol₁, sol₂) :: Vector{Change}
+
+What `sol₂` does differently from `sol₁`, one [`Change`](@ref Resolver.Change)
+per package that moved, appeared or disappeared, sorted by package.
+
+This is how a feasible goal query gets its price tag: `resolve` answers
+`without = "TranscodingStreams"` with a `Dict` rather than a complaint, and the
+"avoidable, but it costs you CSV 0.10.15 → 0.5.26" rendering is this diff
+against the plain resolve. Both solutions are the caller's already; nothing
+here needs the resolver.
+"""
+function changes(
+    a :: AbstractDict{P,V},
+    b :: AbstractDict{P,V},
+) where {P,V}
+    out = Change{P,V}[]
+    for p in sort!(collect(union(keys(a), keys(b))))
+        u = get(a, p, nothing)
+        w = get(b, p, nothing)
+        u == w || push!(out, Change{P,V}(p, u, w))
+    end
+    return out
+end

--- a/src/Diagnose.jl
+++ b/src/Diagnose.jl
@@ -662,13 +662,15 @@ end
 
 # the version list to compress against; a package the diagnosis never recorded
 # (possible only for hand-built facts) falls back to the subset itself
-versions_of(d::Diagnosis{P,V}, p::P) where {P,V} = get(d.versions, p, V[])
+# `d` is anything carrying a `versions` table -- a `Diagnosis` or a `Holdback`;
+# rendering a fact needs the package's version list and nothing else
+versions_of(d, p) = get(d.versions, p, valtype(d.versions)())
 
-render_fact(io::IO, f::Requirement, d::Diagnosis) =
+render_fact(io::IO, f::Requirement, d) =
     print(io, "you require ", f.pkg)
-render_fact(io::IO, f::Uninstallable, d::Diagnosis) =
+render_fact(io::IO, f::Uninstallable, d) =
     print(io, "no version of ", f.pkg, " is installable")
-function render_fact(io::IO, f::UserCompat, d::Diagnosis)
+function render_fact(io::IO, f::UserCompat, d)
     vers = format_versions(versions_of(d, f.pkg), f.allowed)
     f.label === :requested ?
         print(io, "you requested ", f.pkg, " at ", vers) :
@@ -676,11 +678,11 @@ function render_fact(io::IO, f::UserCompat, d::Diagnosis)
         print(io, "your compat restricts ", f.pkg, " to ", vers) :
         print(io, f.label, " restricts ", f.pkg, " to ", vers)
 end
-render_fact(io::IO, f::Pin, d::Diagnosis) =
+render_fact(io::IO, f::Pin, d) =
     print(io, f.pkg, " is pinned at ", f.version)
 # admission knobs get a sentence apiece where one reads better than the
 # generic phrasing; an unknown kind still renders sensibly
-function render_fact(io::IO, f::Admission, d::Diagnosis)
+function render_fact(io::IO, f::Admission, d)
     whole = versions_of(d, f.pkg)
     n = length(f.forbidden)
     # "all versions" is what `format_versions` says when the set is everything,
@@ -706,7 +708,7 @@ function render_fact(io::IO, f::Admission, d::Diagnosis)
               " are not allowed (", vers, ")")
     end
 end
-function render_fact(io::IO, f::Bound, d::Diagnosis)
+function render_fact(io::IO, f::Bound, d)
     all_p = versions_of(d, f.pkg)
     src = length(f.versions) == length(all_p) ? "(all versions)" :
           format_versions(all_p, f.versions)

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -519,6 +519,37 @@ function mark_installable!(
     end
 end
 
+# one sweep of the domination candidates against an exclusion column: every
+# still-tracked version the column excludes has its candidates restricted to
+# the versions the column also excludes, and drops out of the sweep when none
+# are left. A named function rather than a closure in `mark_necessary!`'s
+# per-package loop, which is the filter's hot path.
+function exclude_column!(
+    D    :: Vector{UInt64}, # per-version candidate masks
+    T    :: Vector{UInt64}, # versions still tracked
+    E    :: Vector{UInt64}, # scratch: the column, padded to the column width
+    mask :: BitVector,
+    W    :: Int,
+)
+    resize!(E, W)
+    fill!(E, 0)
+    copyto!(E, 1, mask.chunks, 1, min(W, length(mask.chunks)))
+    @inbounds for w = 1:W
+        c = E[w] & T[w]
+        while !iszero(c)
+            i = ((w - 1) << 6) + trailing_zeros(c) + 1
+            c &= c - 1
+            o = (i - 1) * W
+            live = UInt64(0)
+            for w′ = 1:W
+                live |= (D[o + w′] &= E[w′])
+            end
+            iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
+        end
+    end
+    return T
+end
+
 function mark_necessary!(
     info :: Dict{P, PkgInfo{P,V}},
     excl :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
@@ -674,29 +705,12 @@ function mark_necessary!(
                 end
             end
         end
-        # the virtual package representing the user constraints contributes
-        # one more conflict column — the exclusion mask. its version is
-        # always present, so the column is always active: an excluded
-        # version must not dominate a non-excluded one
+        # the virtual package representing the constraints contributes one
+        # more conflict column -- the exclusion mask. its version is always
+        # present, so the column is always active: an excluded version must not
+        # dominate a non-excluded one
         excl_p = excls[p]
-        if excl_p !== nothing
-            resize!(E, W)
-            fill!(E, 0)
-            copyto!(E, 1, excl_p.chunks, 1, min(W, length(excl_p.chunks)))
-            @inbounds for w = 1:W
-                c = E[w] & T[w]
-                while !iszero(c)
-                    i = ((w - 1) << 6) + trailing_zeros(c) + 1
-                    c &= c - 1
-                    o = (i - 1) * W
-                    live = UInt64(0)
-                    for w′ = 1:W
-                        live |= (D[o + w′] &= E[w′])
-                    end
-                    iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
-                end
-            end
-        end
+        excl_p === nothing || exclude_column!(D, T, E, excl_p, W)
         # union of all candidate sets = the dominated versions
         fill!(T, UInt64(0)) # reuse as the union accumulator
         @inbounds for w = 1:W

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -68,6 +68,7 @@ function class_representatives(
     info  :: AbstractDict{P, PkgInfo{P,V}},
     prob  :: Problem{P} = Problem(P[]),
     perms :: Union{Nothing, AbstractDict{P, Vector{Int}}} = nothing,
+    named :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
 ) where {P,V}
     excl = exclusion_masks(info, prob)
     keep = Dict{P,BitVector}()
@@ -90,6 +91,11 @@ function class_representatives(
             seen[c] = true
             k[i] = true
         end
+        # a version some query names by *value* -- a `pkg => version` goal --
+        # has to survive as itself: its class siblings answer every constraint
+        # the same way, but they are not the version that was asked for
+        n = get(named, p, nothing)
+        n === nothing || (k .|= n)
         keep[p] = k
     end
     return keep
@@ -248,7 +254,8 @@ filter_pkg_info!(
 
 function filter_pkg_info!(
     info :: Dict{P, PkgInfo{P,V}},
-    prob :: Problem{P},
+    prob :: Problem{P};
+    reach :: Bool = true, # false: keep every route a goal might need
 ) where {P,V}
     reqs = prob.reqs
     # user constraints enter as the exclusion masks of the virtual package
@@ -275,7 +282,18 @@ function filter_pkg_info!(
     # can satisfy those — so the requirements remain valid across rounds.
     # rounds strictly shrink the total version count, so the loop
     # terminates
+    #
+    # `reach = false` runs only the arc-consistency pass: reachability and
+    # redundancy both preserve the *optimal* answer, which is a weaker thing
+    # than preserving the answer to an arbitrary goal, and either can delete
+    # the only version of a package that avoids (or reaches) the one a goal is
+    # about. Arc consistency deletes only versions no model contains at all,
+    # which can witness no goal either.
     mark_installable!(info)
+    if !reach
+        drop_unmarked!(info)
+        return info
+    end
     mark_necessary!(info, excl)
     drop_unmarked!(info)
     while true

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -1,0 +1,139 @@
+# Goals: what a resolve is *for*, beyond satisfying the problem.
+#
+# `prob`'s constraints are negotiable -- a diagnosis may propose relaxing any of
+# them -- and the goal is the fixed ask. That one sentence is the whole semantic
+# difference between `resolve(info, prob; with = "CUDA")` and adding CUDA to
+# `prob.reqs`: "drop requirement CUDA" can never appear as a fix.
+#
+# In the instance a goal is a hard assumption: one selector-guarded clause per
+# term, held on by every probe a diagnosis runs, and absent from the keep-order
+# fix enumeration works over. Held on rather than asserted at level 0 only so
+# that a conflict can be asked whether it *needed* the goal, which is what tells
+# the report's header apart from an ordinary one.
+
+"""
+    Goal(with, without)
+
+A resolve's fixed ask: `with` names packages that must be present — each as
+`pkg => versions` where `versions` is `nothing` for "any version" and otherwise
+anything `in` answers for — and `without` names packages that must be absent.
+
+Built from `resolve`'s `with` / `without` keywords rather than constructed
+directly; nothing about it is exported.
+"""
+struct Goal{P}
+    with    :: Vector{Pair{P,Any}}
+    without :: Vector{P}
+end
+
+Base.isempty(g::Goal) = isempty(g.with) && isempty(g.without)
+
+# the packages a goal is about: what the universe has to cover for it to be
+# answerable at all
+goal_packages(g::Goal{P}) where {P} =
+    sort!(unique!(P[P[p for (p, _) in g.with]; g.without]))
+
+# does this version satisfy a version goal? the target is any `in`-supporting
+# set -- and a bare version of the universe's own version type reads as the
+# singleton set containing it, so `with = "DataFrames" => v"1.8.2"` means what
+# it looks like
+matches_goal(v::V, s::V) where {V} = v == s
+matches_goal(v, s) = v ∈ s
+
+# Normalize the keyword arguments. Each accepts a package, a `pkg => versions`
+# pair, or any collection of those; `nothing` (the default) means no goal, and a
+# goal with nothing in it is `nothing` again, so the unconstrained path never
+# pays for the machinery below.
+function make_goal(::Type{P}, with, without) where {P}
+    with === nothing && without === nothing && return nothing
+    g = Goal{P}(Pair{P,Any}[], P[])
+    add_with!(g.with, P, with)
+    add_without!(g.without, P, without)
+    isempty(g) ? nothing : g
+end
+
+add_with!(v::Vector{Pair{P,Any}}, ::Type{P}, ::Nothing) where {P} = v
+add_with!(v::Vector{Pair{P,Any}}, ::Type{P}, p::P) where {P} =
+    push!(v, p => nothing)
+add_with!(v::Vector{Pair{P,Any}}, ::Type{P}, x::Pair) where {P} =
+    push!(v, convert(P, first(x)) => last(x))
+add_with!(v::Vector{Pair{P,Any}}, ::Type{P}, xs) where {P} =
+    (foreach(x -> add_with!(v, P, x), xs); v)
+
+add_without!(v::Vector{P}, ::Type{P}, ::Nothing) where {P} = v
+add_without!(v::Vector{P}, ::Type{P}, p::P) where {P} = push!(v, p)
+add_without!(v::Vector{P}, ::Type{P}, xs) where {P} =
+    (foreach(x -> add_without!(v, P, x), xs); v)
+
+# May a sub-instance still be filtered for reachability and redundancy under
+# this goal? Yes with no goal, and yes for a pure presence ask -- whose packages
+# the caller has already made requirements of the sub-instance, so reachability
+# keeps their prefix. Anything that names versions, or bans a package, is
+# exactly what those passes prune away.
+goal_reach_safe(::Nothing) = true
+goal_reach_safe(g::Goal) =
+    isempty(g.without) && all(s === nothing for (_, s) in g.with)
+
+# The versions a goal names by value, per package, as a mask over the universe's
+# version list. The class collapse must keep these as representatives of their
+# own: two versions in one interchangeability class are indistinguishable to
+# every constraint, but a goal is stated on the version *value*, so collapsing
+# the one the caller asked for into a sibling would answer a different question.
+function goal_masks(
+    info :: AbstractDict{P,PkgInfo{P,V}},
+    goal :: Goal{P},
+) where {P,V}
+    masks = Dict{P,BitVector}()
+    for (p, s) in goal.with
+        s === nothing && continue
+        haskey(info, p) || continue
+        vers = info[p].versions
+        m = falses(length(vers))
+        for (i, v) in enumerate(vers)
+            m[i] = matches_goal(v, s)
+        end
+        any(m) && (masks[p] = m)
+    end
+    return masks
+end
+
+"""
+    prepare_goal_info(info, prob, goal; order = nothing) :: Dict{P,PkgInfo{P,V}}
+
+The **goal sub-instance**: the T1 artifact `info`, collapsed to
+interchangeability-class representatives and arc-consistent, but *not* filtered
+for reachability or redundancy.
+
+Those two passes are what the per-resolve preparation
+([`prepare_pkg_info`](@ref Resolver.prepare_pkg_info)) adds, and they prune
+exactly the escape routes a goal needs: reachability keeps only the versions an
+*optimal* solution could use, and redundancy drops a version a better one
+dominates — either can delete the only version of a package that avoids (or
+reaches) the package the goal is about. See the manual's diagnostics theory page
+on goal safety.
+
+What survives is licensed: arc consistency deletes only versions no model
+contains, which can witness no goal; and interchangeability classes never merge
+across different dependency sets, so a package that avoids `X` can never hide
+inside a class whose representative needs it. Versions a goal names by value are
+kept out of the collapse besides, since a class sibling is not the version that
+was asked for.
+"""
+function prepare_goal_info(
+    info  :: AbstractDict{P,PkgInfo{P,V}},
+    prob  :: Problem{P},
+    goal  :: Goal{P};
+    group :: Bool = true,
+    order = nothing,
+) where {P,V}
+    perms = version_permutations(info, order)
+    keep = group ?
+        class_representatives(info, prob, perms, goal_masks(info, goal)) :
+        nothing
+    work = Dict{P,PkgInfo{P,V}}()
+    copy_marked!(work, info, keep, perms)
+    drop_unmarked!(work)      # materialize the collapse
+    mark_installable!(work)   # ... which can leave a dependency unsatisfiable
+    drop_unmarked!(work)
+    return work
+end

--- a/src/Holdback.jl
+++ b/src/Holdback.jl
@@ -324,7 +324,14 @@ function Base.show(io::IO, ::MIME"text/plain", h::Holdback)
             " → allows: ", holdback_solution(h))
 end
 
-# "your compat on Statistics", the noun form of the action a fix would take
+"""
+    blame_phrase(f::Fact) :: String
+
+The noun form of the change `f` stands for — "your compat on Statistics", "your
+pin on Foo" — for sentences that name a culprit rather than issue an
+instruction ("held back by *your compat on Statistics*"). The counterpart of
+[`render_action`](@ref Resolver.render_action).
+"""
 blame_phrase(f::UserCompat) =
     f.label === :requested ? string("the version you requested for ", f.pkg) :
     f.label === :compat    ? string("your compat on ", f.pkg) :

--- a/src/Holdback.jl
+++ b/src/Holdback.jl
@@ -1,0 +1,361 @@
+# Diagnostics for resolutions that *succeeded* and still surprised someone.
+#
+# A user compat bound on a non-upgradable stdlib steers the julia choice: a
+# julia version is compatible with exactly the stdlib versions it bundles, so a
+# stale `LinearAlgebra = "~1.10"` quietly pins the whole toolchain to julia
+# 1.10 -- correctly, and without a word. The resolution is right; what is
+# missing is anyone saying *why*.
+#
+# This is the satisfiable-side sibling of the UNSAT machinery, and it reuses
+# all of it. For a package resolved below the best version its universe would
+# admit, assume the better version on the instance: that is unsatisfiable, and
+# the same biased group-MUS that explains an unsatisfiable resolve explains
+# this one. One probe with the blamed constraints relaxed verifies the fix and
+# produces its versions, by the same optimizing descent, so a holdback's
+# witness is as honest as an UNSAT fix's.
+
+"""
+    Holdback(pkg, resolved, best, chain, fix, versions)
+
+Why `pkg` resolved to `resolved` rather than to `best`, the newest version of it
+the problem's admission settings allow.
+
+`chain` tells the story in the same [`Fact`](@ref Resolver.Requirement)
+vocabulary an unsatisfiable diagnosis uses, and `fix` — when there is one — is a
+verified correction whose `solution` says what `pkg` would resolve to instead.
+`fix` is `nothing` when nothing the caller is allowed to relax would help, which
+is a real answer and not a failure: a version held back by bounds only an
+upstream release could move is held back for a reason the report should state
+rather than paper over.
+
+`versions` records the version lists the report needs, as in
+[`Diagnosis`](@ref).
+"""
+struct Holdback{P,V}
+    pkg      :: P
+    resolved :: V
+    best     :: V
+    chain    :: Vector{Fact}
+    fix      :: Union{Nothing,Fix{P,V}}
+    versions :: Dict{P,Vector{V}}
+end
+
+# what `pkg` would resolve to under the holdback's fix, or `nothing`
+improved(h::Holdback{P,V}) where {P,V} =
+    h.fix === nothing ? nothing : get(h.fix.solution, h.pkg, nothing)
+
+"""
+    Holdbacks(held, unexamined)
+
+What [`holdbacks`](@ref Resolver.holdbacks) returns: the explanations, as an
+ordinary vector of [`Holdback`](@ref) — iterate it, index it, `isempty` it —
+plus `unexamined`, the number of candidate packages the probe budget stopped it
+from looking at.
+
+Explaining a package costs several solves over the whole instance, so the budget
+is real and a caller that silently dropped the rest would be misreporting. The
+count is carried rather than implied, and `show` says it out loud.
+
+`unexamined` counts packages that resolved below their best version and were
+never probed — not packages known to be held back. Whether a constraint is
+actually to blame is exactly what a probe decides, so claiming more than that
+would be guessing.
+"""
+struct Holdbacks{P,V} <: AbstractVector{Holdback{P,V}}
+    held       :: Vector{Holdback{P,V}}
+    unexamined :: Int
+end
+
+Base.size(hs::Holdbacks) = size(hs.held)
+Base.getindex(hs::Holdbacks, i::Int) = hs.held[i]
+Base.IndexStyle(::Type{<:Holdbacks}) = IndexLinear()
+
+function Base.show(io::IO, ::MIME"text/plain", hs::Holdbacks)
+    for h in hs
+        show(io, MIME("text/plain"), h)
+    end
+    render_unexamined(io, hs)
+end
+
+# the line that keeps a truncated report honest
+function render_unexamined(io::IO, hs::Holdbacks)
+    hs.unexamined > 0 || return
+    println(io, "(", hs.unexamined, " more package",
+            hs.unexamined == 1 ? "" : "s",
+            " resolved below their best version, not examined)")
+end
+
+"""
+    holdbacks(info, prob, sol, [pkgs]; by = identity, max_probes = 8)
+
+Explain the packages in `pkgs` that `sol` resolved below their best *admissible*
+version, as a `Holdback` each; packages that are at their best, or whose version
+is merely the one the priority order settled on, produce nothing.
+
+"Best" is the newest version `prob`'s admission knobs allow: compat bounds and
+pins are what a fix relaxes, so they do not bound it, but a prerelease no query
+would accept is not an option being missed. A package with no admissible version
+at all is an unsatisfiable problem's business and produces nothing here.
+
+`info` must be the *prepared* universe the solution came from (see
+`prepare_pkg_info`) and `prob` its problem. The instance this builds is its own,
+so nothing the caller holds is disturbed.
+
+A holdback whose only remedy is something no fix can propose — an
+incompatibility that only an upstream release could dissolve — is reported with
+no fix rather than with an invented one.
+
+`max_probes` bounds how many packages are *probed*, since each costs a handful
+of solves over the whole instance; the result's `unexamined` says how many
+candidates that left over, and rendering it says so.
+"""
+function holdbacks(
+    info :: Dict{P,PkgInfo{P,V}},
+    prob :: Problem{P},
+    sol  :: AbstractDict{P,V},
+    pkgs = keys(sol);
+    by   :: Function = identity,
+    max_probes :: Integer = 8,
+) where {P,V}
+    out = Holdback{P,V}[]
+    none = Holdbacks{P,V}(out, 0)
+    # the candidates, cheapest test first: a package already at the best version
+    # the problem admits needs no solving to rule out
+    cands = Pair{P,V}[]
+    for p in pkgs
+        haskey(info, p) && haskey(sol, p) || continue
+        best = reachable_best(prob, p, info[p].versions)
+        best === nothing && continue
+        best == sol[p] && continue
+        push!(cands, p => best)
+    end
+    isempty(cands) && return none
+    sort!(cands)
+    unexamined = max(0, length(cands) - max_probes)
+
+    sat = SAT(info, prob)
+    try
+        with_relaxed_selectors(sat) do
+            R = relaxation(sat, prob.reqs)
+            # the requirement and constraint groups every probe holds on, and
+            # the order the story prefers to blame: requirements are deleted
+            # first so that a holdback tellable through the user's own compat
+            # is blamed on the compat, not on "you require Foo"
+            on = Int[R.reqs; R.user]
+            shrink = Int[R.reqs; R.user]
+            softof = Dict{P,Int}(R.rel[i].pkg => i for i in R.user)
+            for (p, best) in Iterators.take(cands, max_probes)
+                h = holdback(sat, R, p, best, sol, on, shrink, softof, by)
+                h === nothing || push!(out, h)
+            end
+        end
+    finally
+        finalize(sat)
+    end
+    return Holdbacks{P,V}(out, unexamined)
+end
+
+# The best version of `p` a fix could actually reach: the newest one the
+# problem's own *admission* settings allow. Compat bounds and pins do not bound
+# it -- those are exactly what a fix proposes relaxing -- but an admission kind
+# does: advertising a prerelease as "available" to a query that does not admit
+# prereleases offers something that is not on the table, and worse, it makes the
+# probe ask why *that* version was missed and answer with the knob rather than
+# with the bound that is the real story. Yanked versions are pre-filtered out of
+# the universe (see the manual's diagnostics page), so they never come up here.
+#
+# `nothing` when no version is admissible at all: that is an unsatisfiable
+# problem's business, not a holdback's.
+function reachable_best(prob::Problem{P}, p::P, vers::Vector{V}) where {P,V}
+    isempty(prob.excludes) && return isempty(vers) ? nothing : first(vers)
+    i = findfirst(vers) do v
+        !any(forbids(p, v)::Bool for (_, forbids) in prob.excludes)
+    end
+    i === nothing ? nothing : vers[i]
+end
+
+function holdback(
+    sat    :: SAT{P,V},
+    R      :: Relaxation{P},
+    p      :: P,
+    best   :: V,
+    sol    :: AbstractDict{P,V},
+    on     :: Vector{Int},
+    shrink :: Vector{Int},
+    softof :: Dict{P,Int},
+    by     :: Function,
+) where {P,V}
+    vers = sat.info[p].versions
+    b = findfirst(==(best), vers)::Int
+
+    # Could `p` be at `best` at all? If so its version is what the priority
+    # order settled on rather than what a constraint forced, and there is no
+    # constraint to blame -- reporting one would be inventing a culprit.
+    with_best(g) = (sat_assume(sat, p, b); relax_sat(sat, R, g))
+    with_best(on) && return nothing
+
+    # what a minimal explanation needs, with `p@best` assumed throughout
+    mus = group_mus_with(sat, R, on, shrink) do
+        sat_assume(sat, p, b)
+    end
+    isempty(mus) && return nothing
+
+    facts = Fact[]
+    blamed = P[]
+    for i in mus
+        r = R.rel[i]
+        append!(facts, group_facts(sat, r))
+        r.kind === :user && push!(blamed, r.pkg)
+    end
+    # the incompatibility that actually stops `p@best`, read straight off the
+    # conflict matrix: true by construction, and what makes the story concrete
+    for q in blamed
+        append!(facts, blocking_bound(sat.info, p, best, q))
+    end
+
+    # the fix: relax the blamed packages' constraints and see what `p` gets
+    drop = Set{Int}(softof[q] for q in blamed if haskey(softof, q))
+    fix = nothing
+    if !isempty(drop)
+        kept = Int[i for i in Int[R.reqs; R.user] if i ∉ drop]
+        got = fix_solution(sat, R, kept, by)
+        # only a fix if it actually moves `p` forward
+        if haskey(got, p) && better(vers, got[p], sol[p])
+            actions = Fact[]
+            for i in drop
+                append!(actions, group_facts(sat, R.rel[i]))
+            end
+            isempty(actions) ||
+                (fix = Fix{P,V}(order_facts(actions), got))
+        end
+    end
+
+    versions = Dict{P,Vector{V}}()
+    record(q) = haskey(sat.info, q) &&
+        (versions[q] = copy(sat.info[q].versions))
+    record(p)
+    for f in facts
+        record(fact_pkg(f))
+        f isa Bound && record(f.dep)
+    end
+    return Holdback{P,V}(p, sol[p], best, order_chain(facts, P, V),
+                         fix, versions)
+end
+
+# is `u` a better version of this package than `w`? versions are listed best
+# first, so the earlier index wins
+function better(vers::Vector{V}, u::V, w::V) where {V}
+    i = findfirst(==(u), vers)
+    j = findfirst(==(w), vers)
+    i !== nothing && j !== nothing && i < j
+end
+
+# the conflicts that stop `p@v` from coexisting with `q`, as one `Bound` naming
+# the versions of `q` that would still work. Read off the matrix rather than
+# probed, so it costs nothing and cannot be wrong -- it is a restatement of the
+# instance, not a claim about minimality.
+function blocking_bound(
+    info :: Dict{P,PkgInfo{P,V}},
+    p    :: P,
+    v    :: V,
+    q    :: P,
+) where {P,V}
+    facts = Fact[]
+    p == q && return facts
+    info_p = info[p]
+    haskey(info_p.interacts, q) || return facts
+    i = findfirst(==(v), info_p.versions)
+    i === nothing && return facts
+    b = info_p.interacts[q]
+    vers_q = info[q].versions
+    bad = [j for j = 1:length(vers_q) if info_p.conflicts[i, b+j]]
+    isempty(bad) && return facts
+    badset = Set(bad)
+    push!(facts, Bound{P,V}(p, V[v], q,
+        V[vers_q[j] for j = 1:length(vers_q) if j ∉ badset]))
+    return facts
+end
+
+# `group_mus`, with extra assumptions re-applied before every solve. picosat
+# drops assumptions after each call, so a query that fixes a version for the
+# whole shrink has to say so each time.
+function group_mus_with(
+    setup  :: Function,
+    sat    :: SAT,
+    R      :: Relaxation,
+    on     :: AbstractVector{Int},
+    shrink :: AbstractVector{Int},
+)
+    probe(g) = (setup(); relax_sat(sat, R, g))
+    probe(on) && return Int[]
+    mus = collect(on)
+    for g in shrink
+        k = findfirst(==(g), mus)
+        k === nothing && continue
+        deleteat!(mus, k)
+        probe(mus) && insert!(mus, k, g) # needed: keep it
+    end
+    return sort!(mus)
+end
+
+## rendering
+
+function Base.show(io::IO, h::Holdback)
+    print(io, "Holdback(", h.pkg, " ", h.resolved, " < ", h.best,
+          h.fix === nothing ? ", no fix)" : ", fixable)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", h::Holdback)
+    println(io, h.pkg, " resolved to ", h.resolved,
+            "; ", h.best, " is available.")
+    for f in h.chain
+        f isa Bound && f.incidental && continue
+        print(io, "  • ")
+        render_fact(io, f, h)
+        println(io)
+    end
+    if h.fix === nothing
+        println(io, "  ⇒ nothing you can change would move it.")
+        return
+    end
+    println(io, "  ⇒ held back by ",
+            join(map(blame_phrase, h.fix.actions), " and "), ".")
+    println(io, "  ", join(map(render_action, h.fix.actions), " and "),
+            " → allows: ", holdback_solution(h))
+end
+
+# "your compat on Statistics", the noun form of the action a fix would take
+blame_phrase(f::UserCompat) =
+    f.label === :requested ? string("the version you requested for ", f.pkg) :
+    f.label === :compat    ? string("your compat on ", f.pkg) :
+                             string("the ", f.label, " on ", f.pkg)
+blame_phrase(f::Pin)         = string("your pin on ", f.pkg)
+blame_phrase(f::Admission)   = string("the ban on ", f.kind, " versions of ", f.pkg)
+blame_phrase(f::Requirement) = string("your requirement on ", f.pkg)
+blame_phrase(f::Fact)        = string(fact_pkg(f))
+
+# the packages of a holdback's witness worth naming: the one held back, and
+# whatever else the story is about
+function holdback_solution(h::Holdback{P,V}) where {P,V}
+    sol = h.fix.solution
+    rel = Set{P}((h.pkg,))
+    for f in h.chain
+        push!(rel, fact_pkg(f))
+        f isa Bound && push!(rel, f.dep)
+    end
+    pkgs = sort!(P[q for q in keys(sol) if q ∈ rel])
+    sort!(pkgs; by = q -> q ≠ h.pkg) # the held-back package first
+    isempty(pkgs) ? "nothing" :
+        join((string(q, " ", sol[q]) for q in pkgs), ", ")
+end
+
+# one line, for a caller that wants the answer and not the reasoning
+function summarize(h::Holdback)
+    v = improved(h)
+    v === nothing && return string(h.pkg, " is held back to ", h.resolved,
+        " (", h.best, " available); nothing you can change would move it")
+    string(h.pkg, " is held back to ", h.resolved, " by ",
+           join(map(blame_phrase, h.fix.actions), " and "),
+           "; relaxing ", length(h.fix.actions) == 1 ? "it" : "them",
+           " allows ", h.pkg, " ", v)
+end

--- a/src/Problem.jl
+++ b/src/Problem.jl
@@ -50,6 +50,9 @@ struct Problem{P,V,S}
     # admission knobs: per kind, a predicate `(p, v) -> Bool` that is true for
     # the versions that kind forbids
     excludes :: Vector{Pair{Symbol,Any}}
+    # how to describe a package's compat bound in a report, when "your compat"
+    # would be wrong
+    labels :: AbstractDict{P,Symbol}
 end
 
 function Problem(
@@ -57,15 +60,18 @@ function Problem(
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     excludes = NoKinds,
+    labels :: AbstractDict{P} = EmptyDict{P,Symbol}(),
 ) where {P}
     Problem{P, valtype(pins), valtype(compat)}(
-        P[p for p in reqs], adopt(compat), adopt(pins), adopt_kinds(excludes))
+        P[p for p in reqs], adopt(compat), adopt(pins), adopt_kinds(excludes),
+        adopt(labels))
 end
 
 # a caller's dictionary is copied, so later mutation can't change the problem;
 # the shared empties are immutable and shared on purpose
 adopt(d::AbstractDict) = Dict(d)
 adopt(d::EmptyDict) = d
+
 
 adopt_kinds(kinds) = isempty(kinds) ? NoKinds :
     Pair{Symbol,Any}[Symbol(kind) => forbids for (kind, forbids) in kinds]
@@ -74,6 +80,7 @@ adopt_kinds(kinds) = isempty(kinds) ? NoKinds :
 # an unconstrained resolve must not do any per-version work
 is_constrained(prob::Problem) =
     !isempty(prob.compat) || !isempty(prob.pins) || !isempty(prob.excludes)
+
 
 # The user constraints are read as a *virtual package*: one always-required
 # version, no dependencies, whose conflict rows are exactly the exclusions

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -91,7 +91,7 @@ function resolve_core(
 end
 
 """
-    resolve(data, prob::Problem; by = identity, diagnose = true)
+    resolve(data, prob::Problem; with = ..., without = ..., diagnose = true)
         -> Union{Dict{P,V}, Diagnosis{P,V}, Nothing}
     resolve(data, reqs; by = identity, diagnose = true, compat = ..., pins = ...)
 
@@ -138,6 +138,38 @@ The other methods accept two more keywords:
     versions to one representative before solving (see `prepare_pkg_info`).
     Grouping is an optimization and cannot change the answer; `group = false` is
     the escape hatch that says so.
+
+## Goals
+
+`with` and `without` say what the resolve is *for*, beyond satisfying `prob`:
+
+```julia
+resolve(info, prob; with = "CUDA")                        # present
+resolve(info, prob; with = "DataFrames" => v"1.8.2")      # present, at a version
+resolve(info, prob; without = "FillArrays")               # absent
+resolve(info, prob; with = ["CUDA" => spec("5"), "MKL"], without = "GLMakie")
+```
+
+`with` takes a package, a `pkg => versions` pair (any `in`-supporting set, or a
+bare version), or a collection of either; `without` takes a package or a
+collection. Together they express a conjunction.
+
+The return contract is unchanged: the optimal solution satisfying `prob` *and*
+the goal, a [`Diagnosis`](@ref) of why it cannot be had, or `nothing` under
+`diagnose = false` — which with a goal is the cheap feasibility probe. (Cheaper
+still, when the versions are not wanted either: [`issatisfiable`](@ref).)
+
+What separates `with = "CUDA"` from adding CUDA to `prob.reqs` is one sentence:
+`prob`'s constraints are *negotiable* — a diagnosis may propose relaxing any of
+them — and the goal is the *fixed ask*, so "drop requirement CUDA" can never
+appear as a fix.
+
+A goal is answered on a sub-instance built from the T1 artifact rather than on
+the per-resolve one (see `prepare_goal_info`), because the per-resolve filter
+prunes exactly the escape routes a goal needs. When `data` is a provider or a
+`PkgData` dict the closure is widened to cover the goal's packages; a
+caller-supplied `PkgInfo` artifact is used as it stands, so a goal naming a
+package outside it reads as unsatisfiable.
 """
 function resolve(
     sat  :: SAT{P,V},
@@ -146,7 +178,10 @@ function resolve(
     restore :: Bool = true, # restore the SAT instance's state before returning
     diagnose :: Bool = true, # explain an unsatisfiable result
 ) where {P,V}
-    sol = resolve_core(sat, reqs; by, restore)
+    # a `with` goal's packages are in the solution by fiat, so the descent has
+    # to reach and optimize them the way it does a requirement; otherwise they
+    # are true in the model and pruned out of the answer
+    sol = resolve_core(sat, descent_roots(sat, reqs); by, restore)
     if sol === nothing
         # the failed check added no clauses, so the instance is still exactly
         # the one that failed: diagnose it in place, before anything else
@@ -164,8 +199,9 @@ function resolve_prepared(
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
     diagnose :: Bool = true,
+    goal :: Union{Nothing,Goal{P}} = nothing,
 ) where {P,V}
-    sat = SAT(info, prob)
+    sat = SAT(info, prob, goal)
     # the instance is single-use, so don't bother restoring its state -- but
     # the diagnosis, if any, runs on it before it is freed
     try resolve(sat, prob.reqs; by, restore=false, diagnose)
@@ -173,6 +209,111 @@ function resolve_prepared(
         finalize(sat)
     end
 end
+
+# the packages the layered descent optimizes and keeps: the requirements, plus
+# whatever a `with` goal insists on having
+function descent_roots(sat::SAT{P}, reqs::SetOrVec{P}) where {P}
+    goal = sat.goal
+    goal === nothing && return reqs
+    isempty(goal.with) && return reqs
+    sort!(unique!(P[collect(reqs);
+                    P[p for (p, _) in goal.with if haskey(sat.info, p)]]))
+end
+
+## goal routing
+#
+# A goal is answered on a different universe than the goal-⊤ resolve is. The
+# per-resolve preparation keeps only what an *optimal* solution could use, which
+# is exactly what a goal asks to step outside of: `A→B`, `B@3.1→X`, `B@2.3→∅`
+# leaves only `B@3.1` reachable, so the prepared instance calls X unavoidable
+# while the raw problem avoids it via `B@2.3`. So a goal query runs on a
+# sub-instance built from T1 instead -- see `prepare_goal_info`, and the theory
+# page's goal-safety section.
+#
+# The closure has to cover the goal's packages too. A package the universe does
+# not have at all stays in the goal rather than being dropped from it: `with` on
+# a package that does not exist is unsatisfiable, and saying so beats answering
+# a question nobody asked.
+
+goal_universe(deps::DepsProvider{P}, prob, goal; kws...) where {P} =
+    goal_universe(pkg_info(deps, goal_reqs(prob, goal, Set{P}(deps.packages))),
+                  prob, goal; kws...)
+
+goal_universe(data::AbstractDict{P,<:PkgData{P}}, prob, goal; kws...) where {P} =
+    goal_universe(pkg_info(data, goal_reqs(prob, goal, keys(data))),
+                  prob, goal; kws...)
+
+goal_universe(info::AbstractDict{P,PkgInfo{P,V}}, prob, goal;
+              group = true, order = nothing) where {P,V} =
+    prepare_goal_info(info, prob, goal; group, order)
+
+goal_reqs(prob::Problem{P}, goal::Goal{P}, known) where {P} =
+    sort!(unique!(P[prob.reqs; P[p for p in goal_packages(goal) if p ∈ known]]))
+
+"""
+    issatisfiable(data, prob::Problem; with = ..., without = ...) :: Bool
+    issatisfiable(data, reqs; with = ..., without = ..., compat = ..., pins = ...)
+
+Can `prob` be satisfied — and, with a goal, satisfied *while* getting what the
+goal asks for? One solve, no optimizing descent, no explanation: the cheapest
+question in the API, for the caller that is asking it in a loop.
+
+This is the bottom rung of a three-tier ladder, all three answering the same
+question with more or less work:
+
+| call | cost | answer |
+|:--|:--|:--|
+| `issatisfiable(data, prob; with)` | one solve | `Bool` |
+| `resolve(data, prob; with, diagnose = false)` | one solve + descent | the solution, or `nothing` |
+| `resolve(data, prob; with)` | + explanation | the solution, or a [`Diagnosis`](@ref) |
+
+Nothing distinguishes them but effort — the verdicts agree — so a UI greying out
+an upgrade button uses the first, a caller that wants the versions uses the
+second, and only the one that will actually show a report pays for the third.
+"""
+function issatisfiable(
+    data,
+    prob :: Problem{P};
+    group :: Bool = true,
+    order = nothing,
+    with = nothing,
+    without = nothing,
+) where {P}
+    goal = make_goal(P, with, without)
+    info = goal === nothing ?
+        prepare_pkg_info_for(data, prob; group, order) :
+        goal_universe(data, prob, goal; group, order)
+    all(p -> haskey(info, p), prob.reqs) || return false
+    sat = SAT(info, prob, goal)
+    try is_satisfiable(sat, prob.reqs)
+    finally
+        finalize(sat)
+    end
+end
+
+issatisfiable(
+    data,
+    reqs :: SetOrVec{P};
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+    group  :: Bool = true,
+    order  = nothing,
+    with = nothing,
+    without = nothing,
+) where {P} = issatisfiable(data, Problem(reqs; compat, pins);
+                            group, order, with, without)
+
+# the goal-⊤ universe, per data flavour -- the same three shapes `resolve` has
+prepare_pkg_info_for(deps::DepsProvider{P}, prob; group, order) where {P} =
+    (info = pkg_info(deps, prob);
+     prepare_pkg_info(info, prob, info; group, order))
+prepare_pkg_info_for(data::AbstractDict{P,<:PkgData{P}}, prob;
+                     group, order) where {P} =
+    (info = pkg_info(data, prob);
+     prepare_pkg_info(info, prob, info; group, order))
+prepare_pkg_info_for(info::AbstractDict{P,PkgInfo{P,V}}, prob;
+                     group, order) where {P,V} =
+    prepare_pkg_info(info, prob; group, order)
 
 # primary entry points: a Problem (requirements + user constraints). each
 # builds the T1 artifact for the problem's requirements, then prepares it —
@@ -186,7 +327,12 @@ function resolve(
     group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
     diagnose :: Bool = true,
+    with = nothing,
+    without = nothing,
 ) where {P}
+    goal = make_goal(P, with, without)
+    goal === nothing || return resolve_prepared(
+        goal_universe(deps, prob, goal; group, order), prob; by, diagnose, goal)
     info = pkg_info(deps, prob)
     resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob;
                      by, diagnose)
@@ -199,7 +345,12 @@ function resolve(
     group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
     diagnose :: Bool = true,
+    with = nothing,
+    without = nothing,
 ) where {P}
+    goal = make_goal(P, with, without)
+    goal === nothing || return resolve_prepared(
+        goal_universe(data, prob, goal; group, order), prob; by, diagnose, goal)
     info = pkg_info(data, prob)
     resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob;
                      by, diagnose)
@@ -214,7 +365,12 @@ function resolve(
     group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
     diagnose :: Bool = true,
+    with = nothing,
+    without = nothing,
 ) where {P,V}
+    goal = make_goal(P, with, without)
+    goal === nothing || return resolve_prepared(
+        goal_universe(info, prob, goal; group, order), prob; by, diagnose, goal)
     resolve_prepared(prepare_pkg_info(info, prob; group, order), prob;
                      by, diagnose)
 end
@@ -231,8 +387,10 @@ resolve(
     group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
     diagnose :: Bool = true,
+    with = nothing,
+    without = nothing,
 ) where {P} = resolve(deps, Problem(reqs; compat, pins);
-                       by, group, order, diagnose)
+                       by, group, order, diagnose, with, without)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
@@ -243,8 +401,10 @@ resolve(
     group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
     diagnose :: Bool = true,
+    with = nothing,
+    without = nothing,
 ) where {P} = resolve(data, Problem(reqs; compat, pins);
-                       by, group, order, diagnose)
+                       by, group, order, diagnose, with, without)
 
 resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},
@@ -255,5 +415,7 @@ resolve(
     group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
     diagnose :: Bool = true,
+    with = nothing,
+    without = nothing,
 ) where {P,V} = resolve(info, Problem(reqs; compat, pins);
-                       by, group, order, diagnose)
+                       by, group, order, diagnose, with, without)

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -91,14 +91,20 @@ function resolve_core(
 end
 
 """
-    resolve(data, prob::Problem; by = identity) -> Union{Dict{P,V}, Nothing}
-    resolve(data, reqs; by = identity, compat = ..., pins = ...)
+    resolve(data, prob::Problem; by = identity, diagnose = true)
+        -> Union{Dict{P,V}, Diagnosis{P,V}, Nothing}
+    resolve(data, reqs; by = identity, diagnose = true, compat = ..., pins = ...)
 
 Resolve the requirements `reqs` against the package universe described by
 `data`, returning the optimal solution as a dict mapping each needed package
-to its chosen version, or `nothing` when the requirements are not jointly
-satisfiable. The solution covers every requirement and is exactly the
+to its chosen version. The solution covers every requirement and is exactly the
 dependency closure of the requirements under its own chosen versions.
+
+When the requirements are not jointly satisfiable the result is a
+[`Diagnosis`](@ref) — the independent conflicts, the facts that tell each one's
+story, and a menu of verified fixes — which `show` renders as a report. Pass
+`diagnose = false` to skip computing it and get `nothing` instead, which is all
+a caller that only wants the verdict needs and costs nothing to produce.
 
 A [`Problem`](@ref) additionally constrains the admissible versions with user
 compat bounds and pins; the answer is the one the same universe with those
@@ -138,9 +144,16 @@ function resolve(
     reqs :: SetOrVec{P} = keys(sat.info);
     by   :: Function = identity, # priority ordering
     restore :: Bool = true, # restore the SAT instance's state before returning
+    diagnose :: Bool = true, # explain an unsatisfiable result
 ) where {P,V}
     sol = resolve_core(sat, reqs; by, restore)
-    sol === nothing && return nothing
+    if sol === nothing
+        # the failed check added no clauses, so the instance is still exactly
+        # the one that failed: diagnose it in place, before anything else
+        # touches it
+        diagnose || return nothing
+        return Resolver.diagnose(sat, P[p for p in reqs]; by)
+    end
     return Dict{P,V}(p => sat.info[p].versions[i] for (p, i) in sol)
 end
 
@@ -150,10 +163,12 @@ function resolve_prepared(
     info :: Dict{P,PkgInfo{P,V}},
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
+    diagnose :: Bool = true,
 ) where {P,V}
     sat = SAT(info, prob)
-    # the instance is single-use, so don't bother restoring its state
-    try resolve(sat, prob.reqs; by, restore=false)
+    # the instance is single-use, so don't bother restoring its state -- but
+    # the diagnosis, if any, runs on it before it is freed
+    try resolve(sat, prob.reqs; by, restore=false, diagnose)
     finally
         finalize(sat)
     end
@@ -170,9 +185,11 @@ function resolve(
     by   :: Function = identity, # package ordering
     group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
+    diagnose :: Bool = true,
 ) where {P}
     info = pkg_info(deps, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob;
+                     by, diagnose)
 end
 
 function resolve(
@@ -181,9 +198,11 @@ function resolve(
     by   :: Function = identity, # package ordering
     group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
+    diagnose :: Bool = true,
 ) where {P}
     info = pkg_info(data, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob;
+                     by, diagnose)
 end
 
 # a caller-supplied info may be a reusable (or cached) T1 artifact, so this
@@ -194,8 +213,10 @@ function resolve(
     by   :: Function = identity, # package ordering
     group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
+    diagnose :: Bool = true,
 ) where {P,V}
-    resolve_prepared(prepare_pkg_info(info, prob; group, order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob; group, order), prob;
+                     by, diagnose)
 end
 
 # convenience entry points: bare requirements, with the user constraints (if
@@ -209,7 +230,9 @@ resolve(
     by     :: Function = identity, # package ordering
     group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
-) where {P} = resolve(deps, Problem(reqs; compat, pins); by, group, order)
+    diagnose :: Bool = true,
+) where {P} = resolve(deps, Problem(reqs; compat, pins);
+                       by, group, order, diagnose)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
@@ -219,7 +242,9 @@ resolve(
     by     :: Function = identity, # package ordering
     group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
-) where {P} = resolve(data, Problem(reqs; compat, pins); by, group, order)
+    diagnose :: Bool = true,
+) where {P} = resolve(data, Problem(reqs; compat, pins);
+                       by, group, order, diagnose)
 
 resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},
@@ -229,4 +254,6 @@ resolve(
     by     :: Function = identity, # package ordering
     group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
-) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, group, order)
+    diagnose :: Bool = true,
+) where {P,V} = resolve(info, Problem(reqs; compat, pins);
+                       by, group, order, diagnose)

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -1,6 +1,6 @@
 module Resolver
 
-export resolve, Problem, Diagnosis
+export resolve, Problem, Diagnosis, Holdback, holdbacks
 
 include("BitKernels.jl")
 include("DepsProvider.jl")
@@ -13,5 +13,6 @@ include("SAT.jl")
 include("Diagnose.jl")
 include("Resolve.jl")
 include("Closure.jl")
+include("Holdback.jl")
 
 end # module

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -1,6 +1,6 @@
 module Resolver
 
-export resolve, Problem
+export resolve, Problem, Diagnosis
 
 include("BitKernels.jl")
 include("DepsProvider.jl")
@@ -10,6 +10,8 @@ include("PkgInfoFiles.jl")
 include("FilterPkgs.jl")
 include("PicoSAT.jl")
 include("SAT.jl")
+include("Diagnose.jl")
 include("Resolve.jl")
+include("Closure.jl")
 
 end # module

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -1,6 +1,7 @@
 module Resolver
 
-export resolve, Problem, Diagnosis, Holdback, holdbacks
+export resolve, issatisfiable,
+    Problem, Diagnosis, Holdback, holdbacks
 
 include("BitKernels.jl")
 include("DepsProvider.jl")
@@ -8,6 +9,7 @@ include("Problem.jl")
 include("PkgInfo.jl")
 include("PkgInfoFiles.jl")
 include("FilterPkgs.jl")
+include("Goal.jl")
 include("PicoSAT.jl")
 include("SAT.jl")
 include("Diagnose.jl")

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -1,6 +1,6 @@
 module Resolver
 
-export resolve, issatisfiable,
+export resolve, issatisfiable, report, changes,
     Problem, Diagnosis, Holdback, holdbacks
 
 include("BitKernels.jl")

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -6,6 +6,9 @@ mutable struct SAT{P,V}
     # diagnostics (the constraints are asserted as unit clauses inside a push
     # frame, so popping it relaxes all of them at once)
     sels :: Dict{Int,Tuple{Symbol,P}}
+    # the problem those selectors came from, so a diagnosis can say what each
+    # one actually forbids; nothing for a bare structural instance
+    prob :: Union{Nothing,Problem{P}}
 end
 
 function Base.show(io::IO, sat::SAT)
@@ -274,7 +277,7 @@ function SAT(
         PicoSAT.reset(pico)
         rethrow()
     end
-    finalizer(finalize, SAT(info, pico, vars, Dict{Int,Tuple{Symbol,P}}()))
+    finalizer(finalize, SAT(info, pico, vars, Dict{Int,Tuple{Symbol,P}}(), nothing))
 end
 
 # the structural SAT instance for `info`, plus `prob`'s constraints as
@@ -307,6 +310,7 @@ function add_exclusions!(
     sat  :: SAT{P,V},
     prob :: Problem{P},
 ) where {P,V}
+    sat.prob = prob
     is_constrained(prob) || return sat
     info = sat.info
     pico = sat.pico
@@ -367,13 +371,7 @@ function add_exclusions!(
         end
     end
     # assert the selectors in a push frame of their own
-    isempty(sat.sels) && return sat
-    sat_push(sat)
-    for sel in sort!(collect(keys(sat.sels)))
-        PicoSAT.add(pico, sel)
-        PicoSAT.add(pico, 0)
-    end
-    return sat
+    return assert_selectors!(sat)
 end
 
 function finalize(sat::SAT)
@@ -459,6 +457,32 @@ function with_temp_clauses(body::Function, sat::SAT)
     try body()
     finally
         sat_pop(sat)
+    end
+end
+
+# assert the user-constraint selectors as unit clauses in a frame of their own,
+# so production solves see them at level 0 and one pop relaxes them all
+function assert_selectors!(sat::SAT)
+    isempty(sat.sels) && return sat
+    sat_push(sat)
+    for sel in sort!(collect(keys(sat.sels)))
+        PicoSAT.add(sat.pico, sel)
+        PicoSAT.add(sat.pico, 0)
+    end
+    return sat
+end
+
+# run `body` with the user constraints relaxed: popping their frame turns every
+# selector back into an ordinary variable, so assumptions can switch the
+# constraints on and off one group at a time -- which is what diagnosis does.
+# The frame is re-asserted afterwards, so an instance that has been diagnosed
+# still resolves exactly as it did before.
+function with_relaxed_selectors(body::Function, sat::SAT)
+    isempty(sat.sels) && return body()
+    sat_pop(sat)
+    try body()
+    finally
+        assert_selectors!(sat)
     end
 end
 

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -6,6 +6,14 @@ mutable struct SAT{P,V}
     # diagnostics (the constraints are asserted as unit clauses inside a push
     # frame, so popping it relaxes all of them at once)
     sels :: Dict{Int,Tuple{Symbol,P}}
+    # selector variables guarding the goal's clauses, if any. Separate from
+    # `sels` because a goal is the query's fixed ask, not one of the negotiable
+    # constraints: every probe holds these on and no fix may propose dropping
+    # one (see Goal.jl)
+    goals :: Vector{Int}
+    # the goal those clauses came from, so the descent knows which packages it
+    # has to reach and a diagnosis knows what to call them
+    goal :: Union{Nothing,Goal{P}}
     # the problem those selectors came from, so a diagnosis can say what each
     # one actually forbids; nothing for a bare structural instance
     prob :: Union{Nothing,Problem{P}}
@@ -277,7 +285,9 @@ function SAT(
         PicoSAT.reset(pico)
         rethrow()
     end
-    finalizer(finalize, SAT(info, pico, vars, Dict{Int,Tuple{Symbol,P}}(), nothing))
+    finalizer(finalize,
+        SAT(info, pico, vars, Dict{Int,Tuple{Symbol,P}}(), Int[],
+            nothing, nothing))
 end
 
 # the structural SAT instance for `info`, plus `prob`'s constraints as
@@ -296,12 +306,52 @@ end
 function SAT(
     info :: Dict{P,PkgInfo{P,V}},
     prob :: Problem{P},
+    goal :: Union{Nothing,Goal{P}} = nothing,
 ) where {P,V}
     sat = SAT(info)
-    try add_exclusions!(sat, prob)
+    try
+        goal === nothing || add_goal!(sat, goal)
+        add_exclusions!(sat, prob)
     catch
         finalize(sat)
         rethrow()
+    end
+    return sat
+end
+
+# the goal's clauses, one selector per term. A `with` term is a disjunction over
+# the versions it admits -- empty, hence unsatisfiable, when the universe has
+# none of them, which is the honest answer to "can I have a version that does
+# not exist here". A `without` term is a single negative literal, and one naming
+# a package the universe does not have is satisfied by having nothing to say.
+function add_goal!(sat::SAT{P,V}, goal::Goal{P}) where {P,V}
+    sat.goal = goal
+    info = sat.info
+    pico = sat.pico
+    _, vars, _ = sat_variables(info)
+    for (p, s) in goal.with
+        sel = PicoSAT.inc_max_var(pico)
+        push!(sat.goals, sel)
+        PicoSAT.add(pico, -sel)
+        if haskey(info, p)
+            if s === nothing
+                PicoSAT.add(pico, vars[p])
+            else
+                v_p = vars[p]
+                for (i, v) in enumerate(info[p].versions)
+                    matches_goal(v, s) && PicoSAT.add(pico, v_p + i)
+                end
+            end
+        end
+        PicoSAT.add(pico, 0)
+    end
+    for p in goal.without
+        haskey(info, p) || continue
+        sel = PicoSAT.inc_max_var(pico)
+        push!(sat.goals, sel)
+        PicoSAT.add(pico, -sel)
+        PicoSAT.add(pico, -vars[p])
+        PicoSAT.add(pico, 0)
     end
     return sat
 end
@@ -311,7 +361,7 @@ function add_exclusions!(
     prob :: Problem{P},
 ) where {P,V}
     sat.prob = prob
-    is_constrained(prob) || return sat
+    is_constrained(prob) || return assert_selectors!(sat)
     info = sat.info
     pico = sat.pico
     _, vars, lads = sat_variables(info)
@@ -460,12 +510,14 @@ function with_temp_clauses(body::Function, sat::SAT)
     end
 end
 
-# assert the user-constraint selectors as unit clauses in a frame of their own,
-# so production solves see them at level 0 and one pop relaxes them all
+# assert the user-constraint and goal selectors as unit clauses in a frame of
+# their own, so production solves see them at level 0 and one pop relaxes them
+# all. The goal's go in the same frame only so that a diagnosis can ask whether
+# a conflict *needed* the goal; every probe it runs holds them on regardless.
 function assert_selectors!(sat::SAT)
-    isempty(sat.sels) && return sat
+    isempty(sat.sels) && isempty(sat.goals) && return sat
     sat_push(sat)
-    for sel in sort!(collect(keys(sat.sels)))
+    for sel in sort!([collect(keys(sat.sels)); sat.goals])
         PicoSAT.add(sat.pico, sel)
         PicoSAT.add(sat.pico, 0)
     end
@@ -478,7 +530,7 @@ end
 # The frame is re-asserted afterwards, so an instance that has been diagnosed
 # still resolves exactly as it did before.
 function with_relaxed_selectors(body::Function, sat::SAT)
-    isempty(sat.sels) && return body()
+    isempty(sat.sels) && isempty(sat.goals) && return body()
     sat_pop(sat)
     try body()
     finally

--- a/test/classes.jl
+++ b/test/classes.jl
@@ -112,8 +112,8 @@ end
 
 # grouping cannot change the answer, whatever the constraints or the ordering
 function test_collapse_invariance(data, prob; by::Function = identity)
-    @test resolve(data, prob; by, group = true) ==
-          resolve(data, prob; by, group = false)
+    @test bare_resolve(data, prob; by, group = true) ==
+          bare_resolve(data, prob; by, group = false)
 end
 
 # the constraints that split classes: forbid exactly one member of a
@@ -147,7 +147,7 @@ end
     info = test_classes(data)
     @test info[:A].classes == [1, 1, 1]
     @test info[:B].classes == [1, 1]
-    @test resolve(data, [:A, :B]) == Dict(:A => :v3, :B => :v2)
+    @test bare_resolve(data, [:A, :B]) == Dict(:A => :v3, :B => :v2)
 
     # differing dependency sets split
     data = Dict(
@@ -322,7 +322,7 @@ end
             while true
                 fill_data!(m, n, deps, comp, data)
                 test_collapse_invariance(data, prob)
-                sol = resolve(data, prob)
+                sol = bare_resolve(data, prob)
                 sol === nothing && break
                 p = rand(collect(keys(sol)))
                 v = sol[p]
@@ -392,11 +392,11 @@ end
                 specific = pkg_info(deps, reqs) # T1 over the closure of reqs
                 compat, pins = random_constraints(m, n)
                 for prob in (Problem(reqs), Problem(reqs; compat, pins))
-                    @test resolve(all_reqs, prob) == resolve(specific, prob)
-                    @test resolve(all_reqs, prob) == resolve(data, prob)
+                    @test bare_resolve(all_reqs, prob) == bare_resolve(specific, prob)
+                    @test bare_resolve(all_reqs, prob) == bare_resolve(data, prob)
                     # the T1 artifacts are reusable: resolving does not
                     # consume them
-                    @test resolve(all_reqs, prob) == resolve(all_reqs, prob)
+                    @test bare_resolve(all_reqs, prob) == bare_resolve(all_reqs, prob)
                 end
             end
         end
@@ -416,7 +416,7 @@ end
     info = pkg_info(data)
     before = deepcopy(info)
     prob = Problem([:C]; compat = Dict(:B => [:v1]))
-    @test resolve(info, prob) == resolve(data, prob)
+    @test bare_resolve(info, prob) == bare_resolve(data, prob)
     @test info == before
     @test all(info[p].classes == before[p].classes for p in keys(info))
     # ... and preparing it explicitly yields a universe of its own

--- a/test/diagnose.jl
+++ b/test/diagnose.jl
@@ -1,0 +1,717 @@
+# UNSAT diagnostics.
+
+using Resolver: Bound, Conflict, Diagnosis, Fact, Fix, Pin, PkgData, PkgInfo,
+    Problem, Requirement, SAT, Uninstallable, UpstreamFix,
+    UserCompat, dep_closure, filter_dominated, finalize, format_versions,
+    Admission, MAX_UPSTREAM_SHOWN, interacting_pairs, order_chain, order_facts,
+    pkg_info, prepare_pkg_info, render_action, restrict_info, superseded
+
+@testset "diagnose: fact vocabulary" begin
+    # facts compare and hash by value, across kinds
+    @test Requirement("A") == Requirement("A")
+    @test Requirement("A") ≠ Requirement("B")
+    @test UserCompat("A", [1, 2]) == UserCompat("A", [1, 2])
+    @test UserCompat("A", [1, 2]) ≠ UserCompat("A", [1])
+    @test Pin("A", 1) == Pin("A", 1)
+    @test Bound("A", [1], "C", [2]) == Bound("A", [1], "C", [2])
+    @test Bound("A", [1], "C", [2]) ≠ Bound("A", [1], "C", [3])
+    @test length(Set(Fact[Requirement("A"), Requirement("A")])) == 1
+    @test length(Set(Fact[Requirement("A"), Uninstallable("A")])) == 2
+    @test length(Set(Fact[Pin("A", 1), Pin("A", 2)])) == 2
+
+    # deterministic ordering: actionability kind first, then package
+    fs = Fact[Bound("B", [1], "C", [1]), Requirement("Z"), Pin("Y", 1),
+              UserCompat("A", Int[]), Requirement("A"), Uninstallable("M")]
+    @test order_facts(fs) == Fact[
+        Requirement("A"), Requirement("Z"), Uninstallable("M"),
+        Pin("Y", 1), UserCompat("A", Int[]), Bound("B", [1], "C", [1])]
+end
+
+@testset "diagnose: format_versions" begin
+    @test format_versions([1, 2, 3, 4, 5], [1, 2, 3, 5]) == "1–3, 5"
+    @test format_versions([1, 2, 3], [1, 2, 3]) == "all versions"
+    @test format_versions([1, 2, 3], [2]) == "2"
+    @test format_versions([1, 2, 3], Int[]) == "no versions"
+    @test format_versions([10, 20, 30, 40], [10, 20, 40]) == "10–20, 40"
+    # ranges read low–high (and runs ascend) even when `whole` is descending,
+    # as the registry provider produces
+    @test format_versions([3, 2, 1], [1, 2]) == "1–2"
+    @test format_versions([5, 4, 3, 2, 1], [1, 2, 3, 5]) == "1–3, 5"
+    # versions absent from `whole` are skipped, not an error: a fact may name a
+    # version the filtered instance no longer carries
+    @test format_versions([1, 2, 3], [2, 9]) == "2"
+    @test format_versions([1, 2, 3], [9]) == "no versions"
+    @test format_versions(Int[], [1]) == "no versions"
+end
+
+@testset "diagnose: filter_dominated" begin
+    mkfix(actions...) = Fix{String,Int}(Fact[actions...], Dict{String,Int}())
+    fA  = mkfix(Requirement("A"))
+    fAB = mkfix(Requirement("A"), Requirement("B"))
+    fBC = mkfix(Requirement("B"), UserCompat("C", Int[]))
+    # a fix relaxing a proper subset of another's restrictions dominates it;
+    # the dominated fix is dropped and the order of the rest preserved
+    @test filter_dominated([fAB, fA, fBC]) == [fA, fBC]
+    @test filter_dominated([fA, fBC]) == [fA, fBC]
+    @test filter_dominated(Fix{String,Int}[]) == Fix{String,Int}[]
+    # equal action sets don't dominate each other (⊊ is strict)
+    @test length(filter_dominated([fA, mkfix(Requirement("A"))])) == 2
+end
+
+@testset "diagnose: order_chain" begin
+    # story order: requirements first, then a BFS along the bound edges, each
+    # package emitting its own facts as it is introduced
+    facts = Fact[
+        Bound("D", [3], "C", [2, 3]),
+        Bound("B", [1], "D", [3]),
+        Bound("A", [1], "C", [1]),
+        Requirement("B"),
+        Requirement("A"),
+    ]
+    chain = order_chain(facts, String, Int)
+    @test chain == Fact[
+        Requirement("A"), Requirement("B"),
+        Bound("A", [1], "C", [1]),
+        Bound("B", [1], "D", [3]),
+        Bound("D", [3], "C", [2, 3]),
+    ]
+
+    # a package's own facts come out with it: pin then compat, before its bounds
+    facts = Fact[
+        UserCompat("C", [3]),
+        Bound("A", [1], "C", [1, 2]),
+        Requirement("A"),
+        Pin("A", 1),
+        Uninstallable("A"),
+    ]
+    chain = order_chain(facts, String, Int)
+    @test chain == Fact[
+        Requirement("A"), Uninstallable("A"), Pin("A", 1),
+        Bound("A", [1], "C", [1, 2]), UserCompat("C", [3]),
+    ]
+
+    # facts the BFS can't reach are still emitted, in kind order
+    facts = Fact[UserCompat("Z", Int[]), Requirement("A")]
+    @test order_chain(facts, String, Int) ==
+        Fact[Requirement("A"), UserCompat("Z", Int[])]
+
+    # deterministic regardless of input order
+    for _ = 1:8
+        @test order_chain(shuffle(facts), String, Int) ==
+            Fact[Requirement("A"), UserCompat("Z", Int[])]
+    end
+end
+
+@testset "diagnose: rendering" begin
+    versions = Dict("A" => [1], "C" => [1, 2, 3], "P" => [1, 2])
+    d = Diagnosis{String,Int}(
+        ["A"],
+        [Conflict{String,Int}(["A"], Fact[
+            Requirement("A"),
+            Bound("A", [1], "C", [1, 2]),
+            UserCompat("C", [3]),
+            Pin("P", 2),
+            Uninstallable("Q"),
+        ], UpstreamFix{String,Int}[
+            UpstreamFix(Bound("A", [1], "C", [1, 2]), Dict("A" => 1, "C" => 1)),
+        ])],
+        [Fix{String,Int}(Fact[UserCompat("C", [3])], Dict("A" => 1, "C" => 1)),
+         Fix{String,Int}(Fact[Requirement("A")], Dict{String,Int}())],
+        versions,
+    )
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("Conflict 1: A cannot be satisfied.", report)
+    @test occursin("you require A", report)
+    @test occursin("A (all versions) works with C only at 1–2", report)
+    @test occursin("your compat restricts C to 3", report)
+    @test occursin("P is pinned at 2", report)
+    @test occursin("no version of Q is installable", report)
+    @test occursin("Verified fixes:", report)
+    @test occursin("1. relax your compat on C", report)
+    @test occursin("→ allows: A 1, C 1", report)
+    @test occursin("2. drop requirement A", report)
+    @test occursin("→ allows: nothing", report)
+    @test occursin("Upstream fixes:", report)
+    @test occursin("a release of A or C relaxing their compat on each other",
+                   report)
+    # requirements lead the "allows" list, then the other relevant packages
+    @test !occursin("C 1, A 1", report)
+
+    # compact summary: singular and plural
+    @test sprint(show, d) == "Diagnosis(1 conflict, 2 fixes)"
+    d1 = Diagnosis{String,Int}(["A"],
+        [d.conflicts[1], d.conflicts[1]], [d.fixes[1]], versions)
+    @test sprint(show, d1) == "Diagnosis(2 conflicts, 1 fix)"
+
+    # a fix's solution is rendered only for conflict-relevant packages; the
+    # complete assignment stays on the struct
+    d2 = Diagnosis{String,Int}(["A"],
+        [Conflict{String,Int}(["A"], Fact[Requirement("A")],
+                              UpstreamFix{String,Int}[])],
+        [Fix{String,Int}(Fact[Requirement("A")],
+                         Dict("A" => 1, "Filler" => 1))],
+        Dict("A" => [1], "Filler" => [1]))
+    report2 = sprint(show, MIME("text/plain"), d2)
+    @test occursin("→ allows: A 1", report2)
+    @test !occursin("Filler", report2)
+    @test d2.fixes[1].solution["Filler"] == 1
+
+    # action rendering
+    @test render_action(Requirement("A")) == "drop requirement A"
+    @test render_action(UserCompat("A", Int[])) == "relax your compat on A"
+    @test render_action(Pin("A", 1)) == "unpin A"
+end
+
+## diagnosis on the failed production instance
+
+const NoDeps = Dict{Int,Vector{String}}
+const NoComp = Dict{Int,Dict{String,Vector{Int}}}
+
+# the diagnosis of an unsatisfiable resolve (and a check that it *is* one).
+# `excludes` only travels in a `Problem` -- the convenience keywords carry
+# compat and pins alone -- so this builds one
+function diagnosis(data, reqs; excludes = [], kw...)
+    d = resolve(data, Problem(reqs; excludes, kw...))
+    @test d isa Diagnosis
+    return d
+end
+
+# independently verify a fix against the *raw* problem: apply exactly the
+# actions it names -- no more -- and check that the corrected problem really
+# does resolve, to exactly the solution the fix recorded, covering every
+# remaining requirement.
+#
+# "Exactly the actions it names" is the point. A fix relaxes a whole package's
+# exclusion column, but only names the sources that put a cell in it; this
+# checks that the ones it leaves unnamed really were doing nothing, so that
+# following the report to the letter produces the promised versions.
+function verify_fix(data, reqs, compat, pins, fix; excludes = [])
+    reqs2 = collect(reqs)
+    compat2 = Dict(compat)
+    pins2 = Dict(pins)
+    # (kind, package) pairs the fix says to relax
+    offkind = Set{Tuple{Symbol,Any}}()
+    for a in fix.actions
+        a isa Requirement  && (reqs2 = filter(≠(a.pkg), reqs2))
+        a isa UserCompat   && delete!(compat2, a.pkg)
+        a isa Pin          && delete!(pins2, a.pkg)
+        a isa Admission    && push!(offkind, (a.kind, a.pkg))
+    end
+    excludes2 = [Symbol(kind) => ((p, v) -> (Symbol(kind), p) ∉ offkind &&
+                                            forbids(p, v)::Bool)
+                 for (kind, forbids) in excludes]
+    prob = Problem(reqs2; compat = compat2, pins = pins2, excludes = excludes2)
+    sol = resolve(data, prob; diagnose = false)
+    sol === nothing && return false
+    sol == fix.solution && all(haskey(sol, p) for p in reqs2)
+end
+
+@testset "diagnose: requirement-level conflicts" begin
+    # two requirements fighting over a shared dependency: one cluster, both
+    # requirements in it, and dropping either one is a fix
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+        "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [2]))),
+        "C" => PkgData([1, 2], NoDeps(), NoComp()),
+    )
+    d = diagnosis(data, ["A", "B"])
+    @test length(d.conflicts) == 1
+    @test d.conflicts[1].reqs == ["A", "B"]
+    @test Set(Fact[Requirement("A"), Requirement("B")]) ⊆ Set(d.conflicts[1].chain)
+    @test length(d.fixes) == 2
+    @test Set(Set(a.pkg for a in f.actions) for f in d.fixes) ==
+        Set([Set(["A"]), Set(["B"])])
+    for fix in d.fixes
+        @test verify_fix(data, ["A", "B"], Dict{String,Vector{Int}}(),
+                         Dict{String,Int}(), fix)
+    end
+
+    # two independent conflicts: separate clusters, and every fix repairs both
+    data2 = Dict(data...,
+        "X" => PkgData([1], Dict(1 => ["Z"]), Dict(1 => Dict("Z" => Int[]))),
+        "Z" => PkgData([1, 2], NoDeps(), NoComp()),
+    )
+    reqs = ["A", "B", "X"]
+    d2 = diagnosis(data2, reqs)
+    @test length(d2.conflicts) == 2
+    @test [c.reqs for c in d2.conflicts] == [["A", "B"], ["X"]]
+    @test !isempty(d2.fixes)
+    for fix in d2.fixes
+        @test any(a isa Requirement && a.pkg == "X" for a in fix.actions)
+        @test verify_fix(data2, reqs, Dict{String,Vector{Int}}(),
+                         Dict{String,Int}(), fix)
+    end
+
+    # cluster requirements are a requirement-level MUS: unsatisfiable, and
+    # minimally so
+    for c in d2.conflicts
+        @test bare_resolve(data2, c.reqs) === nothing
+        for p in c.reqs
+            @test bare_resolve(data2, filter(≠(p), c.reqs)) !== nothing
+        end
+    end
+end
+
+@testset "diagnose: user constraints" begin
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), NoComp()),
+        "B" => PkgData([1], NoDeps(), NoComp()),
+    )
+    compat = Dict("B" => Int[])
+    d = diagnosis(data, ["A"]; compat)
+    @test UserCompat("B", Int[]) in d.conflicts[1].chain
+    # keep-order prefers keeping requirements, so relaxing the compat comes
+    # before dropping the requirement
+    @test length(d.fixes) == 2
+    @test d.fixes[1].actions == Fact[UserCompat("B", Int[])]
+    @test d.fixes[2].actions == Fact[Requirement("A")]
+    @test d.fixes[1].solution == Dict("A" => 1, "B" => 1)
+    @test isempty(d.fixes[2].solution)
+    for fix in d.fixes
+        @test verify_fix(data, ["A"], compat, Dict{String,Int}(), fix)
+    end
+
+    # a pin the user can lift
+    d = diagnosis(data, ["A"]; pins = Dict("B" => 9))
+    @test Pin("B", 9) in d.conflicts[1].chain
+    @test d.fixes[1].actions == Fact[Pin("B", 9)]
+
+    # a package carrying BOTH a compat bound and a pin is one relaxable group:
+    # the two share an exclusion column, and relaxing half of one is exactly
+    # the counterexample of Proposition D1'. The fix relaxes the whole column,
+    # but names only the sources that put a cell in it -- and `verify_fix`
+    # applies exactly what is named, so this is a test that the unnamed ones
+    # really were inert.
+    data3 = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), NoComp()),
+        "B" => PkgData([1, 2], NoDeps(), NoComp()),
+    )
+    compat3 = Dict("B" => [2])
+    pins3 = Dict("B" => 1)
+    d = diagnosis(data3, ["A"]; compat = compat3, pins = pins3)
+    fix = d.fixes[1]
+    @test Set(a.pkg for a in fix.actions) == Set(["B"])
+    @test verify_fix(data3, ["A"], compat3, pins3, fix)
+
+    # both sources named when both forbid something that is still there
+    data4 = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), Dict(1 => Dict("B" => [2]))),
+        "B" => PkgData([3, 2, 1], NoDeps(), NoComp()),
+    )
+    compat4 = Dict("B" => [1, 2])
+    pins4 = Dict("B" => 1)
+    d = diagnosis(data4, ["A"]; compat = compat4, pins = pins4)
+    fix = d.fixes[1]
+    @test any(a isa Pin for a in fix.actions)
+    @test verify_fix(data4, ["A"], compat4, pins4, fix)
+
+    # a constraint source that forbids nothing gets no selector, so it is not
+    # named in the report either
+    d = diagnosis(data3, ["A"];
+                  compat = Dict("B" => [1, 2]), pins = Dict("B" => 9))
+    @test !any(f isa UserCompat for f in d.conflicts[1].chain)
+    @test any(f isa Pin for f in d.conflicts[1].chain)
+end
+
+@testset "diagnose: admission knobs" begin
+    # An admission knob -- "no prereleases", "no yanked versions" -- is just
+    # another constraint source, so it gets a selector, a fact and a fix like
+    # any other. What it does not get is its own relaxation: it shares a
+    # package's exclusion column with that package's compat bound and pin, and
+    # Theorem D1 only licenses moving the column as a whole.
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), NoComp()),
+        "B" => PkgData([2, 1], NoDeps(), NoComp()),
+    )
+    # every version of B is a "prerelease": nothing admissible is left. B's two
+    # versions are interchangeable and forbidden alike, so the collapse keeps
+    # one representative of them -- which is exactly why the fact names one
+    # version rather than two
+    nopre = ["prerelease" => (p, v) -> p == "B"] # a string kind is accepted
+    d = diagnosis(data, ["A"]; excludes = nopre)
+    chain = d.conflicts[1].chain
+    @test Requirement("A") in chain
+    @test Admission(:prerelease, "B", [2]) in chain
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("every version of B is a prerelease, which is not allowed",
+                   report)
+    @test occursin("allow prereleases of B", report)
+    @test d.fixes[1].actions == Fact[Admission(:prerelease, "B", [2])]
+    @test d.fixes[1].solution == Dict("A" => 1, "B" => 2)
+    @test d.fixes[2].actions == Fact[Requirement("A")]
+
+    # only some versions forbidden: the fact names them. A's own bound admits
+    # only B@2, and B@2 is the prerelease -- so B@1 and B@3 survive the
+    # collapse as one allowed class and B@2 as its own forbidden one
+    data3 = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), Dict(1 => Dict("B" => [2]))),
+        "B" => PkgData([3, 2, 1], NoDeps(), NoComp()),
+    )
+    some = Pair{Symbol,Any}[:prerelease => (p, v) -> p == "B" && v == 2]
+    d = diagnosis(data3, ["A"]; excludes = some)
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("prereleases of B are not allowed (2)", report)
+    @test d.fixes[1].actions == Fact[Admission(:prerelease, "B", [2])]
+    @test d.fixes[1].solution == Dict("A" => 1, "B" => 2)
+    @test verify_fix(data3, ["A"], Dict{String,Vector{Int}}(),
+                     Dict{String,Int}(), d.fixes[1]; excludes = some)
+
+    # a yanked newest version, with the older one ruled out by compat. Both
+    # sources feed B's one exclusion column, but only the knob still forbids
+    # anything the instance has -- the compat bound admits the survivor -- so
+    # the fix names the knob alone, and `verify_fix` confirms that lifting just
+    # the knob really does give the promised versions
+    yanked = Pair{Symbol,Any}[:yanked => (p, v) -> p == "B" && v == 2]
+    d = diagnosis(data, ["A"];
+                  compat = Dict("B" => [2]), excludes = yanked)
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("every version of B is yanked", report)
+    fix = d.fixes[1]
+    @test fix.actions == Fact[Admission(:yanked, "B", [2])]
+    @test occursin("allow the yanked version 2 of B", report)
+    @test !occursin("relax your compat", report)
+    @test fix.solution == Dict("A" => 1, "B" => 2)
+    @test verify_fix(data, ["A"], Dict("B" => [2]), Dict{String,Int}(), fix;
+                     excludes = yanked)
+
+    # an unknown kind still renders sensibly rather than erroring
+    odd = Pair{Symbol,Any}[:experimental => (p, v) -> p == "B"]
+    d = diagnosis(data, ["A"]; excludes = odd)
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("every version of B is experimental, which is not allowed",
+                   report)
+    @test occursin("allow experimental versions of B", report)
+
+    # a knob that forbids nothing anywhere leaves no trace
+    inert = Pair{Symbol,Any}[:prerelease => (p, v) -> false]
+    data2 = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+        "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [2]))),
+        "C" => PkgData([1, 2], NoDeps(), NoComp()),
+    )
+    d = diagnosis(data2, ["A", "B"]; excludes = inert)
+    @test !any(f isa Admission for f in d.conflicts[1].chain)
+    @test !any(a isa Admission for f in d.fixes for a in f.actions)
+end
+
+@testset "diagnose: superseded prereleases" begin
+    # the predicate: a prerelease is superseded by the release of the same base
+    # version, and by nothing else
+    vers = [v"1.2.3", v"1.2.3-alpha1", v"1.3.0-rc1", v"1.1.0"]
+    @test  superseded(v"1.2.3-alpha1", vers)
+    @test !superseded(v"1.3.0-rc1", vers)   # 1.3.0 is not out
+    @test !superseded(v"1.2.3", vers)       # not a prerelease
+    @test !superseded(v"1.2.3-alpha1", [v"1.2.3-alpha1", v"1.2.4"])
+    # build metadata does not make a release a different version
+    @test superseded(v"1.0.22-rc1", [v"1.0.22+0"])
+    # a version type with no notion of prereleases is never superseded
+    @test !superseded(2, [1, 2, 3])
+
+    nodeps = Dict{VersionNumber,Vector{String}}()
+    nocomp = Dict{VersionNumber,Dict{String,Vector{VersionNumber}}}()
+    pre = Pair{Symbol,Any}[:prerelease => (p, v) -> !isempty(v.prerelease)]
+
+    # not superseded: 2.0.0-rc1 is the only 2.0.0 there is, so admitting
+    # prereleases is a real suggestion
+    data = Dict(
+        "A" => PkgData([v"1.0.0"], Dict(v"1.0.0" => ["B"]),
+                       Dict(v"1.0.0" => Dict("B" => [v"2.0.0-rc1"]))),
+        "B" => PkgData([v"2.0.0-rc1", v"1.0.0"], nodeps, nocomp),
+    )
+    d = diagnosis(data, ["A"]; excludes = pre)
+    @test any(a isa Admission && a.kind === :prerelease
+              for f in d.fixes for a in f.actions)
+    @test occursin("allow prereleases of B",
+                   sprint(show, MIME("text/plain"), d))
+
+    # superseded: B@2.0.0 exists, so nobody should be told to install
+    # 2.0.0-rc1 -- even though admitting it would technically resolve
+    data2 = Dict(
+        "A" => PkgData([v"1.0.0"], Dict(v"1.0.0" => ["B"]),
+                       Dict(v"1.0.0" => Dict("B" => [v"2.0.0-rc1"]))),
+        "B" => PkgData([v"2.0.0", v"2.0.0-rc1", v"1.0.0"], nodeps, nocomp),
+    )
+    d = diagnosis(data2, ["A"]; excludes = pre)
+    report = sprint(show, MIME("text/plain"), d)
+    @test !occursin("allow prereleases", report)
+    @test !any(a isa Admission for f in d.fixes for a in f.actions)
+end
+
+@testset "diagnose: constraint labels" begin
+    # "your compat" is wrong when the bound came from `Pkg.add(name, version)`
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), NoComp()),
+        "B" => PkgData([2, 1], NoDeps(), NoComp()),
+    )
+    compat = Dict("B" => Int[])
+    d = diagnosis(data, ["A"]; compat)
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("your compat restricts B to no versions", report)
+    @test occursin("relax your compat on B", report)
+
+    d = diagnosis(data, ["A"]; compat, labels = Dict("B" => :requested))
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("you requested B at no versions", report)
+    @test occursin("relax the version you requested for B", report)
+    @test !occursin("your compat", report)
+
+    # an unknown label still renders, generically
+    d = diagnosis(data, ["A"]; compat, labels = Dict("B" => Symbol("the lockfile")))
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("the lockfile restricts B to no versions", report)
+    @test occursin("relax the the lockfile on B", report)
+end
+
+@testset "diagnose: uninstallable requirements" begin
+    # a requirement the filter dropped outright -- no installable version --
+    # cannot be reasoned about on the instance, so it gets its own conflict and
+    # every fix has to drop it
+    data = Dict(
+        "A" => PkgData(Int[], NoDeps(), NoComp()),
+        "B" => PkgData([1], NoDeps(), NoComp()),
+    )
+    d = diagnosis(data, ["A", "B"])
+    @test length(d.conflicts) == 1
+    @test d.conflicts[1].reqs == ["A"]
+    @test d.conflicts[1].chain == Fact[Requirement("A"), Uninstallable("A")]
+    @test length(d.fixes) == 1
+    @test d.fixes[1].actions == Fact[Requirement("A")]
+    @test d.fixes[1].solution == Dict("B" => 1)
+
+    # transitively uninstallable, alongside a real conflict
+    data2 = Dict(
+        "A" => PkgData([1], Dict(1 => ["Gone"]), NoComp()),
+        "Gone" => PkgData(Int[], NoDeps(), NoComp()),
+        "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => Int[]))),
+        "C" => PkgData([1], NoDeps(), NoComp()),
+    )
+    d2 = diagnosis(data2, ["A", "B"])
+    @test [c.reqs for c in d2.conflicts] == [["A"], ["B"]]
+    @test !isempty(d2.fixes)
+    for fix in d2.fixes
+        @test Set(a.pkg for a in fix.actions) == Set(["A", "B"])
+    end
+end
+
+@testset "diagnose: bound-level stories and upstream fixes" begin
+    # A and B need disjoint versions of C: the story names both
+    # incompatibilities, and relaxing either one alone would resolve it
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+        "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [2]))),
+        "C" => PkgData([1, 2], NoDeps(), NoComp()),
+    )
+    d = diagnosis(data, ["A", "B"])
+    bounds = Bound[f for f in d.conflicts[1].chain if f isa Bound]
+    @test bounds == [Bound("A", [1], "C", [1]), Bound("B", [1], "C", [2])]
+    ups = d.conflicts[1].upstream
+    @test Set((u.bound.pkg, u.bound.dep) for u in ups) ==
+        Set([("A", "C"), ("B", "C")])
+    # every upstream suggestion carries a solution covering the cluster
+    for u in ups
+        @test all(haskey(u.solution, p) for p in d.conflicts[1].reqs)
+    end
+
+    # a conflict caused solely by a stale bound: one upstream suggestion
+    data2 = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => Int[]))),
+        "C" => PkgData([1, 2], NoDeps(), NoComp()),
+    )
+    d2 = diagnosis(data2, ["A"])
+    @test length(d2.conflicts[1].upstream) == 1
+    u = d2.conflicts[1].upstream[1]
+    @test (u.bound.pkg, u.bound.dep) == ("A", "C")
+    @test u.solution == Dict("A" => 1, "C" => 1)
+
+    # a three-package chain: the story follows the dependency edges
+    data3 = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+        "B" => PkgData([1], Dict(1 => ["D"]), Dict(1 => Dict("D" => [3]))),
+        "C" => PkgData([1, 2, 3], NoDeps(), NoComp()),
+        "D" => PkgData([1, 2, 3], Dict(3 => ["C"]),
+                       Dict(3 => Dict("C" => [2, 3]))),
+    )
+    d3 = diagnosis(data3, ["A", "B"])
+    @test length(d3.conflicts) == 1
+    bounds = Bound[f for f in d3.conflicts[1].chain if f isa Bound]
+    # incompatibilities are undirected, so each is stated from its
+    # alphabetically-first side: C@1 (which A needs) rules out the D@3 that B
+    # needs, and D's own versions have collapsed to the two that differ
+    @test bounds == [
+        Bound("A", [1], "C", [1]),
+        Bound("B", [1], "D", [3]),
+        Bound("C", [1], "D", [1]),
+    ]
+
+    # bias: when the same conflict is tellable through a bound or through the
+    # user's own compat, the requirement-level pass keeps the actionable one
+    data4 = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => Int[]))),
+        "C" => PkgData([1], NoDeps(), NoComp()),
+    )
+    d4 = diagnosis(data4, ["A"]; compat = Dict("C" => Int[]))
+    @test UserCompat("C", Int[]) in d4.conflicts[1].chain
+end
+
+@testset "diagnose: incidental facts are demoted" begin
+    # A minimal conflict has to close off the old versions of a package, which
+    # means facts about versions the query already excludes. They belong in the
+    # explanation but not at the same level as the line naming versions the
+    # reader could actually get -- they are the story's tangents.
+    #
+    # B@3 is what the compat admits and it needs C@2; B@1 and B@2 are ruled out
+    # by that same compat, so the facts closing them off are incidental.
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), NoComp()),
+        "B" => PkgData([3, 2, 1], Dict(3 => ["C"], 2 => ["C"], 1 => ["C"]),
+                       Dict(3 => Dict("C" => [2]),
+                            2 => Dict("C" => [1]),
+                            1 => Dict("C" => [1]))),
+        "C" => PkgData([2, 1], NoDeps(), NoComp()),
+    )
+    compat = Dict("B" => [3], "C" => [1])
+    d = diagnosis(data, ["A"]; compat)
+    bounds = Bound[f for f in d.conflicts[1].chain if f isa Bound]
+    @test length(bounds) == 2
+    live = only(f for f in bounds if !f.incidental)
+    @test live.versions == [3]          # the version the compat admits
+    dead = only(f for f in bounds if f.incidental)
+    # B@1 and B@2 say the same thing about C, so the collapse keeps one of them
+    @test dead.versions == [2]          # a version the compat already excludes
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("B 3 works with C only at 2", report)
+    @test occursin("(likewise for B 2, which your constraints already rule out)",
+                   report)
+    # the demoted fact gets no bullet of its own
+    @test count("• B ", report) == 1
+
+    # with *every* group incidental nothing is demoted: a verbose explanation
+    # beats none at all
+    d = diagnosis(data, ["A"]; compat = Dict("B" => Int[]))
+    bounds = Bound[f for f in d.conflicts[1].chain if f isa Bound]
+    @test all(!f.incidental for f in bounds)
+end
+
+@testset "diagnose: closure sub-instances" begin
+    # the dependency closure unions over *all* versions' dependencies
+    data = Dict(
+        "A" => PkgData([1, 2], Dict(1 => ["B"], 2 => ["C"]), NoComp()),
+        "B" => PkgData([1], NoDeps(), NoComp()),
+        "C" => PkgData([1], NoDeps(), NoComp()),
+        "Far" => PkgData([1], NoDeps(), NoComp()),
+    )
+    # (unfiltered, so that A@2 -- which reachability would drop, nothing
+    # forcing A past its best version -- is still there to contribute C)
+    info = pkg_info(data, ["A", "Far"]; filter = false)
+    @test dep_closure(info, ["A"]) == Set(["A", "B", "C"])
+    @test dep_closure(info, ["Far"]) == Set(["Far"])
+    # restriction keeps the closure's structure intact
+    sub = restrict_info(info, dep_closure(info, ["A"]))
+    @test Set(keys(sub)) == Set(["A", "B", "C"])
+    @test Resolver.check_info_structure(sub) === nothing
+    @test bare_resolve(sub, ["A"]) == bare_resolve(info, ["A"])
+
+    # conflicts with packages outside the closure are dropped, and by closure
+    # exactness that changes no verdict
+    data2 = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), NoComp()),
+        "B" => PkgData([1], NoDeps(), NoComp()),
+        "Out" => PkgData([1], NoDeps(), Dict(1 => Dict("B" => Int[]))),
+    )
+    info2 = pkg_info(data2, Problem(["A", "Out"]))
+    sub2 = restrict_info(info2, dep_closure(info2, ["A"]))
+    @test Set(keys(sub2)) == Set(["A", "B"])
+    @test isempty(interacting_pairs(sub2))
+    @test bare_resolve(sub2, ["A"]) == Dict("A" => 1, "B" => 1)
+end
+
+@testset "diagnose: the resolve API" begin
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+        "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [2]))),
+        "C" => PkgData([1, 2], NoDeps(), NoComp()),
+    )
+    prob = Problem(["A", "B"])
+    info = pkg_info(data, prob) # a T1 artifact; `resolve` prepares it itself
+
+    # every entry point returns the diagnosis itself, by default
+    for d in (resolve(data, ["A", "B"]), resolve(data, prob),
+              resolve(info, ["A", "B"]), resolve(info, prob))
+        @test d isa Diagnosis{String,Int}
+    end
+    # ... and `nothing`, the bare verdict, when asked not to
+    for d in (resolve(data, ["A", "B"]; diagnose = false),
+              resolve(data, prob; diagnose = false),
+              resolve(info, prob; diagnose = false))
+        @test d === nothing
+    end
+    # show: a diagnosis at the REPL has to read as the answer it is
+    d = resolve(data, prob)
+    @test sprint(show, d) == "Diagnosis(1 conflict, 2 fixes)"
+    report = sprint(show, MIME("text/plain"), d)
+    @test startswith(report, "Unsatisfiable — 1 conflict, 2 fixes:\n")
+    @test occursin("Conflict 1:", report)
+
+    # a satisfiable resolve is unaffected
+    @test resolve(data, ["A"]) == Dict("A" => 1, "C" => 1)
+
+    # the frame discipline: diagnosing pops the selector frame and puts it
+    # back, so a reused instance still resolves exactly as before
+    cprob = Problem(["A", "B"]; compat = Dict("C" => [1]))
+    # prepared exactly as `resolve` prepares it, so the instance under test is
+    # the production one: collapsed to class representatives, then filtered
+    cinfo = prepare_pkg_info(pkg_info(data, cprob), cprob)
+    sat = SAT(cinfo, cprob)
+    try
+        before = resolve(sat, ["A"])
+        @test before == Dict("A" => 1, "C" => 1)
+        @test resolve(sat, ["A", "B"]) isa Diagnosis # diagnoses in place
+        @test resolve(sat, ["A"]) == before          # ... and restores
+        @test resolve(sat, ["B"]) isa Diagnosis      # C@2 still forbidden
+        @test resolve(sat, ["A"]) == before
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "diagnose: property sweep on tiny data" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    for m = 2:3, n = 2:2
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        tested = 0
+        for _ = 1:300
+            tested < 40 || break
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            compat, pins = random_constraints(m, n)
+            # an admission knob in the mix too, so the contract that a fix
+            # names exactly the sources it needs is tested with all three
+            excludes = rand(Bool) ? [] :
+                let bad = Set{Int}(v for v = 1:n if rand(Bool))
+                    Pair{Symbol,Any}[:test => (p, v) -> v ∈ bad]
+                end
+            reqs = collect(1:m)
+            prob = Problem(reqs; compat, pins, excludes)
+            resolve(data, prob; diagnose = false) === nothing || continue
+            tested += 1
+            dg = resolve(data, prob)
+            @test !isempty(dg.conflicts)
+            # every cluster is a requirement-level MUS of the raw problem
+            for cf in dg.conflicts
+                sub(rs) = Problem(rs; compat, pins, excludes)
+                @test resolve(data, sub(cf.reqs); diagnose = false) === nothing
+                for p in cf.reqs
+                    @test resolve(data, sub(filter(≠(p), cf.reqs));
+                                  diagnose = false) !== nothing
+                end
+            end
+            # every fix really fixes it, to exactly the solution it reports,
+            # applying exactly the actions it names and nothing more
+            for fix in dg.fixes
+                @test verify_fix(data, reqs, compat, pins, fix; excludes)
+            end
+            # no fix is dominated by another
+            @test filter_dominated(dg.fixes) == dg.fixes
+        end
+        @test tested > 0
+    end
+end

--- a/test/goals.jl
+++ b/test/goals.jl
@@ -1,0 +1,304 @@
+# Goals: the `with` / `without` keywords, the universe they are answered on, and
+# the three-tier ladder of how much work an answer costs.
+
+using Resolver: Bound, Dependency, Diagnosis, Fact, PkgData, Problem, Requirement,
+    UserCompat, issatisfiable, pkg_info, prepare_pkg_info, resolve,
+    resolve_prepared
+
+GND() = Dict{Int,Vector{String}}()
+GNC() = Dict{Int,Dict{String,Vector{Int}}}()
+
+# A and B each need a different version of C, so they cannot coexist
+const RIVALS = Dict(
+    "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+    "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [2]))),
+    "C" => PkgData([2, 1], GND(), GNC()),
+)
+
+@testset "goals: the keyword shapes" begin
+    # a package, a pair, and collections of either
+    @test resolve(RIVALS, ["A"]; with = "C") == Dict("A" => 1, "C" => 1)
+    @test resolve(RIVALS, ["A"]; with = "C" => 1) == Dict("A" => 1, "C" => 1)
+    @test resolve(RIVALS, ["A"]; with = "C" => [1, 2]) == Dict("A" => 1, "C" => 1)
+    @test resolve(RIVALS, ["A"]; with = ["A", "C"]) == Dict("A" => 1, "C" => 1)
+    @test resolve(RIVALS, ["C"]; without = "A") == Dict("C" => 2)
+    @test resolve(RIVALS, ["C"]; without = ["A", "B"]) == Dict("C" => 2)
+    # a bare version reads as the singleton set containing it; a set is queried
+    # with `in`, so an empty one admits nothing
+    @test resolve(RIVALS, ["C"]; with = "C" => 2) == Dict("C" => 2)
+    @test resolve(RIVALS, ["C"]; with = "C" => Int[], diagnose = false) ===
+          nothing
+    # both together
+    @test resolve(RIVALS, ["C"]; with = "B", without = "A") ==
+          Dict("B" => 1, "C" => 2)
+    # no goal at all is the goal-⊤ path, untouched
+    @test resolve(RIVALS, ["A"]; with = nothing, without = nothing) ==
+          resolve(RIVALS, ["A"])
+
+    # a `with` goal's package is in the answer, optimized like a requirement
+    sol = resolve(RIVALS, String[]; with = "C")
+    @test sol == Dict("C" => 2)
+    # ... and a goal naming a package the universe does not have is
+    # unsatisfiable, not silently dropped
+    @test resolve(RIVALS, ["A"]; with = "Nonesuch", diagnose = false) === nothing
+    @test resolve(RIVALS, ["A"]; without = "Nonesuch") == Dict("A" => 1, "C" => 1)
+end
+
+@testset "goals: a goal is never a fix" begin
+    # the load-bearing sentence: `prob`'s constraints are negotiable, the goal
+    # is the fixed ask. Adding B to `reqs` would make "drop requirement B" a
+    # fix; asking for it with `with` must not.
+    d = resolve(RIVALS, ["A"]; with = "B")
+    @test d isa Diagnosis
+    @test !isempty(d.fixes)
+    @test all(a != Requirement("B") for f in d.fixes for a in f.actions)
+    @test d.fixes == [d.fixes[1]]
+    @test d.fixes[1].actions == Fact[Requirement("A")]
+    # ... and the witness satisfies the goal, since the goal held over its own
+    # resolve
+    @test d.fixes[1].solution == Dict("B" => 1, "C" => 2)
+
+    # the same problem with B as a requirement offers both directions
+    d2 = resolve(RIVALS, ["A", "B"])
+    @test Set(a for f in d2.fixes for a in f.actions) ==
+          Set(Fact[Requirement("A"), Requirement("B")])
+
+    # goal ≡ modified problem, on the verdict and on the solution -- the two
+    # differ only in what a fix may propose
+    for (reqs, w) in (("A", "C"), ("C", "A"), ("A", "B"))
+        @test resolve(RIVALS, [reqs]; with = w, diagnose = false) ==
+              resolve(RIVALS, sort([reqs, w]); diagnose = false)
+    end
+end
+
+@testset "goals: the report names the goal" begin
+    d = resolve(RIVALS, ["A"]; with = "B")
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("Conflict 1: the goal and A cannot be satisfied together.",
+                   report)
+    @test only(d.conflicts).goal
+    @test only(d.conflicts).reqs == ["A"]
+    @test occursin("A (all versions) works with C only at 1", report)
+    @test occursin("B (all versions) works with C only at 2", report)
+
+    # a conflict that has nothing to do with the goal says nothing about it
+    d2 = resolve(RIVALS, ["A", "B"]; with = "C")
+    @test !any(c.goal for c in d2.conflicts)
+    @test occursin("Conflict 1: A, B cannot be satisfied together.",
+                   sprint(show, MIME("text/plain"), d2))
+
+    # a goal against the user's own constraints needs no requirement at all
+    d3 = resolve(RIVALS, String[]; compat = Dict("C" => [1]), with = "B")
+    @test only(d3.conflicts).goal
+    @test isempty(only(d3.conflicts).reqs)
+    report3 = sprint(show, MIME("text/plain"), d3)
+    @test occursin("Conflict 1: the goal cannot be satisfied.", report3)
+    @test occursin("your compat restricts C to 1", report3)
+    @test occursin("relax your compat on C", report3)
+end
+
+@testset "goals: a `without` story is a chain of forced dependencies" begin
+    # the Makie/FillArrays shape: nothing conflicts with anything, the banned
+    # package is simply unavoidable, and the story is the forcing chain
+    data = Dict(
+        "M" => PkgData([1], Dict(1 => ["G"]), GNC()),
+        "G" => PkgData([2, 1], Dict(2 => ["F"], 1 => ["F"]), GNC()),
+        "F" => PkgData([1], GND(), GNC()),
+        "P" => PkgData([1], GND(), GNC()),
+    )
+    d = resolve(data, ["M"]; without = "F")
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("Conflict 1: the goal and M cannot be satisfied together.",
+                   report)
+    @test occursin("M (all versions) requires G", report)
+    @test occursin("G (all versions) requires F", report)
+    @test Dependency("M", [1], "G", false) in only(d.conflicts).chain
+    # G's two versions are interchangeable, so the universe carries one
+    # representative of them -- the fact names what the instance has
+    @test Dependency("G", [2], "F", false) in only(d.conflicts).chain
+    @test d.fixes[1].actions == Fact[Requirement("M")]
+
+    # an avoidable package is not a conflict: it is a different solution, and
+    # the caller diffs the two to price it
+    data2 = Dict(
+        "M" => PkgData([2, 1], Dict(2 => ["F"]), GNC()),
+        "F" => PkgData([1], GND(), GNC()),
+    )
+    @test resolve(data2, ["M"]) == Dict("M" => 2, "F" => 1)
+    @test resolve(data2, ["M"]; without = "F") == Dict("M" => 1)
+
+    # only *forced* edges are ever named: with a route around G the chain has
+    # nothing honest to say, so it says nothing
+    data3 = Dict(
+        "M" => PkgData([2, 1], Dict(2 => ["G"]), GNC()),
+        "G" => PkgData([1], Dict(1 => ["F"]), GNC()),
+        "F" => PkgData([1], GND(), GNC()),
+    )
+    @test resolve(data3, ["M"]; without = "F") == Dict("M" => 1)
+end
+
+# The counterexample §4 of the design is built on: reachability keeps only the
+# versions an *optimal* solution could use, which is exactly what a goal asks to
+# step outside of. `A→B`, `B@3.1→X`, `B@2.3→∅`, no conflicts anywhere: the
+# per-resolve filter keeps only B@3.1, so an instance prepared that way calls X
+# unavoidable — while the raw problem avoids it by taking B@2.3.
+const REACH = Dict(
+    "A" => PkgData([1], Dict(1 => ["B"]), GNC()),
+    "B" => PkgData([31, 23], Dict(31 => ["X"]), GNC()),
+    "X" => PkgData([1], GND(), GNC()),
+)
+
+@testset "goals: the per-resolve instance answers the wrong question" begin
+    prob = Problem(["A"])
+    # the plain resolve takes the best B, and X comes along
+    @test resolve(REACH, ["A"]) == Dict("A" => 1, "B" => 31, "X" => 1)
+
+    # the per-resolve filter has dropped B@23 -- correctly, for its own
+    # question: no optimal solution uses it
+    prepared = prepare_pkg_info(pkg_info(REACH, prob), prob)
+    @test prepared["B"].versions == [31]
+    @test haskey(prepared, "X")
+    # ... so asking *that* instance to avoid X is unsatisfiable, which is wrong
+    @test resolve_prepared(prepared, Problem(["A", "X"]); diagnose = false) !==
+          nothing
+    sat = Resolver.SAT(prepared, prob, Resolver.Goal{String}(
+        Pair{String,Any}[], ["X"]))
+    try
+        @test !Resolver.is_satisfiable(sat, ["A"])
+    finally
+        Resolver.finalize(sat)
+    end
+
+    # the goal route answers it: B@23 is in the T1 artifact, so avoiding X
+    # costs a worse B and nothing else
+    @test resolve(REACH, ["A"]; without = "X") == Dict("A" => 1, "B" => 23)
+    @test issatisfiable(REACH, ["A"]; without = "X")
+    # and the oracle agrees: a universe with X's only route deleted resolves
+    # to exactly that
+    free = Dict("A" => REACH["A"],
+                "B" => PkgData([23], GND(), GNC()))
+    @test resolve(free, ["A"]) == Dict("A" => 1, "B" => 23)
+
+    # the same trap the other way round: a version goal below the reachable
+    # prefix. Only B@31 survives preparation, so `B => 23` looks impossible
+    @test resolve(REACH, ["A"]; with = "B" => 23) == Dict("A" => 1, "B" => 23)
+    @test issatisfiable(REACH, ["A"]; with = "B" => 23)
+end
+
+# The brute-force reference for a goal: enumerate every valid solution, keep
+# the ones the goal admits, and run the layered descent over what is left --
+# `ref_resolve` with two filters and the goal's own packages among the descent's
+# roots. A goal does not change what a solution *is*, only which ones count.
+function ref_goal(
+    data :: AbstractDict{P,<:PkgData{P,V}},
+    reqs :: AbstractVector{P};
+    with = Pair{P,Any}[],
+    without = P[],
+    by = identity,
+) where {P,V}
+    pkgs = sort!(collect(keys(data)))
+    cands = Dict{P,V}[]
+    TestResolver.each_potential_solution(data, pkgs) do s
+        TestResolver.is_valid_solution(data, pkgs, s) || return
+        push!(cands, Dict{P,V}(
+            pkgs[i] => s[i] for i in eachindex(pkgs) if s[i] !== nothing))
+    end
+    filter!(c -> all(haskey(c, q) for q in reqs), cands)
+    for (p, v) in with
+        filter!(c -> haskey(c, p) && (v === nothing || c[p] == v), cands)
+    end
+    for p in without
+        filter!(c -> !haskey(c, p), cands)
+    end
+    isempty(cands) && return nothing
+    sol = Dict{P,V}()
+    layer = sort!(unique(P[reqs; P[p for (p, _) in with]]); by)
+    seen = Set{P}(layer)
+    while true
+        for p in layer
+            rank = Dict{V,Int}(v => r for (r, v) in enumerate(data[p].versions))
+            best = data[p].versions[minimum(rank[c[p]] for c in cands)]
+            sol[p] = best
+            filter!(c -> c[p] == best, cands)
+        end
+        next = P[]
+        for p in layer
+            haskey(data[p].depends, sol[p]) || continue
+            for q in data[p].depends[sol[p]]
+                q in seen || q in next || push!(next, q)
+            end
+        end
+        isempty(next) && break
+        layer = sort!(next; by)
+        union!(seen, layer)
+    end
+    return sol
+end
+
+@testset "goals: brute force agrees on tiny instances" begin
+    # every goal on every tiny random instance: `with`/`without` must agree
+    # with resolving a universe that has the goal baked in by construction.
+    Random.seed!(rand(RandomDevice(), UInt64))
+    for (m, n) in ((2, 2), (3, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:150
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = [p for p = 1:m if rand(Bool)]
+            isempty(reqs) && continue
+            for p = 1:m
+                # every goal shape against the enumerating oracle, and the
+                # cheap predicate against both
+                cases = Any[
+                    ((without = p,), ref_goal(data, reqs; without = [p])),
+                    ((with = p,),
+                     ref_goal(data, reqs; with = Pair{Int,Any}[p => nothing])),
+                ]
+                for v in data[p].versions
+                    push!(cases, ((with = p => v,),
+                        ref_goal(data, reqs; with = Pair{Int,Any}[p => v])))
+                end
+                for (kws, ref) in cases
+                    got = bare_resolve(data, reqs; kws...)
+                    @test got == ref
+                    @test (got !== nothing) == issatisfiable(data, reqs; kws...)
+                end
+
+                # ... and a `with` goal agrees with the modified problem, which
+                # is the whole content of "a goal is not a constraint"
+                @test bare_resolve(data, reqs; with = p) ==
+                      bare_resolve(data, sort!(union(reqs, [p])))
+            end
+        end
+    end
+end
+
+@testset "goals: the three-tier ladder agrees" begin
+    # `issatisfiable`, `diagnose = false` and the full call answer the same
+    # question with more and more work; nothing but the effort differs
+    for (reqs, kws) in (
+        (["A"], (;)),
+        (["A"], (with = "B",)),
+        (["A"], (with = "C" => 2,)),
+        (["A"], (without = "C",)),
+        (["C"], (without = "A",)),
+        (["A", "B"], (;)),
+    )
+        yes = issatisfiable(RIVALS, reqs; kws...)
+        probe = resolve(RIVALS, reqs; diagnose = false, kws...)
+        full = resolve(RIVALS, reqs; kws...)
+        @test yes == (probe !== nothing)
+        @test yes == (full isa Dict)
+        @test !yes || probe == full
+        @test yes || full isa Diagnosis
+    end
+
+    # the probe really does skip the explanation
+    @test resolve(RIVALS, ["A"]; with = "B", diagnose = false) === nothing
+
+    # `issatisfiable` takes the same problem-or-requirements pair `resolve`
+    # does, keywords included
+    @test issatisfiable(RIVALS, Problem(["A"]))
+    @test !issatisfiable(RIVALS, Problem(["A"]; compat = Dict("C" => [2])))
+    @test !issatisfiable(RIVALS, ["A"]; compat = Dict("C" => [2]))
+    @test !issatisfiable(RIVALS, ["A"]; pins = Dict("C" => 2))
+end

--- a/test/holdback.jl
+++ b/test/holdback.jl
@@ -1,0 +1,230 @@
+# Diagnostics for resolutions that succeeded and still surprised someone.
+
+using Resolver: Admission, Bound, Fact, Holdback, Holdbacks, Pin, PkgData,
+    Problem, Requirement, UserCompat, holdbacks, improved, pkg_info,
+    prepare_pkg_info, resolve_prepared, summarize
+
+const HND = Dict{Int,Vector{String}}
+const HNC = Dict{Int,Dict{String,Vector{Int}}}
+
+# the shape of the surprise this exists for: a "julia" whose every release
+# bundles exactly one version of a stdlib, so a bound on the stdlib steers the
+# whole toolchain
+const STEERING = Dict(
+    "App"   => PkgData([1], Dict(1 => ["julia"]), HNC()),
+    "julia" => PkgData([12, 11, 10],
+                       Dict(12 => ["Stats"], 11 => ["Stats"], 10 => ["Stats"]),
+                       Dict(12 => Dict("Stats" => [12]),
+                            11 => Dict("Stats" => [11]),
+                            10 => Dict("Stats" => [10]))),
+    "Stats" => PkgData([12, 11, 10], HND(), HNC()),
+)
+
+# resolve, then explain -- on the same prepared universe the solution came from
+function held(data, prob, pkgs = nothing; kw...)
+    info = prepare_pkg_info(pkg_info(data, prob), prob)
+    sol = resolve_prepared(info, prob)
+    @test sol !== nothing
+    hs = pkgs === nothing ? holdbacks(info, prob, sol; kw...) :
+                            holdbacks(info, prob, sol, pkgs; kw...)
+    return sol, hs
+end
+
+@testset "holdback: a stale bound steers the toolchain" begin
+    prob = Problem(["App", "julia"]; compat = Dict("Stats" => [10]))
+    sol, hs = held(STEERING, prob, ["julia"])
+    @test sol["julia"] == 10
+    h = only(hs)
+    @test h.pkg == "julia"
+    @test h.resolved == 10
+    @test h.best == 12
+    # the story names the bound and the incompatibility it creates
+    @test UserCompat("Stats", [10]) in h.chain
+    @test Bound("julia", [12], "Stats", [12]) in h.chain
+    # the fix is verified, and its witness is the optimal resolution under it
+    @test h.fix !== nothing
+    @test h.fix.actions == Fact[UserCompat("Stats", [10])]
+    @test improved(h) == 12
+    @test h.fix.solution == Dict("App" => 1, "julia" => 12, "Stats" => 12)
+    relaxed = Problem(["App", "julia"])
+    @test h.fix.solution ==
+        resolve_prepared(prepare_pkg_info(pkg_info(STEERING, relaxed), relaxed),
+                         relaxed)
+
+    report = sprint(show, MIME("text/plain"), h)
+    @test occursin("julia resolved to 10; 12 is available.", report)
+    @test occursin("your compat restricts Stats to 10", report)
+    @test occursin("julia 12 works with Stats only at 12", report)
+    @test occursin("⇒ held back by your compat on Stats.", report)
+    @test occursin("relax your compat on Stats → allows: julia 12, Stats 12",
+                   report)
+    @test summarize(h) ==
+        "julia is held back to 10 by your compat on Stats; relaxing it allows julia 12"
+    @test sprint(show, h) == "Holdback(julia 10 < 12, fixable)"
+end
+
+@testset "holdback: nothing to explain" begin
+    # unconstrained: everything is at its best, so there is no holdback and no
+    # solving done to discover it
+    prob = Problem(["App", "julia"])
+    sol, hs = held(STEERING, prob)
+    @test sol["julia"] == 12
+    @test isempty(hs)
+
+    # a package that could have been at its best but for the priority order is
+    # not "held back" by anything a report could name
+    data = Dict(
+        "A" => PkgData([2, 1], HND(), Dict(2 => Dict("B" => [1]))),
+        "B" => PkgData([2, 1], HND(), HNC()),
+    )
+    prob = Problem(["A", "B"])
+    sol, hs = held(data, prob)
+    @test sol == Dict("A" => 2, "B" => 1)   # A wins, B settles
+    @test isempty(hs)                       # ... and no constraint to blame
+end
+
+@testset "holdback: every kind of constraint" begin
+    # a pin
+    prob = Problem(["App", "julia"]; pins = Dict("Stats" => 11))
+    _, hs = held(STEERING, prob, ["julia"])
+    h = only(hs)
+    @test h.resolved == 11
+    @test Pin("Stats", 11) in h.chain
+    @test h.fix.actions == Fact[Pin("Stats", 11)]
+    @test improved(h) == 12
+    @test occursin("⇒ held back by your pin on Stats.",
+                   sprint(show, MIME("text/plain"), h))
+
+    # a relaxable admission kind
+    prob = Problem(["App", "julia"];
+                   excludes = [:prerelease => (p, v) -> p == "Stats" && v > 10])
+    _, hs = held(STEERING, prob, ["julia"])
+    h = only(hs)
+    @test h.resolved == 10
+    @test Admission(:prerelease, "Stats", [12, 11]) in h.chain
+    @test improved(h) == 12
+    @test occursin("allow prereleases of Stats → allows: julia 12",
+                   sprint(show, MIME("text/plain"), h))
+end
+
+@testset "holdback: when there is no remedy, say so" begin
+    # Not every holdback has a fix. Here nothing the *user* set is to blame:
+    # App's own bound on julia is what keeps julia back, and no constraint of
+    # yours can move it -- only a release of App could. Inventing a fix would
+    # be worse than admitting there is none.
+    data = Dict(
+        "App"   => PkgData([1], Dict(1 => ["julia"]),
+                           Dict(1 => Dict("julia" => [10]))),
+        "julia" => PkgData([12, 11, 10], HND(), HNC()),
+    )
+    prob = Problem(["App", "julia"])
+    _, hs = held(data, prob, ["julia"])
+    h = only(hs)
+    @test h.resolved == 10
+    @test h.best == 12
+    @test h.fix === nothing
+    @test improved(h) === nothing
+    report = sprint(show, MIME("text/plain"), h)
+    @test occursin("⇒ nothing you can change would move it.", report)
+    @test occursin("nothing you can change would move it", summarize(h))
+    @test sprint(show, h) == "Holdback(julia 10 < 12, no fix)"
+end
+
+@testset "holdback: best means best admissible" begin
+    # "Below its best version" is measured against the versions this problem
+    # would accept, not against the raw universe. A prerelease the query does
+    # not admit is not an option being missed, so nothing is reported -- and
+    # advertising it would bury the bound that is the real story.
+    pre = Pair{Symbol,Any}[:prerelease => (p, v) -> p == "julia" && v == 12]
+    prob = Problem(["App", "julia"]; excludes = pre)
+    sol, hs = held(STEERING, prob, ["julia"])
+    @test sol["julia"] == 11
+    @test isempty(hs)      # 11 *is* the best julia this problem can reach
+
+    # ... and with a bound that holds it below that best, the holdback is
+    # against the best admissible version, not the prerelease above it
+    prob = Problem(["App", "julia"];
+                   compat = Dict("Stats" => [10]), excludes = pre)
+    sol, hs = held(STEERING, prob, ["julia"])
+    @test sol["julia"] == 10
+    h = only(hs)
+    @test h.best == 11
+    @test improved(h) == 11
+    @test occursin("julia resolved to 10; 11 is available.",
+                   sprint(show, MIME("text/plain"), h))
+
+    # a package with no admissible version at all is an unsatisfiable problem's
+    # business; a holdback probe reports nothing rather than inventing a best
+    none = Pair{Symbol,Any}[:prerelease => (p, v) -> p == "Stats"]
+    prob = Problem(["App", "julia"]; compat = Dict("Stats" => [10]))
+    info = prepare_pkg_info(pkg_info(STEERING, prob), prob)
+    sol = resolve_prepared(info, prob)
+    @test isempty(holdbacks(info, Problem(["App", "julia"]; excludes = none),
+                            sol, ["Stats"]))
+end
+
+@testset "holdback: a truncated report says so" begin
+    # Probing a package costs solves, so the budget is real -- and a report
+    # that quietly dropped the rest would be misreporting. Ten packages, each
+    # held back by its own compat bound, against a budget of three.
+    data = Dict{String,PkgData{String,Int,Vector{Int},Vector{Int},HND,HNC}}()
+    for i = 1:10
+        data["P$i"] = PkgData([3, 2, 1], HND(), HNC())
+    end
+    reqs = ["P$i" for i = 1:10]
+    prob = Problem(reqs; compat = Dict("P$i" => [2, 1] for i = 1:10))
+    info = prepare_pkg_info(pkg_info(data, prob), prob)
+    sol = resolve_prepared(info, prob)
+    @test all(sol["P$i"] == 2 for i = 1:10)   # every one held below 3
+
+    full = holdbacks(info, prob, sol; max_probes = 20)
+    @test length(full) == 10
+    @test full.unexamined == 0
+    @test isempty(sprint(Resolver.render_unexamined, full))
+
+    capped = holdbacks(info, prob, sol; max_probes = 3)
+    @test length(capped) == 3
+    @test capped.unexamined == 7
+    # the ones it did examine are explained in full, as always
+    @test all(h.fix !== nothing && improved(h) == 3 for h in capped)
+    report = sprint(show, MIME("text/plain"), capped)
+    @test occursin("(7 more packages resolved below their best version, not examined)",
+                   report)
+    # ... and the count is of candidates, not of confirmed holdbacks
+    @test count("resolved to 2; 3 is available.", report) == 3
+
+    # singular reads properly
+    one = holdbacks(info, prob, sol; max_probes = 9)
+    @test one.unexamined == 1
+    @test occursin("(1 more package resolved below their best version, not examined)",
+                   sprint(show, MIME("text/plain"), one))
+end
+
+@testset "holdback: bookkeeping" begin
+    prob = Problem(["App", "julia"]; compat = Dict("Stats" => [10]))
+    info = prepare_pkg_info(pkg_info(STEERING, prob), prob)
+    sol = resolve_prepared(info, prob)
+
+    # explaining does not disturb the universe it was handed, and repeats
+    before = deepcopy(info)
+    hs1 = holdbacks(info, prob, sol, ["julia"])
+    @test info == before
+    @test summarize(only(hs1)) == summarize(only(holdbacks(info, prob, sol, ["julia"])))
+    # ... and the instance it builds is gone again, so a later resolve is
+    # unaffected
+    @test resolve_prepared(info, prob) == sol
+
+    # every held-back package, and the probe budget that bounds it
+    _, all = held(STEERING, prob)
+    @test all isa Holdbacks{String,Int}
+    @test sort!([h.pkg for h in all]) == ["Stats", "julia"]
+    @test all.unexamined == 0
+    _, capped = held(STEERING, prob; max_probes = 1)
+    @test length(capped) == 1
+    @test capped.unexamined == 1
+
+    # asking about a package that is not in the solution, or not held back,
+    # costs nothing and yields nothing
+    @test isempty(holdbacks(info, prob, sol, ["App"]))
+    @test isempty(holdbacks(info, prob, sol, ["Nonesuch"]))
+end

--- a/test/ordering.jl
+++ b/test/ordering.jl
@@ -48,8 +48,8 @@ end
 function test_order_equivalence(data, prob, order; by::Function = identity)
     baked = bake_order(data, order)
     for group in (true, false)
-        @test resolve(data, prob; by, order, group) ==
-              resolve(baked, prob; by, group)
+        @test bare_resolve(data, prob; by, order, group) ==
+              bare_resolve(baked, prob; by, group)
     end
 end
 
@@ -91,8 +91,8 @@ end
           BitVector([0, 1, 1]) # reversed: :v1 now represents the class
 
     # and the answer follows the order: ascending picks the worst versions
-    @test resolve(data, [:A, :B]) == Dict(:A => :v3, :B => :v2)
-    @test resolve(data, [:A, :B]; order = up) == Dict(:A => :v1, :B => :v1)
+    @test bare_resolve(data, [:A, :B]) == Dict(:A => :v3, :B => :v2)
+    @test bare_resolve(data, [:A, :B]; order = up) == Dict(:A => :v1, :B => :v1)
 end
 
 @testset "ordering: comparator vs. baked, complete data grids" begin
@@ -140,8 +140,8 @@ end
                 # ... and the ordering must not disturb the bake-equivalence of
                 # the user constraints either
                 prob = Problem(reqs; compat, pins)
-                @test resolve(data, prob; by, order) ==
-                      resolve(bake(bake_order(data, order), prob), reqs; by)
+                @test bare_resolve(data, prob; by, order) ==
+                      bare_resolve(bake(bake_order(data, order), prob), reqs; by)
             end
         end
     end
@@ -190,10 +190,10 @@ end
                 for prob in (Problem(reqs), Problem(reqs; compat, pins)),
                     order in (CANONICAL, reversed(m, n), shuffled(m, n))
                     baked = bake_order(data, order)
-                    @test resolve(all_reqs, prob; order) == resolve(baked, prob)
+                    @test bare_resolve(all_reqs, prob; order) == bare_resolve(baked, prob)
                     # ... and the same artifact answers the next query too
-                    @test resolve(all_reqs, prob; order) ==
-                          resolve(all_reqs, prob; order)
+                    @test bare_resolve(all_reqs, prob; order) ==
+                          bare_resolve(all_reqs, prob; order)
                 end
             end
             @test all_reqs == before

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -95,7 +95,8 @@ end
 # `resolve(data, prob)` must agree with the unconstrained resolve of the baked
 # data — including when both are `nothing`
 function test_bake_equivalence(data, prob; by::Function = identity)
-    @test resolve(data, prob; by) == resolve(bake(data, prob), prob.reqs; by)
+    @test bare_resolve(data, prob; by) ==
+        bare_resolve(bake(data, prob), prob.reqs; by)
 end
 
 @testset "Problem: construction & masks" begin
@@ -171,11 +172,11 @@ end
     compat = Dict(:B => [:v1])
     pins = Dict(:A => :v1)
     prob = Problem([:A]; compat, pins)
-    @test resolve(data, [:A]; compat, pins) == resolve(data, prob)
-    @test resolve(data, [:A]; compat) == resolve(data, Problem([:A]; compat))
-    @test resolve(data, [:A]) == resolve(data, Problem([:A]))
+    @test bare_resolve(data, [:A]; compat, pins) == bare_resolve(data, prob)
+    @test bare_resolve(data, [:A]; compat) == bare_resolve(data, Problem([:A]; compat))
+    @test bare_resolve(data, [:A]) == bare_resolve(data, Problem([:A]))
     info = pkg_info(data, prob)
-    @test resolve(info, [:A]; compat, pins) == resolve(info, prob)
+    @test bare_resolve(info, [:A]; compat, pins) == bare_resolve(info, prob)
 end
 
 @testset "Problem: exclusions constrain, they don't delete" begin
@@ -191,7 +192,7 @@ end
     prob = Problem([:A]; compat = Dict(:B => [:v1]))
     info = pkg_info(data, prob)
     @test info[:B].versions == [:v2, :v1] # :v2 forbidden but kept
-    @test resolve(data, prob) == Dict(:A => :v1, :B => :v1)
+    @test bare_resolve(data, prob) == Dict(:A => :v1, :B => :v1)
     test_bake_equivalence(data, prob)
 
     # every version of B forbidden: B saturates, so it keeps all its versions
@@ -206,7 +207,7 @@ end
     # -- though redundancy collapses it, since versions that are all excluded
     # alike all dominate each other
     @test haskey(info, :B)
-    @test resolve(data, prob) == Dict(:A => :v1)
+    @test bare_resolve(data, prob) == Dict(:A => :v1)
     test_bake_equivalence(data, prob)
     # ... and if the dependent can't degrade, the problem is unsatisfiable
     data = Dict(
@@ -214,7 +215,7 @@ end
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
     prob = Problem([:A]; compat = Dict(:B => Symbol[]))
-    @test resolve(data, prob) === nothing
+    @test bare_resolve(data, prob) === nothing
     test_bake_equivalence(data, prob)
 
     # an excluded version must not dominate a non-excluded one: B@v2 has no
@@ -229,7 +230,7 @@ end
     prob = Problem([:A, :B]; pins = Dict(:B => :v1))
     info = pkg_info(data, prob)
     @test info[:B].versions == [:v2, :v1]
-    @test resolve(data, prob) == Dict(:A => :v1, :B => :v1)
+    @test bare_resolve(data, prob) == Dict(:A => :v1, :B => :v1)
     test_bake_equivalence(data, prob)
 end
 
@@ -330,7 +331,7 @@ end
     # ... and it is the same problem as the equivalent compat bounds
     both = Problem([:A]; compat = Dict(:A => [:v1], :B => [:v1]))
     @test exclusion_masks(info, both) == excl
-    @test resolve(data, prob) == resolve(data, both)
+    @test bare_resolve(data, prob) == bare_resolve(data, both)
     test_bake_equivalence(data, prob)
 
     # one selector per source, so a kind, a compat bound and a pin on the same
@@ -374,16 +375,16 @@ end
                 as_compat = Problem(reqs;
                     compat = mergewith!(∩, Dict(compat), Dict(allowed)), pins)
                 for by in (identity, p -> -p)
-                    @test resolve(data, as_kind; by) ==
-                          resolve(data, as_compat; by)
+                    @test bare_resolve(data, as_kind; by) ==
+                          bare_resolve(data, as_compat; by)
                     test_bake_equivalence(data, as_kind; by)
                 end
                 # ... and the collapse and the ordering stay orthogonal to it
-                @test resolve(data, as_kind; group = false) ==
-                      resolve(data, as_kind; group = true)
+                @test bare_resolve(data, as_kind; group = false) ==
+                      bare_resolve(data, as_kind; group = true)
                 order = p -> (u, v) -> u > v
-                @test resolve(data, as_kind; order) ==
-                      resolve(bake(data, as_kind), reqs; order)
+                @test bare_resolve(data, as_kind; order) ==
+                      bare_resolve(bake(data, as_kind), reqs; order)
             end
         end
     end
@@ -424,7 +425,7 @@ end
     lo = p -> -Int(first(string(p))) # reverse alphabetical priority
     for (data, prob) in cases, by in (identity, lo)
         baked = bake(data, prob)
-        @test resolve(data, prob; by) == ref_resolve(baked, prob.reqs; by)
+        @test bare_resolve(data, prob; by) == ref_resolve(baked, prob.reqs; by)
         test_bake_equivalence(data, prob; by)
     end
     for (data, prob) in cases
@@ -519,7 +520,7 @@ end
             while true
                 fill_data!(m, n, deps, comp, data)
                 test_bake_equivalence(data, prob)
-                sol = resolve(data, prob)
+                sol = bare_resolve(data, prob)
                 sol === nothing && break
                 p = rand(collect(keys(sol)))
                 v = sol[p]

--- a/test/relaxation.jl
+++ b/test/relaxation.jl
@@ -1,0 +1,501 @@
+# Relaxation stability: the empirical check behind Theorem D1 and Proposition
+# D1' (see the manual's Theory section, "Diagnosing unsatisfiability").
+#
+# Diagnosis asks a *family* of questions of one instance: what if this
+# requirement were dropped, these constraints relaxed, this incompatibility
+# lifted? The instance it asks them of was prepared -- collapsed to class
+# representatives, then filtered -- with all of them active. Theorem D1 says
+# that is sound, the preparation preserving the layered answer and not merely
+# the verdict, provided every relaxable group is *column-closed*: switching it
+# off clears whole columns of every package's constraint matrix, never part of
+# one. Two granularities qualify, and they are the ones diagnosis uses: all of
+# a package's constraints together -- compat bound, pin and every admission
+# knob, which share one exclusion column -- and all conflicts between an
+# interacting pair.
+#
+# Below column-closure it is false, and this file pins that down too: the
+# one-package counterexample of Proposition D1', the same failure at
+# declaration granularity for third-party bounds, and a sweep confirming that
+# reachability alone -- the half Lemma R covers unconditionally -- is stable at
+# the finer granularity where the rest is not.
+#
+# Everything here is brute force. For each instance the sweep enumerates EVERY
+# relaxation sigma -- every subset of the requirements crossed with every
+# subset of the groups -- and compares against a reference resolve of the raw
+# data with those groups deleted. Not a sample: every sigma. Both `group`
+# settings are swept, so the collapse is under test alongside the filter.
+
+using Resolver: PkgData, PkgInfo, Problem, class_representatives,
+    drop_unmarked!, exclusion_masks, is_excluded, mark_installable!,
+    mark_reachable!, pkg_info, prepare_pkg_info, resolve_prepared,
+    version_permutations
+
+# resolve a universe that is *already* prepared, without preparing it again --
+# the whole point being to interrogate the universe the failed resolve used
+resolve_asis(info, prob; by = identity) =
+    resolve_prepared(info, prob; by, diagnose = false)
+
+## the group granularities
+
+# column-closed: all conflicts between an unordered pair of packages
+pair_groups(data::AbstractDict{P}) where {P} =
+    sort!(collect(Set{Tuple{P,P}}(
+        minmax(p, q)
+        for (p, data_p) in data
+        for v in data_p.versions if haskey(data_p.compat, v)
+        for (q, s) in data_p.compat[v]
+        if q ≠ p && haskey(data, q) && any(w ∉ s for w in data[q].versions))))
+
+# NOT column-closed: one group per compat declaration -- the versions of `pkg`
+# that share one statement about `dep`. This is the granularity a report would
+# like to blame, and Proposition D1' is why it may not.
+struct BoundGroup{P,V}
+    pkg      :: P
+    dep      :: P
+    versions :: Vector{V}
+end
+
+function decl_groups(data::AbstractDict{P,<:PkgData{P,V}}) where {P,V}
+    groups = BoundGroup{P,V}[]
+    for p in sort!(collect(keys(data)))
+        data_p = data[p]
+        byq = Dict{P,Dict{Vector{V},Vector{V}}}() # dep => excluded => versions
+        for v in data_p.versions
+            haskey(data_p.compat, v) || continue
+            for (q, s) in data_p.compat[v]
+                (q == p || !haskey(data, q)) && continue
+                excl = V[w for w in data[q].versions if w ∉ s]
+                isempty(excl) && continue # excludes nothing: no group
+                d = get!(() -> Dict{Vector{V},Vector{V}}(), byq, q)
+                push!(get!(() -> V[], d, excl), v)
+            end
+        end
+        for q in sort!(collect(keys(byq))), e in sort!(collect(keys(byq[q])))
+            push!(groups, BoundGroup{P,V}(p, q, byq[q][e]))
+        end
+    end
+    return groups
+end
+
+# `data` with the given conflict groups deleted -- the upstream releases that
+# loosened those declarations. Rebuilt with plain containers, since the input
+# may use specialized immutable ones (the tiny generators' TinyDict/TinyRange).
+function relax_data(
+    data :: AbstractDict{P,<:PkgData{P,V}},
+    off,
+) where {P,V}
+    # (package, version) => the deps it no longer says anything about
+    drop = Dict{Tuple{P,V},Set{P}}()
+    pairs = Set{Tuple{P,P}}()
+    for g in off
+        if g isa BoundGroup
+            for v in g.versions
+                push!(get!(() -> Set{P}(), drop, (g.pkg, v)), g.dep)
+            end
+        else
+            a, b = g
+            push!(pairs, (a, b))
+            push!(pairs, (b, a))
+        end
+    end
+    Deps = Dict{V,Vector{P}}
+    Comp = Dict{V,Dict{P,Vector{V}}}
+    out = Dict{P,PkgData{P,V,Vector{V},Vector{V},Deps,Comp}}()
+    for (p, data_p) in data
+        vers = V[v for v in data_p.versions]
+        deps = Deps(v => P[q for q in data_p.depends[v]]
+                    for v in vers if haskey(data_p.depends, v))
+        comp = Comp()
+        for v in vers
+            haskey(data_p.compat, v) || continue
+            d = Dict{P,Vector{V}}()
+            gone = get(drop, (p, v), nothing)
+            for (q, s) in data_p.compat[v]
+                haskey(data, q) || continue # compat on an unknown package: inert
+                (p, q) ∈ pairs && continue
+                gone === nothing || q ∉ gone || continue
+                d[q] = V[w for w in data[q].versions if w ∈ s]
+            end
+            comp[v] = d
+        end
+        out[p] = PkgData(vers, deps, comp)
+    end
+    return out
+end
+
+# The layered answer is defined against a version *ranking*, so when the
+# prepared universe is laid out in a non-canonical order the reference side has
+# to rank versions the same way -- otherwise the two are answering different
+# questions. `relax_data` hands back plain vectors, so sorting in place is safe.
+function reorder!(data, order)
+    order === nothing && return data
+    for (p, data_p) in data
+        sort!(data_p.versions; lt = order(p), alg = MergeSort)
+    end
+    return data
+end
+
+# do `data`'s compat declarations make p@v and q@w incompatible?
+function raw_conflict(data, p, v, q, w)
+    (haskey(data[p].compat, v) && haskey(data[p].compat[v], q) &&
+        w ∉ data[p].compat[v][q]) ||
+    (haskey(data[q].compat, w) && haskey(data[q].compat[w], p) &&
+        v ∉ data[q].compat[w][p])
+end
+
+# `info` -- prepared with every group active -- with the conflict bits that
+# `rdata` no longer implies cleared: the prepared universe *under* the
+# relaxation, i.e. the left-hand side of Theorem D1. Dependency columns and the
+# version list are untouched; the point is to ask the already-prepared instance
+# the relaxed question, which is exactly what diagnosis does.
+#
+# `classes` is carried over unchanged: clearing conflict bits can only *merge*
+# row-equality classes, so the old partition stays sound (possibly finer), which
+# is all `PkgInfo` promises of it.
+function relax_info(
+    info  :: Dict{P,PkgInfo{P,V}},
+    rdata :: AbstractDict{P,<:PkgData{P,V}},
+) where {P,V}
+    out = Dict{P,PkgInfo{P,V}}(
+        p => PkgInfo{P,V}(copy(i.versions), copy(i.depends),
+                          copy(i.interacts), copy(i.conflicts), copy(i.classes))
+        for (p, i) in info)
+    for (p, info_p) in out
+        X = info_p.conflicts
+        for (q, b) in info_p.interacts
+            vers_q = out[q].versions
+            for (i, v) in enumerate(info_p.versions),
+                (j, w) in enumerate(vers_q)
+                X[i, b+j] || continue
+                raw_conflict(rdata, p, v, q, w) || (X[i, b+j] = false)
+            end
+        end
+    end
+    return out
+end
+
+## constraint groups, at the two granularities
+
+# the packages `prob` forbids at least one existing version of. Compat bounds
+# and pins name their packages; an admission knob reaches every package, so
+# this asks the universe rather than the problem.
+function constrained_pkgs(data::AbstractDict{P}, prob::Problem{P}) where {P}
+    sort!(P[p for p in keys(data)
+            if any(is_excluded(prob, p, v) for v in data[p].versions)])
+end
+
+# column-closed: all of a package's constraints together -- its compat bound,
+# its pin, and every admission knob that touches it. They share one exclusion
+# column, which is exactly why they have to move together.
+user_pkg_groups(data::AbstractDict{P}, prob::Problem{P}) where {P} =
+    constrained_pkgs(data, prob)
+
+# NOT column-closed: one group per constraint *source* on a package
+function user_source_groups(data::AbstractDict{P}, prob::Problem{P}) where {P}
+    groups = Tuple{Symbol,P}[]
+    for p in constrained_pkgs(data, prob)
+        vers = data[p].versions
+        haskey(prob.compat, p) && any(v ∉ prob.compat[p] for v in vers) &&
+            push!(groups, (:compat, p))
+        haskey(prob.pins, p) && any(v ≠ prob.pins[p] for v in vers) &&
+            push!(groups, (:pin, p))
+        for (kind, forbids) in prob.excludes
+            any(forbids(p, v)::Bool for v in vers) && push!(groups, (kind, p))
+        end
+    end
+    return groups
+end
+
+# `prob` with the given constraint groups switched off. A group named by a bare
+# package switches off that package's whole exclusion column, admission knobs
+# included -- which needs the knobs' predicates masked, since a knob is stated
+# globally and cannot be dropped for one package by deleting an entry.
+function relax_problem(prob::Problem{P}, reqs, off) where {P}
+    compat = Dict(prob.compat)
+    pins   = Dict(prob.pins)
+    offpkg = Set{P}()               # whole exclusion columns switched off
+    offsrc = Set{Tuple{Symbol,P}}() # single sources switched off
+    for g in off
+        g isa Tuple ? push!(offsrc, g) : push!(offpkg, g)
+    end
+    for p in offpkg
+        delete!(compat, p)
+        delete!(pins, p)
+    end
+    for (kind, p) in offsrc
+        kind === :compat ? delete!(compat, p) :
+        kind === :pin    ? delete!(pins, p)   : nothing
+    end
+    excludes = Pair{Symbol,Any}[
+        kind => ((p, v) -> p ∉ offpkg && (kind, p) ∉ offsrc &&
+                           forbids(p, v)::Bool)
+        for (kind, forbids) in prob.excludes]
+    Problem(reqs; compat, pins, excludes, labels = prob.labels)
+end
+
+subsets(v::AbstractVector) =
+    (v[[isodd(b >> (i-1)) for i = 1:length(v)]] for b = 0:(1 << length(v)) - 1)
+
+## the universes under test
+
+# the production preparation: T1, then collapse, then filter -- everything on
+prepared_info(data, prob; group = true, order = nothing) =
+    prepare_pkg_info(pkg_info(data, prob.reqs), prob; group, order)
+
+# arc consistency + reachability, no redundancy elimination and no collapse:
+# the half of the preparation Lemma R covers for arbitrary group removal
+function reach_only_info(data, prob; group = false, order = nothing)
+    info = pkg_info(data, prob.reqs; filter = false)
+    mark_installable!(info)
+    drop_unmarked!(info)
+    while true
+        total = sum(length(i.versions) for i in values(info); init = 0)
+        mark_reachable!(info, prob.reqs, exclusion_masks(info, prob))
+        drop_unmarked!(info)
+        sum(length(i.versions) for i in values(info); init = 0) < total || break
+    end
+    return info
+end
+
+# One instance, every sigma: the prepared instance under sigma must answer
+# exactly as a brute-force resolve of the correspondingly deleted raw data.
+# Returns the number of violations, so callers can assert zero or report a rate.
+function sweep_relaxations(data, prob::Problem{P}, by::Function;
+                           prepare = prepared_info,
+                           group = true,
+                           order = nothing,
+                           ugroups = user_pkg_groups(data, prob),
+                           bgroups = pair_groups(data),
+                           quiet::Bool = false) where {P}
+    info = prepare(data, prob; group, order)
+    bad = 0
+    for boff in subsets(bgroups)
+        rdata = reorder!(relax_data(data, boff), order)
+        rinfo = relax_info(info, rdata)
+        for uoff in subsets(ugroups), reqs in subsets(prob.reqs)
+            σprob = relax_problem(prob, reqs, uoff)
+            got  = resolve_asis(rinfo, σprob; by)
+            want = ref_resolve(bake(rdata, σprob), reqs; by)
+            got == want && continue
+            bad += 1
+            quiet || @error "relaxation stability violated" reqs uoff boff got want
+        end
+    end
+    return bad
+end
+
+sweep_size(reqs, ugroups, bgroups) =
+    (1 << length(reqs)) * (1 << length(ugroups)) * (1 << length(bgroups))
+
+# a random admission knob: forbids a random version subset of every package,
+# the same shape of constraint as `:prerelease` and `:yanked`
+random_kinds(n::Int) = rand(Bool) ? Pair{Symbol,Any}[] :
+    let bad = Set{Int}(v for v = 1:n if rand(Bool))
+        Pair{Symbol,Any}[:test => (p, v) -> v ∈ bad]
+    end
+
+@testset "relaxation stability: brute-force sweep" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p  # default priority: lower package id first
+    lo = p -> -p # reversed priority
+    rev = p -> (u, v) -> u > v # a non-canonical version ordering
+
+    # Theorem D1, exhaustive tier: every dependency and compatibility pattern
+    # of the smallest grids, a random constraint draw on each, every sigma --
+    # with and without the interchangeability collapse
+    for m = 1:2, n = 1:2
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for deps_bits = 0:2^d-1
+            deps = make_deps(deps_bits)
+            for comp_bits = 0:2^c-1
+                comp = make_comp(comp_bits)
+                fill_data!(m, n, deps, comp, data)
+                compat, pins = random_constraints(m, n)
+                prob = Problem(collect(1:m);
+                               compat, pins, excludes = random_kinds(n))
+                for group in (true, false)
+                    @test sweep_relaxations(data, prob, rand((hi, lo));
+                                            group) == 0
+                end
+            end
+        end
+    end
+
+    # Theorem D1, random tier: bigger grids, bounded sigma count per instance,
+    # both collapse settings and a non-canonical version ordering
+    for (m, n) in ((2, 3), (3, 2), (3, 3), (4, 2))
+        (m*n)^2 ≤ 128 || continue
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        tested = 0
+        for _ = 1:400
+            tested < 20 || break
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            compat, pins = random_constraints(m, n)
+            prob = Problem(collect(1:m);
+                           compat, pins, excludes = random_kinds(n))
+            ug = user_pkg_groups(data, prob)
+            bg = pair_groups(data)
+            sweep_size(prob.reqs, ug, bg) ≤ 2048 || continue
+            tested += 1
+            by = rand((hi, lo))
+            for (group, order) in ((true, nothing), (false, nothing),
+                                   (true, rev))
+                @test sweep_relaxations(data, prob, by;
+                                        group, order,
+                                        ugroups = ug, bgroups = bg) == 0
+            end
+        end
+        @test tested > 0
+    end
+
+    # Theorem D1, hand-built shapes the random draws under-sample: a constraint
+    # that forbids everything, a pin at a missing version, an incompatibility a
+    # relaxation must be able to bring a version back through
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    chain = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:C], :v1 => [:C]),
+                      Dict(:v2 => Dict(:C => [:v1]))),
+        :B => PkgData([:v2, :v1], Dict(:v2 => [:C]),
+                      Dict(:v2 => Dict(:C => [:v2]))),
+        :C => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    pre = Pair{Symbol,Any}[:prerelease => (p, v) -> v === :v2]
+    cases = [
+        (chain, Problem([:A, :B])),
+        (chain, Problem([:A, :B]; compat = Dict(:C => [:v1]))),
+        (chain, Problem([:A, :B]; compat = Dict(:C => Symbol[]))),
+        (chain, Problem([:A, :B]; pins = Dict(:C => :v9))),
+        (chain, Problem([:A, :B]; pins = Dict(:A => :v2, :C => :v2))),
+        (chain, Problem([:A, :B, :C];
+                        compat = Dict(:A => [:v1]), pins = Dict(:C => :v1))),
+        (chain, Problem([:A, :B]; excludes = pre)),
+        (chain, Problem([:A, :B]; compat = Dict(:C => [:v2]), excludes = pre)),
+        (chain, Problem([:A, :B]; pins = Dict(:C => :v2), excludes = pre)),
+    ]
+    byrev = p -> -Int(first(string(p)))
+    for (data, prob) in cases, by in (identity, byrev), group in (true, false)
+        @test sweep_relaxations(data, prob, by; group) == 0
+    end
+end
+
+@testset "relaxation stability: the collapse keeps forbidden versions" begin
+    # `class_representatives` refines the T1 interchangeability classes by the
+    # exclusion mask *before* picking representatives, so a forbidden
+    # sub-class keeps a representative of its own. That is what makes the
+    # collapse compatible with diagnosis at all: a version the query forbids is
+    # still in the instance, and switching the constraint off can bring it back.
+    #
+    # Checked for every kind of constraint source, since they all feed the one
+    # mask -- which is also why they have to relax together.
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    # :v2 and :v1 are interchangeable: same (empty) dependency set, and nothing
+    # anywhere constrains one and not the other
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    t1 = pkg_info(data, [:A])
+    @test t1[:B].classes == [1, 1] # one class, as promised
+
+    # forbid the *better* member, so that relaxing has something to show
+    sources = [
+        ("compat", Problem([:A]; compat = Dict(:B => [:v1]))),
+        ("pin",    Problem([:A]; pins = Dict(:B => :v1))),
+        ("prerelease",
+         Problem([:A]; excludes = [:prerelease => (p, v) -> v === :v2])),
+        ("yanked",
+         Problem([:A]; excludes = [:yanked => (p, v) -> v === :v2])),
+    ]
+    for (name, prob) in sources
+        keep = class_representatives(pkg_info(data, [:A]), prob)
+        # the one T1 class splits in two, and both halves keep a member
+        @test count(keep[:B]) == 2
+        info = prepared_info(data, prob)
+        @test :v2 ∈ info[:B].versions   # forbidden, but present
+        @test resolve_asis(info, prob) == Dict(:A => :v1, :B => :v1)
+        # ... and switching the source off reactivates it
+        σ = relax_problem(prob, [:A], [:B])
+        @test resolve_asis(info, σ) == Dict(:A => :v1, :B => :v2)
+        @test resolve_asis(info, σ) == bare_resolve(data, [:A])
+    end
+
+    # with no constraint at all the class collapses to one representative
+    keep = class_representatives(pkg_info(data, [:A]), Problem([:A]))
+    @test count(keep[:B]) == 1
+end
+
+@testset "relaxation stability: below column-closure it fails" begin
+    # Proposition D1': one package, two versions, a compat bound admitting only
+    # the worse one and a pin holding the better one. Together they forbid
+    # everything, so the two versions have identical constraint rows and
+    # redundancy deletes the second -- and relaxing just the *pin* then finds
+    # nothing left to satisfy the compat with.
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(:A => PkgData([:v1, :v2], nodeps, nocomp))
+    full = Problem([:A]; compat = Dict(:A => [:v2]), pins = Dict(:A => :v1))
+    info = prepared_info(data, full)
+    @test info[:A].versions == [:v1] # :v2 collapsed into :v1
+    σprob = Problem([:A]; compat = Dict(:A => [:v2])) # pin dropped
+    @test bare_resolve(data, σprob) == Dict(:A => :v2) # raw: satisfiable
+    @test resolve_asis(info, σprob) === nothing        # prepared: not
+    # and the whole-package relaxation, which *is* column-closed, is fine
+    @test sweep_relaxations(data, full, identity) == 0
+
+    # the same, with an admission knob standing in for the compat bound: the
+    # kinds are not special, they are just more sources sharing the one column
+    full2 = Problem([:A]; pins = Dict(:A => :v1),
+                          excludes = [:prerelease => (p, v) -> v === :v1])
+    info2 = prepared_info(data, full2)
+    σ2 = Problem([:A]; excludes = [:prerelease => (p, v) -> v === :v1])
+    @test bare_resolve(data, σ2) == Dict(:A => :v2)
+    @test resolve_asis(info2, σ2) === nothing
+    @test sweep_relaxations(data, full2, identity) == 0
+
+    # and at declaration granularity for third-party bounds: two separate
+    # compat statements about the same package, only one relaxed
+    data = Dict(
+        :A => PkgData([:v1, :v2], Dict(:v2 => [:B]), nocomp),
+        :B => PkgData([:v1, :v2], nodeps,
+                      Dict(:v1 => Dict(:A => [:v1]), :v2 => Dict(:A => Symbol[]))),
+    )
+    prob = Problem([:A, :B]; compat = Dict(:B => [:v1, :v2]),
+                             pins = Dict(:B => :v1, :A => :v2))
+    decls = decl_groups(data)
+    @test length(decls) == 2 # B@v1's statement and B@v2's, coalesced apart
+    # column-closed granularity: sound
+    @test sweep_relaxations(data, prob, identity) == 0
+    # declaration granularity: not (this is a regression test for the *fact*,
+    # so that a future change which makes it sound gets noticed)
+    @test sweep_relaxations(data, prob, identity;
+                            bgroups = decls, quiet = true) > 0
+end
+
+@testset "relaxation stability: reachability alone is unconditionally stable" begin
+    # Lemma R holds for arbitrary group removal, so a reach-only universe --
+    # no redundancy elimination, no collapse -- is stable even at the finer
+    # granularities Proposition D1' breaks, which localizes the whole
+    # instability in the answer-preserving-by-domination half of preparation
+    Random.seed!(rand(RandomDevice(), UInt64))
+    for (m, n) in ((2, 2), (2, 3), (3, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        tested = 0
+        for _ = 1:400
+            tested < 20 || break
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            compat, pins = random_constraints(m, n)
+            prob = Problem(collect(1:m);
+                           compat, pins, excludes = random_kinds(n))
+            ug = user_source_groups(data, prob)
+            bg = decl_groups(data)
+            sweep_size(prob.reqs, ug, bg) ≤ 4096 || continue
+            tested += 1
+            @test sweep_relaxations(data, prob, rand((identity, p -> -p));
+                                    prepare = reach_only_info,
+                                    ugroups = ug, bgroups = bg) == 0
+        end
+        @test tested > 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -283,6 +283,7 @@ include("ordering.jl")
 include("relaxation.jl")
 include("diagnose.jl")
 include("holdback.jl")
+include("goals.jl")
 
 @testset "registry resolve" begin
     rp = registry.provider()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,7 +110,7 @@ end
 @testset "resolve: single solution" begin
     for ex in tiny_data.examples
         data, reqs = ex.data, ex.reqs
-        sol = resolve(data, reqs)
+        sol = bare_resolve(data, reqs)
         # a package => version dict covering the requirements, or nothing
         if sol !== nothing
             @test sol isa Dict{Int,Int}
@@ -118,8 +118,8 @@ end
         end
         # deterministic: resolving again, and with the requirements supplied
         # in a different order, yields the same solution
-        @test resolve(data, reqs) == sol
-        @test resolve(data, reverse(collect(reqs))) == sol
+        @test bare_resolve(data, reqs) == sol
+        @test bare_resolve(data, reverse(collect(reqs))) == sol
     end
 end
 
@@ -135,7 +135,7 @@ end
             fill_data!(m, n, deps, comp, data)
             for reqs_bits = 0:2^m-1, by in (hi, lo)
                 reqs = collect(make_reqs(reqs_bits))
-                @test resolve(data, reqs; by) == ref_resolve(data, reqs; by)
+                @test bare_resolve(data, reqs; by) == ref_resolve(data, reqs; by)
             end
         end
     end
@@ -155,7 +155,7 @@ using Resolver: PkgData
         :PkgA => PkgData([:v1], Dict{Symbol,Vector{Symbol}}(), Dict(:v1 => Dict(:MissingCompat => Any[]))),
         :PkgB => PkgData([:v1], Dict{Symbol,Vector{Symbol}}(), Dict{Symbol,Dict{Symbol,Any}}())
     )
-    sol = resolve(data, [:PkgA])
+    sol = bare_resolve(data, [:PkgA])
     @test sol !== nothing && haskey(sol, :PkgA)
 
     # Test missing required package
@@ -208,8 +208,8 @@ end
         :A => PkgData(Symbol[], nodeps, nocomp),
         :B => PkgData([:v1], nodeps, nocomp),
     )
-    @test resolve(data, [:A]) === nothing
-    @test resolve(data, [:A, :B]) === nothing
+    @test bare_resolve(data, [:A]) === nothing
+    @test bare_resolve(data, [:A, :B]) === nothing
     @test resolve(data, [:B]) == Dict(:B => :v1)
     @test isempty(resolve(data, Symbol[]))
     @test !haskey(pkg_info(data, [:A]), :A)
@@ -221,7 +221,7 @@ end
         :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
         :B => PkgData(Symbol[], nodeps, nocomp),
     )
-    @test resolve(data, [:A]) === nothing
+    @test bare_resolve(data, [:A]) === nothing
     @test isempty(resolve(data, Symbol[]))
     @test isempty(pkg_info(data, [:A]))
     @test isempty(pkg_info(data, Symbol[]))
@@ -237,7 +237,7 @@ end
         :B => PkgData(Symbol[], nodeps, nocomp),
         :C => PkgData([:v1], Dict(:v1 => [:A]), nocomp),
     )
-    @test resolve(data, [:C]) === nothing
+    @test bare_resolve(data, [:C]) === nothing
     @test isempty(pkg_info(data, [:C]))
     test_resolver(data, [:C])
 
@@ -265,8 +265,8 @@ end
         :B => PkgData(Symbol[], nodeps, nocomp),
     )
     info = pkg_info(data, [:A]; filter = false)
-    @test resolve(info, [:A]) === nothing
-    @test resolve(info, [:A]; group = false) === nothing
+    @test bare_resolve(info, [:A]) === nothing
+    @test bare_resolve(info, [:A]; group = false) === nothing
     data = Dict(
         :A => PkgData([:v2, :v1], Dict(:v2 => [:B]), nocomp),
         :B => PkgData(Symbol[], nodeps, nocomp),
@@ -280,6 +280,8 @@ end
 include("problem.jl")
 include("classes.jl")
 include("ordering.jl")
+include("relaxation.jl")
+include("diagnose.jl")
 
 @testset "registry resolve" begin
     rp = registry.provider()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -282,6 +282,7 @@ include("classes.jl")
 include("ordering.jl")
 include("relaxation.jl")
 include("diagnose.jl")
+include("holdback.jl")
 
 @testset "registry resolve" begin
     rp = registry.provider()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -284,6 +284,7 @@ include("relaxation.jl")
 include("diagnose.jl")
 include("holdback.jl")
 include("goals.jl")
+include("toolkit.jl")
 
 @testset "registry resolve" begin
     rp = registry.provider()

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -2,13 +2,20 @@ using Resolver
 using Random
 using Test
 
+# `resolve` without the diagnosis of an unsatisfiable result. Most of the suite
+# compares against a brute-force reference that has no diagnosis to offer, and
+# resolves in tight loops where computing one per failure would dominate the
+# runtime; the diagnostics have their own tests. Named for what it asks for, so
+# that a call site says why it is not asking for the explanation.
+bare_resolve(args...; kws...) = resolve(args...; diagnose = false, kws...)
+
 @isdefined(includet) ? includet("tiny_data.jl") : include("tiny_data.jl")
 @isdefined(includet) ? includet("registry.jl")  : include("registry.jl")
 
 module TestResolver
 
-using Resolver: resolve, DepsProvider, PkgData, PkgInfo, pkg_data, pkg_info,
-    filter_pkg_info!
+using Resolver: resolve, DepsProvider, PkgData, PkgInfo,
+    filter_pkg_info!, pkg_data, pkg_info
 using Test
 
 export test_resolver, ref_resolve
@@ -28,7 +35,7 @@ function test_resolver(
     reqs :: AbstractVector{P},
 ) where {P,V}
     # resolve: a single optimal solution, or nothing when unsatisfiable
-    sol = resolve(data, reqs)
+    sol = resolve(data, reqs; diagnose = false)
 
     if sol === nothing
         # verify that no valid solution covers all the requirements

--- a/test/toolkit.jl
+++ b/test/toolkit.jl
@@ -1,0 +1,143 @@
+# The presentation toolkit: everything the default report decides, as something
+# a caller can decide differently.
+
+using Resolver: Bound, Change, Diagnosis, PkgData, Problem, Requirement,
+    UserCompat, blame_phrase, changes, rank_upstream!, render_action,
+    render_fact, report, resolve, superseded
+
+# `sprint` does not forward keywords, and every knob here is one
+rep(d; kws...) = sprint(io -> report(io, d; kws...))
+
+TND() = Dict{Int,Vector{String}}()
+TNC() = Dict{Int,Dict{String,Vector{Int}}}()
+
+@testset "toolkit: show is report with the defaults" begin
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+        "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [2]))),
+        "C" => PkgData([2, 1], TND(), TNC()),
+    )
+    d = resolve(data, ["A", "B"])
+    @test sprint(show, MIME("text/plain"), d) == rep(d)
+
+    # max_upstream caps the list and says how many it dropped
+    @test occursin("a release of", rep(d; max_upstream = 1))
+    @test occursin("(1 more possible upstream fix not shown)",
+                   rep(d; max_upstream = 1))
+    @test !occursin("more possible upstream", rep(d))
+    @test !occursin("not shown", rep(d; max_upstream = typemax(Int)))
+
+    # trim_witnesses = false prints the whole assignment, not just the
+    # contested packages
+    full = rep(d; trim_witnesses = false)
+    @test occursin("→ allows: A 1, C 1", rep(d))
+    @test occursin("→ allows: A 1, C 1", full)  # nothing else here to add
+end
+
+@testset "toolkit: labels are a rendering choice too" begin
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), Dict(1 => Dict("B" => [2]))),
+        "B" => PkgData([2, 1], TND(), TNC()),
+    )
+    prob = Problem(["A"]; compat = Dict("B" => [1]))
+    d = resolve(data, prob)
+    @test occursin("your compat restricts B to 1", rep(d))
+    @test occursin("relax your compat on B", rep(d))
+    # the same diagnosis, worded as `Pkg.add(name, version)` would want it
+    said = rep(d; labels = Dict("B" => :requested))
+    @test occursin("you requested B at 1", said)
+    @test occursin("relax the version you requested for B", said)
+    # ... and an unknown label reads neutrally rather than erroring
+    @test occursin("lockfile restricts B to 1",
+                   rep(d; labels = Dict("B" => :lockfile)))
+
+    # `Problem`'s labels say the same thing at diagnosis time; the argument is
+    # for callers whose wording is not a property of the problem
+    d2 = resolve(data, Problem(["A"]; compat = Dict("B" => [1]),
+                               labels = Dict("B" => :requested)))
+    @test rep(d2) == said
+end
+
+@testset "toolkit: incidental facts, demoted or dropped" begin
+    # a bound whose own side the user's compat already rules out: needed for
+    # minimality, not what anyone is reading for
+    data = Dict(
+        "A" => PkgData([3, 2, 1], Dict(3 => ["B"], 2 => ["B"], 1 => ["B"]),
+                       Dict(3 => Dict("B" => [2]), 2 => Dict("B" => Int[]),
+                            1 => Dict("B" => Int[]))),
+        "B" => PkgData([2, 1], TND(), TNC()),
+    )
+    prob = Problem(["A"]; compat = Dict("A" => [3], "B" => [1]))
+    d = resolve(data, prob)
+    @test d isa Diagnosis
+    # whatever the demotion decides, the flag is on the fact for a client to
+    # read, and every fact is still in the chain
+    bounds = [f for c in d.conflicts for f in c.chain if f isa Bound]
+    @test !isempty(bounds)
+    plain = rep(d)
+    verbose = rep(d; demote_incidental = false)
+    @test length(split(verbose, "  • ")) ≥ length(split(plain, "  • "))
+    @test !occursin("likewise for", verbose)
+end
+
+@testset "toolkit: the sentence layer" begin
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["B"]), Dict(1 => Dict("B" => [2]))),
+        "B" => PkgData([2, 1], TND(), TNC()),
+    )
+    d = resolve(data, Problem(["A"]; compat = Dict("B" => [1])))
+    f = only(f for c in d.conflicts for f in c.chain if f isa UserCompat)
+    @test sprint(render_fact, f, d) == "your compat restricts B to 1"
+    @test render_action(f) == "relax your compat on B"
+    @test blame_phrase(f) == "your compat on B"
+    @test render_action(Requirement("A")) == "drop requirement A"
+    @test blame_phrase(Requirement("A")) == "your requirement on A"
+end
+
+@testset "toolkit: superseded and upstream ranking" begin
+    # the prerelease-supersession predicate, public so a client filtering its
+    # own suggestions applies the same policy
+    vers = [v"1.2.3", v"1.2.3-alpha1", v"1.3.0-beta1"]
+    @test superseded(v"1.2.3-alpha1", vers)
+    @test !superseded(v"1.3.0-beta1", vers)
+    @test !superseded(v"1.2.3", vers)
+    @test !superseded(1, [1, 2])   # a version type with no prerelease notion
+
+    data = Dict(
+        "A" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [1]))),
+        "B" => PkgData([1], Dict(1 => ["C"]), Dict(1 => Dict("C" => [2]))),
+        "C" => PkgData([2, 1], TND(), TNC()),
+    )
+    d = resolve(data, ["A", "B"])
+    ups = [u for c in d.conflicts for u in c.upstream]
+    @test length(ups) == 2
+    # a client's own filter, over public structure
+    mine = filter(u -> u.bound.pkg == "A" || u.bound.dep == "A", ups)
+    @test !isempty(mine)
+    # ranking off the diagnosis's own version lists, which is all a client
+    # holding a report has
+    ranked = rank_upstream!(copy(ups), d)
+    @test Set(ranked) == Set(ups)
+    @test rank_upstream!(copy(ranked), d) == ranked   # deterministic
+end
+
+@testset "toolkit: changes prices a feasible goal" begin
+    # the `without = "TranscodingStreams"` shape: not a conflict, a different
+    # solution, and the caller diffs the two to say what it costs
+    data = Dict(
+        "CSV" => PkgData([10, 5], Dict(10 => ["Codec"]), TNC()),
+        "Codec" => PkgData([1], TND(), TNC()),
+    )
+    plain = resolve(data, ["CSV"])
+    free = resolve(data, ["CSV"]; without = "Codec")
+    @test plain == Dict("CSV" => 10, "Codec" => 1)
+    @test free == Dict("CSV" => 5)
+    cs = changes(plain, free)
+    @test cs == [Change("CSV", 10, 5), Change("Codec", 1, nothing)]
+    @test sprint(show, cs[1]) == "CSV 10 → 5"
+    @test sprint(show, cs[2]) == "Codec 1 removed"
+    @test sprint(show, Change("X", nothing, 2)) == "X 2 added"
+    # a diff with itself is empty, and the diff is antisymmetric
+    @test isempty(changes(plain, plain))
+    @test changes(free, plain) == [Change("CSV", 5, 10), Change("Codec", nothing, 1)]
+end

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -275,7 +275,12 @@ end
         ws = make_shadow_ws("99.0.0")
         ok, out, err = resolve_workspace_manifest(ws)
         @test !ok
-        @test occursin("Unsatisfiable", err)
+        # ... and explained: the workspace copy of JSON is fixed at a version
+        # Conda's compat rules out, so the only fix is to stop requiring Conda
+        @test occursin("Unresolvable", err)
+        @test occursin("Conflict 1: Conda cannot be satisfied.", err)
+        @test occursin("works with Conda only at no versions", err)
+        @test occursin("drop requirement Conda", err)
     end
 
     @testset "compat excluding a workspace package's local version" begin


### PR DESCRIPTION
Closes #6. Closes #52.

## What

When a resolve fails, `resolve` returns a `Diagnosis` explaining why and what would fix it. When it succeeds surprisingly — a package held below the version you'd expect — `holdbacks` names the constraint responsible. And both generalize to *goal queries*: ask the resolver for an outcome, and get either the optimal solution achieving it or the explanation of what it would take.

```julia
resolve(info, prob)                                  # solve, or explain why not
resolve(info, prob; with = "CUDA")                   # solve with CUDA, or what it would take
resolve(info, prob; without = "FillArrays")          # the FillArrays-free optimum, or why not
resolve(info, prob; with = "DataFrames" => v"1.8.2") # this version, or what it would take
   :: Union{Dict{P,V}, Diagnosis{P,V}, Nothing}      # nothing iff diagnose = false

issatisfiable(info, prob; with = ..., without = ...) # bare feasibility: one solve, no descent
holdbacks(info, prob, sol, [pkgs])                   # why is X at an old version?
```

`prob`'s constraints are *negotiable* — fixes may propose relaxing them; the goal kwargs are the *fixed ask* — never proposed as fixes. `diagnose=false` with a goal is a cheap feasibility probe; `issatisfiable` skips even the optimizing descent. A `Diagnosis` carries independent conflicts as minimal fact chains, **verified fixes** (each witness is the optimal resolve of the fixed problem — what you'd actually get), and ranked upstream suggestions:

```
Unsatisfiable — 1 conflict, 2 fixes:
Conflict 1: DataFrames cannot be satisfied.
  • you requested DataFrames at 1.7
  • DataFrames 1.4.0–1.7.1 requires PrettyTables at 2.1.0–2.4.0
  • you requested PrettyTables at 1
  • PrettyTables 1.3.1 works with DataFrames only at 0.11.7–0.21.8, 1.3.6
    (likewise for PrettyTables 0.1.0–0.11.1, 2.0.0–3.4.3, which your constraints already rule out)
Verified fixes:
  1. relax the version you requested for DataFrames → allows: PrettyTables 1.3.1, DataFrames 1.3.6
  2. relax the version you requested for PrettyTables → allows: DataFrames 1.7.1, PrettyTables 2.4.0
```

`bin/resolve.jl` prints the diagnosis on failure, explains julia automatically whenever it resolves below its best admissible version —

```
Note: julia is held back to 1.10.11 by your compat on LinearAlgebra; relaxing it allows julia 1.12.6.
```

— and answers `--explain=<pkg|pkg@ver>` on demand (below best → the holdback; at best or absent → what having/avoiding it costs).

## How

Diagnosis runs **on the same filtered, collapsed instance resolve used** — the selector-guarded user constraints (#49) turn into assumptions by popping one frame, and every diagnostic artifact is a satisfiability verdict under a relaxation. The licensing theory is new in `docs/src/theory/diagnostics.md`:

- **Theorem D1**: the filter preserves answers under every *column-closed* relaxation. The finer per-source version was conjectured and **disproved by the branch's own sweep** (Prop D1′ — minimal counterexample: a compat bound and a pin jointly forbidding both versions of a package; 1.4% of fine-grained relaxations answer wrongly). **Lemma R**: reachability alone is unconditionally relaxation-stable — redundancy elimination is the sole unstable pass.
- **Proposition G** (goal safety): better-version goals are safe on the per-resolve instance (reach keeps version prefixes); presence goals are not — a committed counterexample shows the filter calling a package "forced" that the raw problem avoids — so they run on a T1 closure sub-instance, exact by **Lemma D3**.
- ~1.9M swept relaxation verdicts back the theorems; goal queries are additionally checked against a brute-force oracle.

## Policy is conventions and post-processing, not knobs

The generation-time surface is `diagnose::Bool`. Everything else:

- Platform packages (julia) are modeled as *dependency edges*, never requirements — so "drop requirement julia" is unrepresentable, not suppressed.
- **Yanked versions are pre-filtered** from the universe: never suggested, by construction. `--allow-yanked[=<pkgs>]` opts back in; the report still explains, from provider metadata, when "the versions your compat admits are yanked."
- Prereleases stay a relaxable admission kind ("allow prereleases of Wine_jll" is a fix worth finding), suggested only when no same-base release supersedes them.
- **Every opinion in the report is a public function**: `report(io, d; max_upstream, demote_incidental, trim_witnesses, labels)`, `changes(sol₁, sol₂)`, `rank_upstream!`, `superseded`, the sentence layer, `Bound.incidental`. The default `show` is one client; a caller like Pkg owns its own presentation (guide: "Rendering your own reports"), including wording for `Pkg.add`-style restrictions via `labels` ("you requested DataFrames at 1.7").

## Cost

Automatic julia holdback: 4–18 ms (free when julia is at its best — no solve). Full UNSAT diagnosis on real registry conflicts: ~0.3–1.2 s end-to-end, with a deterministic work budget on pathological closures (the report then stops at requirement level and says so). Goal queries on a Makie-scale closure: `issatisfiable` 60–150 ms; full diagnosis 113–348 ms. Suite: ~1.9M assertions including the relaxation sweeps.

## Review history

Earlier iterations and review discussion: #30 (closed). Follow-on tracking: #59 (performance directions), #63 (output-quality ceilings), #64 (roadmap).

## Co-author

Implemented with [Claude Code](https://claude.com/claude-code): design discussed with, implementation by, and review by Claude, directed and reviewed by @StefanKarpinski, with review feedback from @KristofferC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7