### PR TITLE
Yanked versions are filtered out of the universe

### DIFF
--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -1,7 +1,7 @@
 module Registries
 
 export registry_provider, package_info, bundled_versions,
-    prerelease_exclusion, yanked_exclusion, is_yanked, is_registered, is_bundled,
+    prerelease_exclusion, yanked_versions, is_registered, is_bundled,
     UPGRADABLE_STDLIBS_UUIDS
 
 import Base: UUID
@@ -262,35 +262,54 @@ prerelease_exclusion(allow_pre::Dict{UUID,Bool}) =
 
 ## yanked versions
 #
-# Yankedness is the same shape of fact as prerelease-ness: a property of a version
-# that a query may or may not be willing to accept. Nothing offers the user a way
-# to accept one yet -- this kind is always in force -- but modeling it as a
-# constraint rather than a deletion is what keeps the package universe shared, and
-# is what lets a diagnostic eventually say "the only version that satisfies this
-# is yanked" instead of "no such version".
+# Yankedness is not the same shape of fact as prerelease-ness. A prerelease is a
+# version you can install and a query says whether it wants one; a yanked version
+# is one the registry has struck, so nothing should install it and nothing should
+# be told to. That makes it a property of the registry state rather than a query
+# knob, and the universe the registries describe is the one with the struck
+# versions taken out -- so the resolver can neither produce a yanked version nor
+# suggest one, by construction, with nothing left to enforce downstream.
 #
-# A version is offered when *some* registry entry has it un-yanked, so it counts
-# as yanked only when every entry that has it says so -- and a version that no
-# registry has at all (a bundled stdlib) is not a registry version to yank.
-function is_yanked(
-    packages :: Dict{UUID,Vector{PkgEntry}},
-    uuid     :: UUID,
-    v        :: VersionNumber,
-)
-    entries = get(packages, uuid, nothing)
-    entries === nothing && return false
-    found = false
-    for entry in entries
-        info = package_info(entry)
-        haskey(info.version_info, v) || continue
-        isyanked(info, v) || return false
-        found = true
+# The multi-registry rule, stated over what each entry that carries the package
+# says: a version yanked by *any* of them is yanked, i.e. the union of their
+# yanked sets. Yanking is often a security action, and one registry cannot undo
+# another's -- a version some registry has struck must not be laundered back into
+# the universe by a registry that still lists it. Only versions some entry has can
+# appear in any of these sets, so a version no registry has at all (a stdlib
+# version that exists only because some Julia bundles it) is never yanked.
+#
+# Kept as its own function because it is the whole semantics and no installed
+# registry pair disagrees about a version today, so this is the only place the
+# rule can be tested directly (see bin/test/runtests.jl).
+function struck_versions(yanked_by_entry)
+    struck = Set{VersionNumber}()
+    for yanked in yanked_by_entry
+        union!(struck, yanked)
     end
-    return found
+    return struck
 end
 
-yanked_exclusion(packages::Dict{UUID,Vector{PkgEntry}}) =
-    :yanked => (uuid::UUID, v::VersionNumber) -> is_yanked(packages, uuid, v)
+# The versions of `uuid` the registries have struck, by that rule.
+function yanked_versions(
+    packages :: Dict{UUID,Vector{PkgEntry}},
+    uuid     :: UUID,
+)
+    entries = get(packages, uuid, nothing)
+    entries === nothing && return Set{VersionNumber}()
+    struck_versions(
+        begin
+            info = package_info(entry)
+            Set{VersionNumber}(v for v in keys(info.version_info) if isyanked(info, v))
+        end
+        for entry in entries
+    )
+end
+
+# Does the query accept `uuid`'s yanked versions? `--allow-yanked` parses into
+# this dictionary exactly as `--allow-pre` parses into its own: keyed by package
+# uuid with the zero uuid holding the default.
+allows_yanked(allow_yanked::Dict{UUID,Bool}, uuid::UUID) =
+    get(allow_yanked, uuid, get(allow_yanked, UUID(0), false))
 
 # Do the registries have this version, as opposed to it existing only because
 # some Julia bundles it? (the provider's `bundled_only`, from the outside.) Only
@@ -307,17 +326,31 @@ function is_registered(
 end
 
 # The package universe the registries and Julia's history describe: every version
-# of every package, every Julia version, and every stdlib version any Julia
-# bundles. It has no query-dependent parameters, which is the point -- one
-# universe per registry state, and every query is a `Problem` over it.
+# of every package the registries offer, every Julia version, and every stdlib
+# version any Julia bundles. It has no query-dependent parameters, which is the
+# point -- one universe per registry state, and every query is a `Problem` over it.
 #
 # (`workspace_pkgs` is not a query knob: a workspace's member packages are part of
 # the environment's package universe, fixed at their local versions, the way a
 # registry's packages are part of it at their registered versions.)
+#
+# `allow_yanked` is not a query knob either, though a flag sets it: yankedness is
+# registry-derived, so what it selects is a *different universe* -- the one that
+# keeps the versions the registries have struck -- rather than a different query
+# over the same one. That is why it belongs here and not in the `Problem`, and
+# rebuilding for it is rare and cheap next to being unable to trust that a resolve
+# never names a yanked version.
+#
+# `yanked` is an out-parameter: pass a dictionary and the provider records, per
+# package, the versions the filter dropped -- which is what lets the caller say
+# "the versions your bound admits are yanked" rather than "no such version".
 function registry_provider(
     packages       :: Dict{UUID,Vector{PkgEntry}};
     workspace_pkgs :: Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}} =
                       Dict{UUID,Tuple{String,VersionNumber,Vector{UUID}}}(),
+    allow_yanked   :: Dict{UUID,Bool} = Dict{UUID,Bool}(),
+    yanked         :: Dict{UUID,Set{VersionNumber}} =
+                      Dict{UUID,Set{VersionNumber}}(),
 )
     stdlibs, bundlers, by_patch = STDLIB_VERSIONS, BUNDLERS, BUNDLERS_BY_PATCH
 
@@ -342,6 +375,12 @@ function registry_provider(
         # versions that exist only because a Julia bundles them (no registry
         # entry); the widening below bounds them to their bundling Julias
         bundled_only = Set{VersionNumber}()
+        # the registry versions the yanked filter struck: left out of `vers`
+        # below, and not restored by the stdlib patch-in either -- a version the
+        # registries have struck is gone from the universe whether or not some
+        # Julia also ships it (that Julia's pin then has nothing to pin to, the
+        # same as any other version the registries do not offer)
+        struck = Set{VersionNumber}()
         if uuid == JULIA_UUID
             union!(vers, JULIA_VERSIONS)
             for v in vers
@@ -368,16 +407,24 @@ function registry_provider(
                 end
             end
         elseif uuid in keys(packages)
+            # the versions the registries have struck, unless this query asked
+            # for them back; recorded so the caller can report what went missing
+            if !allows_yanked(allow_yanked, uuid)
+                union!(struck, yanked_versions(packages, uuid))
+                isempty(struck) || (yanked[uuid] = struck)
+            end
             for entry in packages[uuid]
                 info = package_info(entry)
                 # every version this registry has
                 new_vers = collect(keys(info.version_info))
-                # nothing is filtered out here: the project's own compat,
-                # prerelease admission and yankedness are all query constraints,
-                # and they reach the resolver as part of the `Problem` (see
-                # bin/resolve.jl). the provider only decides which versions exist
+                # yanked versions aside, nothing is filtered out here: the
+                # project's own compat and prerelease admission are query
+                # constraints, and they reach the resolver as part of the
+                # `Problem` (see bin/resolve.jl). the provider decides which
+                # versions exist, and a struck version does not
                 # scan versions and populate deps & compat data
                 for v in new_vers
+                    v in struck && continue
                     # NOTE: we probably won't support the same name meaning
                     # different things in deps vs weakdeps, but here we can
                     # allow it, so we defensively do allow it
@@ -431,6 +478,7 @@ function registry_provider(
         if uuid in keys(stdlibs)
             for (v, info) in stdlibs[uuid]
                 v in vers && continue # prefer real registry data
+                v in struck && continue # struck by the registries
                 push!(vers, v)
                 push!(bundled_only, v)
                 deps[v] = info.deps

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -20,6 +20,7 @@ usage: $PROGRAM_FILE [options] [<project path>]
                           use registry compat syntax, not semver
 
   --allow-pre[=<pkgs>]    allow prerelease versions
+  --allow-yanked[=<pkgs>] allow yanked versions
   --extra-deps=<pkgs>     extra packages to require
   --prioritize=<pkgs>     package names/uuids to prioritize
 
@@ -50,7 +51,7 @@ Wherever <pkgs> appears you can specify a comma-separated list of:
 
 parse_opts!(ARGS, split("""
     print-manifest print-versions
-    julia allow-pre extra-deps prioritize
+    julia allow-pre allow-yanked extra-deps prioritize
     fix fix-minor fix-major unfix
     max max-minor max-major
     min min-minor min-major
@@ -323,6 +324,7 @@ const ZERO_UUID = UUID(0)
 
 # zero UUID used for defaults
 const allow_pre = Dict(ZERO_UUID => false)
+const allow_yanked = Dict(ZERO_UUID => false)
 const FIX_PATCH = Dict(ZERO_UUID => false)
 const FIX_MINOR = Dict(ZERO_UUID => false)
 const FIX_MAJOR = Dict(ZERO_UUID => false)
@@ -331,11 +333,15 @@ const ORDER_MAP = Dict(ZERO_UUID => :max)
 # list of all fixed packages
 const FIXED = UUID[]
 
-handle_opts(r"^(allow_pre|(un)?fix|max|min)") do opt, val
+handle_opts(r"^(allow_(pre|yanked)|(un)?fix|max|min)") do opt, val
     pkgs = isnothing(val) ? [ZERO_UUID] : parse_packages(val)
     if opt == :allow_pre
         for uuid in pkgs
             allow_pre[uuid] = true
+        end
+    elseif opt == :allow_yanked
+        for uuid in pkgs
+            allow_yanked[uuid] = true
         end
     elseif opt == :fix
         for uuid in pkgs
@@ -457,7 +463,16 @@ end
 
 ## do an actual resolve
 
-reg = registry_provider(packages; workspace_pkgs)
+# The versions the yanked filter dropped, per package, filled in by the provider
+# as it is asked for packages. Yankedness is registry-derived, not a query knob:
+# the universe is built without the versions the registries have struck, so a
+# resolve can neither produce one nor suggest one. `--allow-yanked` asks for them
+# back -- for the named packages, or for all of them when given bare -- which
+# builds a universe that keeps them.
+const yanked_dropped = Dict{UUID,Set{VersionNumber}}()
+
+reg = registry_provider(packages;
+    workspace_pkgs, allow_yanked, yanked = yanked_dropped)
 
 # the project's compat bounds are user constraints, not part of the package
 # universe: they go into the `Problem`, which forbids the versions they exclude
@@ -472,21 +487,51 @@ reg = registry_provider(packages; workspace_pkgs)
 # admits, and no registry version fits either, the requirements really are
 # unsatisfiable and saying so beats silently ignoring the bound.
 #
-# the admission knobs ride along as exclusion kinds: `--allow-pre` says which
-# packages' prereleases the query accepts, and yanked versions are forbidden
-# outright (there is no option to accept one yet), each the same way a compat
-# bound forbids a version.
+# prerelease admission rides along as an exclusion kind: `--allow-pre` says which
+# packages' prereleases the query accepts, the same way a compat bound forbids a
+# version. (Yankedness is not one of these: it is a property of the registry state,
+# so the struck versions are not in the universe to begin with -- see the provider.)
 const problem = Problem(reqs;
     compat = project_compat,
     excludes = [
         prerelease_exclusion(allow_pre),
-        yanked_exclusion(packages),
     ],
 )
 
 pkg_info = Resolver.pkg_info(reg, problem)
 sol = resolve(pkg_info, problem; by=sort_packages_by, order=version_order)
-sol === nothing && error("Unsatisfiable")
+
+# The one unsatisfiable shape the universe cannot explain for itself: a bound
+# whose only admissible versions are ones the yanked filter dropped. Those
+# versions are plainly there in the registry, so "unsatisfiable" on its own reads
+# as a lie -- name them, and name the flag that brings them back.
+function yanked_notes()
+    notes = String[]
+    for uuid in sort!(collect(keys(project_compat)))
+        uuid in keys(packages) || continue
+        spec = project_compat[uuid]
+        # asking the provider for the package both fills in what it dropped and
+        # says what it kept, so the note doesn't depend on whether the resolve
+        # happened to reach this package
+        kept = Resolver.pkg_data(reg, uuid).versions
+        dropped = get(yanked_dropped, uuid, nothing)
+        dropped === nothing && continue
+        admitted = sort!([v for v in dropped if v ∈ spec])
+        isempty(admitted) && continue
+        # only when nothing that survived the filter is admissible either:
+        # otherwise the bound is satisfiable and the yank is not the problem
+        any(v -> v ∈ spec, kept) && continue
+        name = first(packages[uuid]).name
+        push!(notes, "note: the versions your compat on $name admits are " *
+            "yanked ($(join(admitted, ", "))); --allow-yanked accepts them anyway")
+    end
+    return notes
+end
+
+if sol === nothing
+    notes = yanked_notes()
+    error(join(["Unsatisfiable"; notes], "\n"))
+end
 
 ## output results
 

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -51,9 +51,12 @@ for reg in reachable_registries()
     end
 end
 
-# The one package universe: `registry_provider` has no query-dependent parameters
-# left, so there is nothing to vary here.
-const reg = registry_provider(packages)
+# The one package universe: the only parameter `registry_provider` has left is
+# `allow_yanked`, and the default universe -- the one every query but
+# `--allow-yanked` resolves against -- is built without the versions the
+# registries have struck.
+const yanked_dropped = Dict{UUID,Set{VersionNumber}}()
+const reg = registry_provider(packages; yanked = yanked_dropped)
 
 # `--allow-pre`'s dictionary: the zero uuid holds the default
 no_pre = Dict(UUID(0) => false)
@@ -71,7 +74,6 @@ function make_problem(
     c[JULIA_UUID] = julia
     Resolver.Problem(reqs; compat = c, excludes = [
         prerelease_exclusion(allow_pre),
-        yanked_exclusion(packages),
     ])
 end
 
@@ -115,6 +117,7 @@ function resolve_versions(
     compat :: AbstractString,
     flags  :: Vector{String} = String[];
     deps   :: Vector{Pair{String,UUID}} = ["JSON" => JSON],
+    err    :: IOBuffer = IOBuffer(), # the script's stderr, for tests that read it
 )
     dir = mktempdir()
     open(joinpath(dir, "Project.toml"), "w") do io
@@ -127,13 +130,14 @@ function resolve_versions(
         println(io, compat)
     end
     out = IOBuffer()
-    err = IOBuffer()
     julia = Base.julia_cmd()[1]
     cmd = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions $flags`
     if !success(pipeline(cmd; stdout = out, stderr = err))
-        # tell "no solution" apart from "the script broke"
-        occursin("Unsatisfiable", String(take!(err))) ||
-            error("failed: $cmd")
+        # tell "no solution" apart from "the script broke", putting the message
+        # back so a caller that passed `err` in can read it too
+        msg = String(take!(err))
+        print(err, msg)
+        occursin("Unsatisfiable", msg) || error("failed: $cmd")
         return nothing
     end
     vers = Dict{UUID,VersionNumber}()
@@ -318,67 +322,141 @@ end
                                       deps = wine)
     end
 
-    # Yankedness is the same shape of fact as prerelease-ness -- a property of a
-    # version that a query may or may not accept -- so it is modeled the same
-    # way, as an exclusion kind, even though nothing yet offers the user a way to
-    # turn it off. The oracle is the old path, where the provider deleted yanked
-    # versions outright.
-    @testset "yanked versions are constrained, not deleted" begin
+    # Yankedness is *not* the same shape of fact as prerelease-ness: a yanked
+    # version is one the registry has struck, so it is not on offer at all. The
+    # provider filters those versions out, which is what makes "the resolver
+    # never produces a yanked version and never suggests one" true by
+    # construction rather than by a constraint every query must remember to
+    # carry. `--allow-yanked` is the one query that asks for a different
+    # universe.
+    @testset "yanked versions are filtered out of the universe" begin
         reqs = sort([COMPAT, LIBSODIUM_JLL, JULIA_UUID])
+
+        # `yanked_versions` reads the registries, not the version number: Compat
+        # 4.0.0 is yanked from General and libsodium_jll's newest version is too
+        @test v"4.0.0" in yanked_versions(packages, COMPAT)
+        @test v"4.1.0" ∉ yanked_versions(packages, COMPAT)
+        @test v"99.0.0" ∉ yanked_versions(packages, COMPAT) # no such version
+        @test v"1.0.22+0" in yanked_versions(packages, LIBSODIUM_JLL)
+        @test v"1.0.21+0" ∉ yanked_versions(packages, LIBSODIUM_JLL)
+        @test v"0.21.4" ∉ yanked_versions(packages, JSON)
+        # not a registered package at all, so nothing of it is struck
+        @test isempty(yanked_versions(packages, JULIA_UUID))
+
+        # The multi-registry rule: a version yanked by *any* entry that carries
+        # it is yanked, because one registry cannot undo another's yank -- which
+        # is often a security action, so a registry that still lists the version
+        # must not launder it back into the universe. No two installed registries
+        # carry the same package with different yank flags (General is the only
+        # one carrying any of these), so the rule cannot be exercised end to end
+        # on real data; test it where it is stated, over the per-entry sets.
+        none = Set{VersionNumber}()
+        @test Registries.struck_versions([Set([v"1.0.0"]), none]) == Set([v"1.0.0"])
+        @test Registries.struck_versions([none, Set([v"1.0.0"])]) == Set([v"1.0.0"])
+        @test Registries.struck_versions([Set([v"1.0.0"]), Set([v"1.0.0"])]) ==
+              Set([v"1.0.0"])
+        @test isempty(Registries.struck_versions([none, none]))
+        # each entry contributes its own, and only versions some entry yanks
+        # appear at all -- which is why a version no registry has is never struck
+        @test Registries.struck_versions([Set([v"1.0.0"]), Set([v"2.0.0"])]) ==
+              Set([v"1.0.0", v"2.0.0"])
+        @test isempty(Registries.struck_versions(Set{VersionNumber}[]))
+
+        # the provider does not offer them, so the one artifact does not have
+        # them either -- and the versions beside them are untouched
         data = Resolver.pkg_data(reg, reqs)
-        yanked = yanked_exclusion(packages)
-        forbids = last(yanked)
-
-        # `is_yanked` reads the registries, not the version number: Compat 4.0.0
-        # is yanked from General and libsodium_jll's newest version is too
-        @test forbids(COMPAT, v"4.0.0")
-        @test !forbids(COMPAT, v"4.1.0")
-        @test forbids(LIBSODIUM_JLL, v"1.0.22+0")
-        @test !forbids(LIBSODIUM_JLL, v"1.0.21+0")
-        @test !forbids(JSON, v"0.21.4")
-        @test !forbids(JULIA_UUID, v"1.10.0") # not a registered package at all
-        @test !forbids(COMPAT, v"99.0.0")     # no such version
-
-        # the provider offers them and the one artifact keeps them
-        @test v"4.0.0" in data[COMPAT].versions
         info = Resolver.pkg_info(reg, reqs)
-        @test v"4.0.0" in info[COMPAT].versions
+        @test v"4.0.0" ∉ data[COMPAT].versions
+        @test v"4.1.0" in data[COMPAT].versions
+        @test v"4.0.0" ∉ info[COMPAT].versions
+        @test v"1.0.22+0" ∉ data[LIBSODIUM_JLL].versions
+        @test v"1.0.21+0" in data[LIBSODIUM_JLL].versions
+        # ... and the provider says what it dropped, which is what lets
+        # bin/resolve.jl name the versions a bound admits that no longer exist
+        @test v"4.0.0" in yanked_dropped[COMPAT]
+        @test v"1.0.22+0" in yanked_dropped[LIBSODIUM_JLL]
+        @test !haskey(yanked_dropped, JULIA_UUID)
 
-        prob = Resolver.Problem(reqs; excludes = [yanked])
-        old = bake(data, prob) # the versions deleted, as the provider used to
-        @test Resolver.resolve(data, prob) == Resolver.resolve(old, reqs)
-        @test Resolver.resolve(info, prob) == Resolver.resolve(old, reqs)
-        # ... together with the prerelease kind, and under a reversed ordering
-        both = Resolver.Problem(reqs;
-            excludes = [yanked, prerelease_exclusion(no_pre)])
-        @test Resolver.resolve(info, both) ==
-              Resolver.resolve(bake(data, both), reqs)
-        order = u -> (<)
-        @test Resolver.resolve(info, both; order) ==
-              Resolver.resolve(bake(data, both), reqs; order)
+        # `--allow-yanked` keeps them: same universe otherwise
+        kept = registry_provider(packages; allow_yanked = Dict(UUID(0) => true))
+        kept_data = Resolver.pkg_data(kept, reqs)
+        @test v"4.0.0" in kept_data[COMPAT].versions
+        @test v"1.0.22+0" in kept_data[LIBSODIUM_JLL].versions
+        # per package: only the named package gets its struck versions back
+        one = Resolver.pkg_data(
+            registry_provider(packages;
+                allow_yanked = Dict(UUID(0) => false, COMPAT => true)), reqs)
+        @test v"4.0.0" in one[COMPAT].versions
+        @test v"1.0.22+0" ∉ one[LIBSODIUM_JLL].versions
 
-        # The selector map names the kind, so a diagnostic could one day say
-        # "the only version that satisfies this is yanked". libsodium_jll's
-        # yanked version is its *newest*, so nothing dominates it and the filter
-        # has to keep it -- it is ruled out by clause. Compat's is not, so
-        # redundancy elimination deletes it, which is the filter subsuming the
-        # deletion the provider used to do.
-        work = Resolver.prepare_pkg_info(info, prob)
-        sat = Resolver.SAT(work, prob)
-        try
-            @test (:yanked, LIBSODIUM_JLL) in values(sat.sels)
-            @test v"1.0.22+0" in work[LIBSODIUM_JLL].versions
-            @test v"4.0.0" ∉ work[COMPAT].versions
-        finally
-            Resolver.finalize(sat)
+        # The mechanism this replaced: the unfiltered universe plus an exclusion
+        # kind forbidding exactly the struck versions. Filtering must give the
+        # same answers -- that is the whole claim of the change -- for the plain
+        # problem, alongside the prerelease kind, and under a reversed ordering.
+        struck = Dict{UUID,Set{VersionNumber}}() # per package, memoized
+        yanked_of(u::UUID) = get!(() -> yanked_versions(packages, u), struck, u)
+        # a kind reaches every package in the universe, not just the required
+        # ones, so this has to answer for any uuid it is handed
+        kind = Pair{Symbol,Any}(:yanked,
+            (u::UUID, v::VersionNumber) -> v in yanked_of(u))
+        for pre in (Pair{Symbol,Any}[],
+                    Pair{Symbol,Any}[prerelease_exclusion(no_pre)])
+            old = Resolver.Problem(reqs; excludes = [kind, pre...])
+            new = Resolver.Problem(reqs; excludes = pre)
+            @test Resolver.resolve(reg, new) == Resolver.resolve(kept, old)
+            @test Resolver.resolve(info, new) == Resolver.resolve(kept, old)
+            order = u -> (<)
+            @test Resolver.resolve(info, new; order) ==
+                  Resolver.resolve(kept, old; order)
         end
 
-        # end to end: libsodium_jll's newest registered version is yanked, so the
-        # resolve must land on the one below it
-        sol = resolve_versions("", ["--julia=1.10"];
-                               deps = ["libsodium_jll" => LIBSODIUM_JLL])
+        # end to end: libsodium_jll's newest registered version is yanked, so
+        # the default resolve lands on the one below it
+        libsodium = ["libsodium_jll" => LIBSODIUM_JLL]
+        sol = resolve_versions("", ["--julia=1.10"]; deps = libsodium)
         @test !isnothing(sol)
         @test sol[LIBSODIUM_JLL] == v"1.0.21+0"
+
+        # ... and `--allow-yanked` takes it, bare or naming the package
+        yes = resolve_versions("", ["--julia=1.10", "--allow-yanked"];
+                               deps = libsodium)
+        @test !isnothing(yes)
+        @test yes[LIBSODIUM_JLL] == v"1.0.22+0"
+        @test yes == resolve_versions(
+            "", ["--julia=1.10", "--allow-yanked=libsodium_jll"]; deps = libsodium)
+
+        # ... while naming some *other* package leaves it filtered
+        other = resolve_versions("", ["--julia=1.10", "--allow-yanked=$COMPAT"];
+                                 deps = libsodium)
+        @test !isnothing(other)
+        @test other[LIBSODIUM_JLL] == v"1.0.21+0"
+
+        # The one failure the filtered universe cannot explain for itself: a
+        # bound whose only admissible versions are struck ones. They are plainly
+        # there in the registry, so bare "Unsatisfiable" would read as a lie --
+        # the note names them and names the flag that brings them back.
+        compat_pkg = ["Compat" => COMPAT]
+        err = IOBuffer()
+        @test isnothing(resolve_versions("Compat = \"=4.0.0\"", ["--julia=1.10"];
+                                         deps = compat_pkg, err))
+        msg = String(take!(err))
+        @test occursin("Unsatisfiable", msg)
+        @test occursin("compat on Compat", msg)
+        @test occursin("yanked (4.0.0)", msg)
+        @test occursin("--allow-yanked", msg)
+
+        # ... and the flag really does accept them
+        sol = resolve_versions("Compat = \"=4.0.0\"",
+            ["--julia=1.10", "--allow-yanked"]; deps = compat_pkg)
+        @test !isnothing(sol)
+        @test sol[COMPAT] == v"4.0.0"
+
+        # no note when a bound admits versions that survived: then the yank is
+        # not what makes the requirements unsatisfiable
+        err = IOBuffer()
+        @test isnothing(resolve_versions("Compat = \"99\"", ["--julia=1.10"];
+                                         deps = compat_pkg, err))
+        @test !occursin("--allow-yanked", String(take!(err)))
     end
 
     # HistoricalStdlibVersions gives one stdlib version number to entries with

--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -405,12 +405,27 @@ The ordering is a `resolve` parameter rather than part of the problem,
 which is what makes one artifact serve every query: it selects among
 the valid solutions instead of changing which solutions are valid. What
 *does* change the model set — the user's compat bounds and pins, and
-the admission of prerelease and yanked versions — is a `Problem`, and
-enters as constraints on the artifact's versions rather than as
-deletions from it (see `exclusion_masks`). So there is one T1 artifact
-per registry state, full stop: every version the registry state offers
-is in it, in canonical order, and each query says which of them it will
-accept and in what order it prefers them.
+the admission of prerelease versions — is a `Problem`, and enters as
+constraints on the artifact's versions rather than as deletions from it
+(see `exclusion_masks`). So there is one T1 artifact per registry
+state, full stop: every version the registry state offers is in it, in
+canonical order, and each query says which of them it will accept and
+in what order it prefers them.
+
+"Every version the registry state offers" is meant strictly, and it is
+where yanked versions come in. Yankedness is not a query fact but part
+of what the registry state says — a yanked version is one the registry
+has struck, so it is not on offer — and the default artifact is built
+with those versions filtered out at the provider (see
+`bin/Registries.jl`). That is a deletion, not a constraint, and it is
+the right shape: a resolve then cannot produce a yanked version or
+suggest one as an alternative, with nothing left to enforce per query.
+The cost is that `--allow-yanked`, the query that wants them back, is
+the one query the baked artifact does not serve: it asks for a universe
+the registry state does not describe, and so rebuilds T1. That is rare
+and cheap next to the alternative, which is carrying struck versions
+through every layer and every diagnostic in order to forbid them again
+at the end.
 
 !!! warning "Formalization boundary"
     Theorems 2, 3, 5, and 6 are proved against the rule set as stated

--- a/src/Problem.jl
+++ b/src/Problem.jl
@@ -27,10 +27,11 @@ Three kinds of constraint, in two shapes:
 
   * `compat`: per package, the set of allowed versions (queried with `in`).
   * `pins`: per package, the one version it is held at.
-  * `excludes`: the *admission* knobs — "no prereleases", "no yanked versions" —
-    which say something about versions rather than about particular packages, and
-    so come as `kind => predicate` pairs, where `predicate(p, v)` is true for the
-    versions that source forbids and `kind` is a symbol naming it.
+  * `excludes`: the *admission* knobs — "no prereleases" is the one the resolver's
+    own tooling uses — which say something about versions rather than about
+    particular packages, and so come as `kind => predicate` pairs, where
+    `predicate(p, v)` is true for the versions that source forbids and `kind` is a
+    symbol naming it.
 
 Constraints for packages that don't exist, and constraints that exclude nothing,
 are allowed and have no effect.
@@ -48,7 +49,7 @@ struct Problem{P,V,S}
     compat :: AbstractDict{P,S}
     pins   :: AbstractDict{P,V}
     # admission knobs: per kind, a predicate `(p, v) -> Bool` that is true for
-    # the versions that kind forbids
+    # the versions that kind forbids ("no prereleases", say)
     excludes :: Vector{Pair{Symbol,Any}}
 end
 

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -306,9 +306,9 @@ end
 end
 
 @testset "Problem: exclusion kinds" begin
-    # `excludes` carries the *admission* knobs — "no prereleases", "no yanked
-    # versions" — which are stated about versions rather than about packages, so
-    # they come as `kind => predicate` pairs instead of per-package entries.
+    # `excludes` carries the *admission* knobs — "no prereleases" and the like —
+    # which are stated about versions rather than about packages, so they come as
+    # `kind => predicate` pairs instead of per-package entries.
     # Semantically a kind is nothing but another constraint source: forbidding
     # exactly the versions a compat entry forbids must be the same problem.
     nodeps = Dict{Symbol,Vector{Symbol}}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -316,6 +316,13 @@ end
     # To test this, we use the same commands as the
     # `julia-downgrade-compat` action to resolve a project
     # depending on Compat with "4.0" compatibility requirement.
+    #
+    # The struck version is not in the package universe at all: bin/Registries.jl
+    # filters yanked versions out at the provider, so the resolve below cannot
+    # produce v4.0.0 or offer it as an alternative (`--allow-yanked` is what asks
+    # for a universe that keeps them). What this testset checks is the outcome --
+    # the version the action ends up with -- which is the same whichever
+    # mechanism enforces it; the mechanism itself is covered in bin/test/.
 
     julia = Base.julia_cmd()[1]
     project = pkgdir(Resolver, "bin")


### PR DESCRIPTION
Design decision: yanked-ness is not a query knob. The resolver must neither produce a yanked version nor suggest one — and both hold **by construction** once the version simply isn't in the universe. Replaces the `:yanked` admission-kind wiring in bin with provider-level pre-filtering.

- **Careful semantics**: a version yanked in **any** registry entry carrying it is struck everywhere (yanking is often a security action — one registry must not launder another's yank; the rule lives in a pure `struck_versions` function with direct unit tests, since no real-registry disagreement exists to exercise it end-to-end), and never for a version no registry has; struck versions are also excluded from the stdlib patch-in so they can't sneak back as bundled-only entries.
- **`--allow-yanked[=<pkgs>]`** mirrors `--allow-pre` exactly (bare = all, list = named packages) and rebuilds the universe with them retained.
- **The provider records what it dropped**, and the unsatisfiable error path uses it for the one note that prevents gaslighting — when your compat admits only versions that exist in the registry but were struck:

```
ERROR: LoadError: Unsatisfiable
note: the versions your compat on Compat admits are yanked (4.0.0); --allow-yanked accepts them anyway
```

- **Docs**: the theory page's cache-tier prose now states the honest trade — the default T1 artifact bakes the filter (yanked-ness is registry-derived, a deletion not a constraint), and `--allow-yanked` is the one query it doesn't serve, so that path rebuilds (rare, cheap).

**Equality evidence**: 18 CLI scenarios (orderings, julia bounds, admission flags, stdlib shapes, the real yanked cases) byte-identical against pristine main, plus an in-process equality testset against the old mechanism under combined prerelease kinds and a reversed ordering. Full suite green.

**One flagged edge for review**: LibOSXUnwind_jll 0.0.6+1 is the registry's only version that is both yanked *and* julia-bundled (1.6.0–1.6.7). It is filtered — matching main's current behavior exactly, which keeps the equality gate honest. If bundled copies should instead win over a registry yank, that's a one-line change (and the one scenario where the branch would then differ from main); practical effect today is nil either way.

## Co-author
Implemented with [Claude Code](https://claude.com/claude-code): implementation and review by Claude, directed and reviewed by @StefanKarpinski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7