### PR TITLE
issatisfiable: the bare feasibility check

### DIFF
--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -93,7 +93,12 @@ end
 function resolves(reqs::Vector{UUID}; julia::VersionSpec)
     prob = make_problem(reqs; julia)
     info = Resolver.pkg_info(reg, prob)
-    Resolver.resolve(info, prob) !== nothing
+    verdict = Resolver.resolve(info, prob) !== nothing
+    # this is exactly what `issatisfiable` answers on its own, so it must agree
+    # with the descent's verdict here -- on real registry data, with the Julia
+    # bound and the admission kinds in force
+    @test Resolver.issatisfiable(info, prob) == verdict
+    return verdict
 end
 
 # Resolve a project with the given dependencies, `[compat]` body and command
@@ -477,6 +482,8 @@ end
         # and a bound no Julia satisfies is unsatisfiable, not silently widened
         @test isnothing(Resolver.resolve(info,
             make_problem(reqs; julia = VersionSpec("99"))))
+        @test !Resolver.issatisfiable(info,
+            make_problem(reqs; julia = VersionSpec("99")))
     end
 
     # The Julia versions to resolve for come from `--julia` if given, otherwise

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,7 @@
 
 ```@docs
 resolve
+issatisfiable
 Problem
 ```
 

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -230,3 +230,92 @@ resolve(
     group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
 ) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, group, order)
+
+"""
+    issatisfiable(data, reqs; compat = ..., pins = ...) -> Bool
+
+Compute `resolve(data, reqs; ...) !== nothing` more efficiently, with a single
+satisfiability check instead of a full optimizing resolve. Use this when you
+want to know whether the requirements can be satisfied but don't need an
+actual solution.
+
+`data` may be a `DepsProvider`, a dict of `PkgData`, a dict of `PkgInfo`, or a
+`SAT` instance, and a `Problem` may be passed in place of the requirements and
+keywords, as with `resolve`. The `by`, `order` and `group` keywords are not
+accepted since they affect which solution `resolve` picks, not whether one
+exists. The `SAT` method leaves the instance unchanged, so it can be reused.
+"""
+function issatisfiable(
+    sat  :: SAT{P},
+    reqs :: SetOrVec{P} = keys(sat.info),
+) where {P}
+    # a requirement the instance doesn't know has no installable version —
+    # the filter drops such packages — so it cannot be satisfied
+    all(p -> haskey(sat.info, p), reqs) || return false
+    # the requirements are satisfiable iff this one solve says so; it only
+    # assumes, so the instance is left exactly as it was found
+    return is_satisfiable(sat, reqs)
+end
+
+# check a universe that `prepare_pkg_info` has already laid out, collapsed
+# & filtered
+function issatisfiable_prepared(
+    info :: Dict{P,PkgInfo{P,V}},
+    prob :: Problem{P},
+) where {P,V}
+    sat = SAT(info, prob)
+    try issatisfiable(sat, prob.reqs)
+    finally
+        finalize(sat)
+    end
+end
+
+# primary entry points, mirroring `resolve`'s: a Problem against each shape of
+# package data, each building the T1 artifact and preparing it the same way
+
+function issatisfiable(
+    deps :: DepsProvider{P},
+    prob :: Problem{P},
+) where {P}
+    info = pkg_info(deps, prob)
+    issatisfiable_prepared(prepare_pkg_info(info, prob, info), prob)
+end
+
+function issatisfiable(
+    data :: AbstractDict{P,<:PkgData{P}},
+    prob :: Problem{P},
+) where {P}
+    info = pkg_info(data, prob)
+    issatisfiable_prepared(prepare_pkg_info(info, prob, info), prob)
+end
+
+# a caller-supplied info may be a reusable (or cached) T1 artifact, so this
+# method prepares into a dict of its own and leaves the argument alone
+issatisfiable(
+    info :: AbstractDict{P,PkgInfo{P,V}},
+    prob :: Problem{P},
+) where {P,V} = issatisfiable_prepared(prepare_pkg_info(info, prob), prob)
+
+# convenience entry points: bare requirements, with the user constraints (if
+# any) given as keywords instead of a `Problem`
+
+issatisfiable(
+    deps :: DepsProvider{P},
+    reqs :: SetOrVec{P} = deps.packages;
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+) where {P} = issatisfiable(deps, Problem(reqs; compat, pins))
+
+issatisfiable(
+    data :: AbstractDict{P,<:PkgData{P}},
+    reqs :: SetOrVec{P} = keys(data);
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+) where {P} = issatisfiable(data, Problem(reqs; compat, pins))
+
+issatisfiable(
+    info :: AbstractDict{P,PkgInfo{P,V}},
+    reqs :: SetOrVec{P} = keys(info);
+    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
+    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
+) where {P,V} = issatisfiable(info, Problem(reqs; compat, pins))

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -1,6 +1,6 @@
 module Resolver
 
-export resolve, Problem
+export resolve, issatisfiable, Problem
 
 include("BitKernels.jl")
 include("DepsProvider.jl")

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -95,7 +95,10 @@ end
 # `resolve(data, prob)` must agree with the unconstrained resolve of the baked
 # data — including when both are `nothing`
 function test_bake_equivalence(data, prob; by::Function = identity)
-    @test resolve(data, prob; by) == resolve(bake(data, prob), prob.reqs; by)
+    sol = resolve(data, prob; by)
+    @test sol == resolve(bake(data, prob), prob.reqs; by)
+    # and the cheap verdict agrees with the descent's, constraints and all
+    @test issatisfiable(data, prob) == (sol !== nothing)
 end
 
 @testset "Problem: construction & masks" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,6 +278,7 @@ end
 end
 
 include("problem.jl")
+include("satisfiable.jl")
 include("classes.jl")
 include("ordering.jl")
 
@@ -297,6 +298,14 @@ include("ordering.jl")
     sol = resolve(rp, String[])
     @test sol isa Dict{String,VersionNumber}
     @test isempty(sol)
+    # the cheap verdict on a real registry, straight from the provider
+    @test issatisfiable(rp, ["JSON"])
+    @test issatisfiable(rp, ["DataFrames", "JSON"])
+    @test issatisfiable(rp, String[])
+    # ... including through the convenience keywords: no version of JSON can
+    # satisfy a pin at a version that doesn't exist
+    @test !issatisfiable(rp, ["JSON"]; pins = Dict("JSON" => v"0.0.0"))
+    @test resolve(rp, ["JSON"]; pins = Dict("JSON" => v"0.0.0")) === nothing
 end
 
 @testset "yanked packages" begin

--- a/test/satisfiable.jl
+++ b/test/satisfiable.jl
@@ -1,0 +1,197 @@
+# `issatisfiable`: the satisfiability verdict without the descent.
+#
+# The contract is agreement with `resolve`: `issatisfiable(args...)` is true
+# exactly when `resolve(args...)` returns a solution. That equality is checked
+# here across the entry-point family and on the edge cases, and — since it has
+# to hold for every instance, not just the hand-built ones — inside
+# `test_resolver` (test/setup.jl) and `test_bake_equivalence` (test/problem.jl),
+# so every sweep in the suite checks it too.
+
+using Resolver: SAT, PicoSAT, DepsProvider, PkgData, pkg_info, finalize
+
+# The number of solves an instance has run — or `nothing` when picosat's report
+# didn't reach us (see below). Picosat counts its own `picosat_sat` calls and
+# reports the total in its statistics dump, which it writes to its output stream
+# — stdout unless told otherwise — so the count is available without a counter
+# of our own anywhere in the solving path. Two wrinkles: picosat prints the
+# "N calls" line only once there have been *several* calls, so an absent line
+# means at most one, which the propagation count separates from none at all (a
+# solve of an instance that has clauses propagates); and reading any of it means
+# capturing what the C library prints, which may not work everywhere.
+function solve_count(sat::SAT)
+    path, io = mktemp()
+    try
+        redirect_stdout(io) do
+            ccall((:picosat_stats, PicoSAT.lib), Cvoid, (Ptr{Cvoid},), sat.pico)
+            # picosat prints through the C library's buffered stdout, so flush
+            # it before the redirect is undone
+            ccall(:fflush, Cint, (Ptr{Cvoid},), C_NULL)
+        end
+        close(io)
+        stats = read(path, String)
+        props = match(r"(\d+) propagations", stats)
+        props === nothing && return nothing # the dump didn't reach us
+        calls = match(r"(\d+) calls", stats)
+        calls === nothing && return parse(Int, props.captures[1]) > 0 ? 1 : 0
+        return parse(Int, calls.captures[1])
+    finally
+        close(io)
+        rm(path; force = true)
+    end
+end
+
+@testset "issatisfiable: the entry-point family" begin
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), nocomp),
+        :B => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    compat = Dict(:B => [:v1])
+    pins = Dict(:A => :v1)
+
+    # every shape of package data `resolve` accepts, with a `Problem` and with
+    # the convenience keywords that build one
+    deps = DepsProvider(p -> data[p], keys(data))
+    info = pkg_info(data, Problem([:A]; compat, pins))
+    for src in (data, deps, info)
+        for prob in (Problem([:A]),
+                     Problem([:A]; compat),
+                     Problem([:A]; pins),
+                     Problem([:A]; compat, pins),
+                     Problem([:A]; compat = Dict(:B => Symbol[])),
+                     Problem([:A]; pins = Dict(:B => :v9)),
+                     Problem([:A, :B]; compat = Dict(:Z => Symbol[])),
+                     Problem(Symbol[]))
+            @test issatisfiable(src, prob) == (resolve(src, prob) !== nothing)
+        end
+        # the keyword forms are the same calls as the `Problem` ones
+        @test issatisfiable(src, [:A]) == issatisfiable(src, Problem([:A]))
+        @test issatisfiable(src, [:A]; compat) ==
+              issatisfiable(src, Problem([:A]; compat))
+        @test issatisfiable(src, [:A]; compat, pins) ==
+              issatisfiable(src, Problem([:A]; compat, pins))
+        # requirements may be a set as well as a vector, and default to the
+        # whole universe
+        @test issatisfiable(src, Set([:A])) == issatisfiable(src, [:A])
+        @test issatisfiable(src) == (resolve(src) !== nothing)
+    end
+
+    # ... and a SAT instance, the shape the others build internally
+    sat = SAT(info, Problem([:A]; compat, pins))
+    try
+        @test issatisfiable(sat, [:A]) == (resolve(sat, [:A]) !== nothing)
+        @test issatisfiable(sat) == (resolve(sat) !== nothing)
+    finally
+        finalize(sat)
+    end
+
+    # a requirement the data doesn't have is an error, exactly as for `resolve`
+    @test_throws ArgumentError issatisfiable(data, [:Nope])
+end
+
+@testset "issatisfiable: edge cases" begin
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    data = Dict(
+        :A => PkgData(Symbol[], nodeps, nocomp), # no versions: uninstallable
+        :B => PkgData([:v1], Dict(:v1 => [:A]), nocomp),
+        :C => PkgData([:v1], nodeps, nocomp),
+    )
+    # no requirements at all is satisfiable (`resolve` returns an empty dict)
+    @test issatisfiable(data, Symbol[])
+    @test resolve(data, Symbol[]) == Dict()
+    # a package with no versions can't be required, directly or transitively —
+    # the filter drops it, so the verdict comes from the requirement check
+    @test !issatisfiable(data, [:A])
+    @test !issatisfiable(data, [:B])
+    @test !issatisfiable(data, [:B, :C])
+    @test issatisfiable(data, [:C])
+    # an unfiltered artifact reaches the same verdicts
+    info = pkg_info(data, [:B]; filter = false)
+    @test !issatisfiable(info, [:B])
+    @test issatisfiable(info, [:C])
+end
+
+@testset "issatisfiable: one solve, no descent, no state" begin
+    nodeps = Dict{Symbol,Vector{Symbol}}()
+    nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    # A@v2 needs B@v1 and B@v2 needs C@v1, so the best versions are not jointly
+    # feasible: the descent has improvement work to do, and one solve cannot be
+    # the whole story
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]),
+                      Dict(:v2 => Dict(:B => [:v1]))),
+        :B => PkgData([:v2, :v1], Dict(:v2 => [:C], :v1 => [:C]),
+                      Dict(:v2 => Dict(:C => [:v1]))),
+        :C => PkgData([:v2, :v1], nodeps, nocomp),
+    )
+    reqs = [:A, :B, :C]
+    prob = Problem(reqs)
+    info = pkg_info(data, prob)
+
+    # the verdict costs a single solve, and since the requirements are assumed
+    # rather than asserted, the instance is left exactly as it was found
+    sat = SAT(info, prob)
+    try
+        clauses = PicoSAT.clause_count(sat.pico)
+        # can the solve count be read here? the clause counts below stand on
+        # their own either way — asserting nothing is what leaves the instance
+        # reusable, and it is also what the descent cannot do
+        counts = solve_count(sat) !== nothing
+        counts || @info "picosat's solve count is unreadable here: not checked"
+        @test !counts || solve_count(sat) == 0
+        @test issatisfiable(sat, reqs)
+        @test !counts || solve_count(sat) == 1
+        @test PicoSAT.clause_count(sat.pico) == clauses
+        # ... so the same instance answers again, at the same price
+        @test issatisfiable(sat, reqs)
+        @test !counts || solve_count(sat) == 2
+        @test PicoSAT.clause_count(sat.pico) == clauses
+    finally
+        finalize(sat)
+    end
+
+    # the descent, for comparison: it asserts the requirements and pins each
+    # package it optimizes, so it both solves more than once (three times, on
+    # this data) and — until the temporary clauses are rolled back — leaves
+    # clauses behind
+    sat = SAT(info, prob)
+    try
+        counts = solve_count(sat) !== nothing
+        clauses = PicoSAT.clause_count(sat.pico)
+        @test resolve(sat, reqs; restore = false) == resolve(data, reqs)
+        @test !counts || solve_count(sat) > 1
+        @test PicoSAT.clause_count(sat.pico) > clauses
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "issatisfiable: the verdict is order-independent" begin
+    # `issatisfiable` takes no `by` and no `order` because neither can move the
+    # verdict: orderings select among the valid solutions rather than deciding
+    # which ones are valid. Sweep the tiny grids under both, constrained and
+    # not, and check the one verdict against every `resolve` in sight.
+    Random.seed!(rand(RandomDevice(), UInt64))
+    hi = p -> p
+    lo = p -> -p
+    up = p -> (u, v) -> u > v # prefer the *lowest* version
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:20
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            for cs in (nothing, random_constraints(m, n))
+                compat, pins = cs === nothing ?
+                    (Dict{Int,Vector{Int}}(), Dict{Int,Int}()) : cs
+                prob = Problem(reqs; compat, pins)
+                verdict = issatisfiable(data, prob)
+                for by in (hi, lo), order in (nothing, up), group in (true, false)
+                    @test verdict ==
+                        (resolve(data, prob; by, order, group) !== nothing)
+                end
+            end
+        end
+    end
+end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -7,8 +7,8 @@ using Test
 
 module TestResolver
 
-using Resolver: resolve, DepsProvider, PkgData, PkgInfo, pkg_data, pkg_info,
-    filter_pkg_info!
+using Resolver: resolve, issatisfiable, DepsProvider, PkgData, PkgInfo,
+    pkg_data, pkg_info, filter_pkg_info!
 using Test
 
 export test_resolver, ref_resolve
@@ -29,6 +29,10 @@ function test_resolver(
 ) where {P,V}
     # resolve: a single optimal solution, or nothing when unsatisfiable
     sol = resolve(data, reqs)
+
+    # the cheap feasibility check must reach the same verdict as the descent:
+    # this is `issatisfiable`'s whole contract, so every sweep checks it
+    @test issatisfiable(data, reqs) == (sol !== nothing)
 
     if sol === nothing
         # verify that no valid solution covers all the requirements


### PR DESCRIPTION
Adds the cheap feasibility tier that today can only be expressed by paying `resolve`'s full optimizing descent:

```julia
issatisfiable(deps_or_data_or_info, prob_or_reqs; compat = ..., pins = ...) :: Bool
```

Entry points mirror `resolve`'s one-for-one; internally it's the same preparation pipeline plus **one** assumption-only satisfiability check — no descent, no solution extraction, no state left on the instance (it answers again at the same price). Ordering/grouping knobs are deliberately absent: verdicts are order- and collapse-independent by the layered theory, so they'd be knobs that provably cannot matter (docstring says so).

**Agreement is asserted at the sweep choke points** — `test_resolver` and `test_bake_equivalence` both check `issatisfiable == (resolve !== nothing)`, so the property rides every existing sweep (~1.9M cases: tiny/complete, semi-full, random, adversarial, zero-version, constraint grids, exclusion kinds) plus real-registry scenarios in the bin suite (julia bounds, admission kinds, an unsatisfiable julia=99 case). New `test/satisfiable.jl` covers the entry-point family, edge cases, and order-independence swept over `by` × `order` × `group`.

**The cheapness claim is verified exactly, not by timing**: picosat reports its own solve count, so the test reads it from the C library's stats — `issatisfiable` = exactly 1 solve, 0 clauses added, vs 3 solves + retained clauses for the descent on the same instance. (Skipped gracefully where C-stdout capture isn't available; the clause-count assertions stand everywhere.)

## Co-author
Implemented with [Claude Code](https://claude.com/claude-code): implementation and review by Claude, directed and reviewed by @StefanKarpinski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7