### PR TITLE
Index the package universe by interchangeability classes

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,11 +9,15 @@ Problem
 ## Internals
 
 ```@docs
+Resolver.PkgInfo
 Resolver.pkg_info
 Resolver.version_classes
+Resolver.class_members
+Resolver.collapse_classes!
+Resolver.Universe
 Resolver.prepare_pkg_info
 Resolver.version_permutations
-Resolver.class_representatives
+Resolver.class_ranking
 Resolver.find_reachable
 Resolver.exclusion_masks
 ```

--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -390,27 +390,54 @@ invalidates only the middle tier, which is orders of magnitude cheaper
 to rebuild than the first.
 
 The implementation draws the line between the first tier and the rest
-at `pkg_info`, whose output — conflict matrices, the arc-consistency
-prune and the classes (`version_classes`) — is exactly the
-registry-only artifact, and it merges the second and third tiers into
-one per-resolve pass, `prepare_pkg_info`, since the middle tier is
-cheap enough not to be worth storing. That pass lays each package's
-versions out in the ordering the query asked for
-(`version_permutations`), refines the classes by the user's constraints
-and collapses each to its best member in that ordering
-(`class_representatives`), and filters the result
-(`filter_pkg_info!`).
+at `pkg_info`, whose output — conflict matrices indexed by the classes
+(`version_classes`), with the versions that cannot be installed
+whatever else is chosen already dropped — is exactly the registry-only
+artifact, and it merges the second and third tiers into one per-resolve
+pass, `prepare_pkg_info`, since the middle tier is cheap enough not to
+be worth storing.
+
+The artifact is indexed by those classes throughout: a `PkgInfo`'s
+conflict matrix has one row per class and one column per partner class.
+Building it takes one row per version first, since that is what the
+partition is computed from, and then merges them (`collapse_classes!`).
+Nothing is lost in the merge: members of a class have equal rows by
+definition, and — since conflicts are recorded symmetrically — members
+of a partner class index equal columns, so the merged matrix states
+exactly the same conflicts.
+
+What the per-resolve pass then does is choose, per class, which member
+it stands for. The user's constraints act only by forbidding members
+(`exclusion_masks`): a class keeps whichever of its admissible members
+the query's ordering ranks best, and competes at that member's rank,
+which is why the classes have to be laid out in the order those
+representatives put them in (`class_ranking`). A class the query
+admits no member of is *deactivated* — nothing can choose it — and
+that, not deletion, is the whole of a constraint's effect. Then the
+result is filtered (`filter_pkg_info!`).
+
+Deactivation is deliberately not deletion. A deactivated class stays in
+the matrices: reachability continues its prefix past one, since a class
+that cannot be selected is not somewhere a package can be installed,
+but still follows its dependencies, and redundancy elimination neither
+deletes one nor lets one license a deletion. What that buys is that the
+universe a later question about relaxing a constraint would need is
+still present — and, one level down, that such a question is even well
+posed, since a constraint cannot make two versions' rows identical: it
+does not touch the rows, and versions whose rows *are* identical are
+one class sharing one column, with no pair of separately deletable
+objects to fall between.
 
 The ordering is a `resolve` parameter rather than part of the problem,
 which is what makes one artifact serve every query: it selects among
 the valid solutions instead of changing which solutions are valid. What
 *does* change the model set — the user's compat bounds and pins, and
 the admission of prerelease versions — is a `Problem`, and enters as
-constraints on the artifact's versions rather than as deletions from it
-(see `exclusion_masks`). So there is one T1 artifact per registry
-state, full stop: every version the registry state offers is in it, in
-canonical order, and each query says which of them it will accept and
-in what order it prefers them.
+constraints on the artifact's versions rather than as deletions from it.
+So there is one T1 artifact per registry state, full stop: every
+version the registry state offers is in it, in canonical order and in
+its class, and each query says which of them it will accept and in what
+order it prefers them.
 
 "Every version the registry state offers" is meant strictly, and it is
 where yanked versions come in. Yankedness is not a query fact but part

--- a/src/BitKernels.jl
+++ b/src/BitKernels.jl
@@ -1,13 +1,64 @@
 # Every PkgInfo conflicts matrix is allocated with its row dimension padded
 # to a whole number of 64-bit words (see padded_rows), so that column j
 # occupies exactly the aligned chunk words X.chunks[(j-1)*W .+ (1:W)] where
-# W = size(X, 1) >> 6. Version i of the package corresponds to bit i-1 of
-# that span; the row after the last version holds the column's active flag;
-# any rows beyond that are padding and must remain zero. The helpers below
-# are the word-parallel column primitives the filtering passes build on.
+# W = size(X, 1) >> 6. Class i of the package corresponds to bit i-1 of that
+# span; the row after the last class holds the column's in-universe flag; any
+# rows beyond that are padding and must remain zero. The helpers below are the
+# word-parallel column primitives the filtering passes build on.
+#
+## What the flags mean
+#
+# A class carries two independent facts, and they are stored in two different
+# places:
+#
+#   1. **in-universe** — "this class is still part of the problem". This is the
+#      flag in the matrix: X[i, end] for class i, and X[end, j] for column j
+#      (a partner's block of columns mirrors that partner's own class flags).
+#      Three passes clear it, and all three of them mean "delete": the
+#      installability prune (`mark_installable!`), reachability
+#      (`mark_reachable!`) and redundancy elimination (`mark_necessary!`).
+#      `drop_unmarked!` reads this flag and nothing else, and rebuilds each
+#      matrix without whatever it says is gone.
+#
+#   2. **activated** — "this query admits some member of this class". Class
+#      members are indistinguishable to everything in the registry, so a user
+#      constraint can only forbid members; a class all of whose members it
+#      forbids is *empty*, hence *deactivated*, and cannot be selected. This
+#      fact is not in the matrix at all: it is `Universe.reps[p][i] == 0`,
+#      per-resolve state, which `deactivations` turns into a per-package mask
+#      for the passes that want it. `Universe`'s docstring says why it is kept
+#      there rather than in a flag of its own.
+#
+# **Deactivation never implies deletion.** A deactivated class stays
+# in-universe: it keeps its row, its column in every partner, and its
+# dependency columns. It is the universe a later relaxation of whatever emptied
+# it would need to find still there.
+#
+# The passes read the two facts differently, and deliberately so:
+#
+#   * `find_reachable` keeps a prefix of each package's classes and stops at
+#     the first one it can install. A deactivated class cannot be selected, so
+#     the prefix has to continue past it — while its dependencies are followed
+#     anyway, which is what keeps the packages behind it in the universe. Its
+#     own drops clear the in-universe flag.
+#   * `mark_necessary!` takes deactivated classes off *both* sides of the
+#     domination test: they may not be deleted (a relaxation would want them
+#     back) and they may not dominate (domination says a better class will be
+#     selected instead, which is worth nothing when that class cannot be).
+#     The test itself reads only the rows, so a conflict against a deactivated
+#     *partner* class still counts.
+#   * `drop_unmarked!` reads the in-universe flag only. It never learns about
+#     deactivation at all.
+#
+# The two must not be conflated, whichever way round. Treating an emptied class
+# as not-in-universe would have `drop_unmarked!` delete it, so a relaxation of
+# whatever emptied it would find it gone; and it would make
+# `mark_necessary!`'s partner-column test — which ANDs in the partner's own
+# in-universe flag — treat a conflict against an emptied partner class as
+# vacuous, which can license a deletion that same relaxation needs undone.
 
-# rows to allocate for a package with m versions:
-# m version rows plus the flag row, rounded up to whole words
+# rows to allocate for a package with m classes:
+# m class rows plus the flag row, rounded up to whole words
 padded_rows(m::Int) = 64 * cld(m + 1, 64)
 
 # number of 64-bit words per column

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -1,4 +1,84 @@
 """
+    Universe{P,V}
+
+The universe a single resolve is run against: one
+[`PkgInfo`](@ref Resolver.PkgInfo) per package, plus `reps` — per package, per
+class, the index into that package's `versions` of the member the class stands
+for under this query, or `0` when the query admits none of them.
+
+`info` carries the package universe ([`pkg_info`](@ref Resolver.pkg_info)) and
+`reps` carries everything the query determines about it. A user constraint acts
+by forbidding *members* of classes. Class members are indistinguishable to
+everything in the registry, so forbidding some of them only changes which one
+stands for the class; forbidding all of them leaves the class **empty**, hence
+**deactivated** — it cannot be selected.
+
+Deactivated classes are **not** deleted. They stay in the matrices as the
+columns a later relaxation of whatever emptied them would need, and the passes
+read the deactivation the way they read a conflict with an always-present
+version: reachability continues its prefix past a deactivated class while still
+following its dependencies, redundancy elimination neither deletes one nor lets
+one license a deletion, and the SAT instance forbids each of them with one
+relaxable unit clause. BitKernels.jl's header spells out how a class's
+*in-universe* flag in the matrix and its *activated* state here divide the work.
+
+## Why deactivation is read off `reps`
+
+`reps` has to exist regardless: a class's representative is what names the
+version in the answer, and it is what the class competes at when the classes
+are ranked. A class the query admits no member of simply has no representative,
+so "unavailable for this query" costs nothing extra to represent. A second flag
+bit in the matrix would work equally well; it would just encode a fact `reps`
+already carries.
+
+## Why the query's state is separate from the artifact
+
+The invariant worth protecting is that the artifact `info` is
+*query-independent*: it is a function of the registry alone, `PkgInfoFiles`
+writes and reads it, and one of them answers every query, whatever that query
+constrains or prefers. `reps` is the opposite — one query's worth of state,
+recomputed per resolve.
+
+Keeping the two in separate values is what makes that invariant checkable
+rather than merely intended. Were `reps` a field of `PkgInfo`, the persisted
+type would contain query state: serialization would have to know to skip it,
+and a freshly loaded artifact would carry a field whose only honest value is
+"not computed yet" — with `0`, which means *deactivated*, as its natural
+uninitialized value, so forgetting to fill it in yields a universe where
+nothing can be selected rather than an error. Whatever shape this ends up
+taking, that is the property it has to preserve: nothing a query decides may
+be reachable from the thing that gets cached and shared.
+"""
+struct Universe{P,V}
+    info :: Dict{P, PkgInfo{P,V}}
+    reps :: Dict{P, Vector{Int}}
+end
+
+# the universe an unconstrained query makes of an artifact: every class stands
+# for its first member (the canonical order's best), nothing is deactivated
+default_reps(info::AbstractDict{P, PkgInfo{P,V}}) where {P,V} =
+    Dict{P,Vector{Int}}(
+        p => Int[first(mem) for mem in info_p.members]
+        for (p, info_p) in info)
+
+Universe(info::Dict{P, PkgInfo{P,V}}) where {P,V} =
+    Universe{P,V}(info, default_reps(info))
+Universe(info::AbstractDict{P, PkgInfo{P,V}}) where {P,V} =
+    Universe{P,V}(Dict{P, PkgInfo{P,V}}(info), default_reps(info))
+
+# per package, a mask of its deactivated (empty) classes — only for the
+# packages that have one, so that an unconstrained resolve, where there are
+# none at all, does no per-class work downstream
+function deactivations(univ::Universe{P,V}) where {P,V}
+    deact = Dict{P,BitVector}()
+    for (p, reps_p) in univ.reps
+        any(iszero, reps_p) || continue
+        deact[p] = BitVector(iszero(r) for r in reps_p)
+    end
+    return isempty(deact) ? EmptyDict{P,BitVector}() : deact
+end
+
+"""
     version_permutations(info, order) :: Union{Nothing, Dict{P, Vector{Int}}}
 
 Per package, the permutation that puts its versions into the ordering `order`
@@ -15,6 +95,10 @@ is a `resolve` parameter rather than part of the [`Problem`](@ref), and why the
 T1 artifact can be built and cached without knowing it (see the manual's Theory
 section, on order-free deletion and on interchangeability classes being
 ordering-independent while the representative choice is not).
+
+This is the ordering of *versions*; what the universe is laid out in is the
+ordering of *classes* it induces, which is
+[`class_ranking`](@ref Resolver.class_ranking)'s business.
 """
 version_permutations(
     info  :: AbstractDict{P, PkgInfo{P,V}},
@@ -39,134 +123,162 @@ function version_permutations(
 end
 
 """
-    class_representatives(info, prob, perms) :: Dict{P, BitVector}
+    class_ranking(info, prob, perms) :: (reps, perms′)
 
-Per package, a mask of the versions that survive collapsing its
-interchangeability classes: the T1 classes (`version_classes`) refined by
-`prob`, then one representative per refined class.
+What a query makes of an artifact's classes, before anything is materialized:
+per package, which member each class stands for (`reps`, a version index per
+class, `0` for a class with no admissible member) and how the classes have to be
+reordered to be in rank order (`perms′`, an entry per package that needs it,
+`nothing` when none does).
 
-**Refinement.** User compat and pins are the only constraints that can tell two
-members of a T1 class apart, because they are stated on version *values*
-instead of on the registry's rows — so splitting each class by `prob`'s
-[`exclusion_masks`](@ref Resolver.exclusion_masks) is enough, and it costs
-nothing for the packages the user did not constrain. Read as the virtual
-package of `Problem`'s docstring, this is just row equality again, over one
-more conflict column.
+**Representative.** A class's members are indistinguishable to the registry, so
+the only thing a user constraint can do to a class is forbid some of its
+members. What is left, the class *admits*; the best of those in the active
+version ordering — `perms`, see
+[`version_permutations`](@ref Resolver.version_permutations) — represents it.
+A class admitting nothing is empty, hence deactivated, and has no
+representative.
 
-**Representative.** The best member in the active rank order — the
-lowest-indexed one when the order is canonical, and otherwise the one `perms`
-(see [`version_permutations`](@ref Resolver.version_permutations)) ranks first.
+**Rank.** A class ranks where the member it stands for ranks, because that is
+the version choosing it yields: a class whose best member is forbidden competes
+at its best *admissible* member, and can therefore fall behind classes it
+outranks in the artifact. An empty class ranks where its best member would, the
+position it would compete from if the constraint that emptied it were lifted.
+Every class's key is a distinct version rank, so this is a total order.
 
-Collapsing is answer-preserving: identical constraint rows are in particular a
-subset of each other, so a class member is dominated by its representative and
-the redundancy theorem's swap argument applies (see the manual's Theory section,
-lemma on interchangeable versions). Representatives *are* versions, and the
-members dropped are exactly the ones the layered answer never chooses, so
-nothing has to be mapped back afterwards.
+Both outputs are per-resolve state: the partition they index is the registry's,
+but which member stands for a class, and hence how the classes are ordered,
+belongs to the query.
 """
-function class_representatives(
+function class_ranking(
     info  :: AbstractDict{P, PkgInfo{P,V}},
     prob  :: Problem{P} = Problem(P[]),
     perms :: Union{Nothing, AbstractDict{P, Vector{Int}}} = nothing,
 ) where {P,V}
     excl = exclusion_masks(info, prob)
-    keep = Dict{P,BitVector}()
-    seen = Bool[] # refined classes already represented
+    reps = Dict{P, Vector{Int}}()
+    perms′ = Dict{P, Vector{Int}}()
+    key = Int[] # scratch: per class, the rank of the member it competes at
     for (p, info_p) in info
-        m = length(info_p.versions)
+        m = nclasses(info_p)          # one entry of `reps` and `key` per class
+        nv = length(info_p.versions)  # ... walking this many versions to fill them
         cls = info_p.classes
         e = get(excl, p, nothing)
         perm = perms === nothing ? nothing : get(perms, p, nothing)
-        k = falses(m)
-        resize!(seen, 2m)
-        fill!(seen, false)
-        for r = 1:m
-            # walk the versions best first, so the first member of a class
-            # found is the one the active order ranks best
+        reps_p = zeros(Int, m)
+        resize!(key, m)
+        fill!(key, 0)
+        # walk the versions best first, so the first admissible member of a
+        # class found is the one the active order ranks best. i indexes
+        # versions, j the class each one is in
+        for r = 1:nv
             i = perm === nothing ? r : perm[r]
-            # refined class key: the T1 class, split by forbidden-ness
-            c = 2 * cls[i] - (e !== nothing && e[i])
-            seen[c] && continue
-            seen[c] = true
-            k[i] = true
+            j = cls[i]
+            reps_p[j] == 0 || continue
+            e === nothing || !e[i] || continue
+            reps_p[j] = i
+            key[j] = r
         end
-        keep[p] = k
+        if any(iszero, reps_p)
+            # the empty classes rank where their best member would
+            for r = 1:nv
+                j = cls[perm === nothing ? r : perm[r]]
+                key[j] == 0 || continue
+                key[j] = r
+            end
+        end
+        reps[p] = reps_p
+        issorted(key) || (perms′[p] = sortperm(key))
     end
-    return keep
+    return reps, isempty(perms′) ? nothing : perms′
 end
 
 """
-    prepare_pkg_info(info, prob, [info′]; group = true, order = nothing)
+    prepare_pkg_info(info, prob, [info′]; order = nothing) :: Universe
 
 The per-resolve half of preprocessing, run on a T1 artifact (see
 [`pkg_info`](@ref Resolver.pkg_info)) to produce the universe the SAT instance
-is built over. Three steps, in this order:
+is built over. Two steps:
 
-1. **Lay out** each package's versions in the ordering the query wants
-   (`version_permutations`), which is a no-op for the canonical order.
-2. **Collapse** each interchangeability class, refined by `prob`, to its best
-   member in that ordering (`class_representatives`).
-3. **Filter** the collapsed universe for reachability and redundancy against
-   the actual requirements and constraints (`filter_pkg_info!`).
+1. **Rank** each package's classes for this query (`class_ranking`): pick the
+   member each class stands for and lay the classes out in the order those
+   members put them in. Under the canonical ordering and no constraints this is
+   the layout the artifact already has, and costs nothing.
+2. **Filter** the result for reachability and redundancy against the actual
+   requirements and constraints (`filter_pkg_info!`).
 
-Filtering has to come last: both of its passes are stated in terms of the
-version ordering, and both get cheaper the fewer versions there are. The layout
-and the collapse share one materialization with it: the collapse is handed over
-as *marks* rather than as a rebuilt universe, so the filter's own first
-`drop_unmarked!` performs both (see `copy_marked!`).
+Filtering has to come second: both of its passes are stated in terms of the rank
+order, so the layout has to exist first.
 
-The result is a fresh dict — `info` is left untouched, so a T1 artifact stays
-reusable across resolves — unless the caller passes its own scratch dict as
-`info′`, or `info` itself when it owns it (which reordering rules out, since it
-rebuilds the matrices). `group = false` skips the collapse, which is the
-ungrouped path the tests compare against.
+The user's constraints reach the matrices through nothing but step 1's
+representatives. A constrained query and an unconstrained one produce the same
+matrices, up to the class reordering their representatives induce; the whole of
+what a constraint does is empty classes, and an empty class is deactivated
+rather than deleted, split or rewritten. That is what makes a class's
+deactivation the only thing there is to relax.
+
+The result is a fresh universe — `info` is left untouched, so a T1 artifact
+stays reusable across resolves — unless the caller passes its own scratch dict
+as `info′`, or `info` itself when it owns it (which reordering rules out, since
+it rebuilds the matrices).
 """
-function prepare_pkg_info(
+prepare_pkg_info(
     info  :: AbstractDict{P, PkgInfo{P,V}},
     prob  :: Problem{P},
     info′ :: Dict{P, PkgInfo{P,V}} = Dict{P, PkgInfo{P,V}}();
-    group :: Bool = true,
     order = nothing, # nothing = canonical, else package -> `lt` comparator
+) where {P,V} =
+    filter_pkg_info!(rank_pkg_info(info, prob, info′; order), prob)
+
+# step 1 on its own: the query's universe before anything is filtered out of
+# it. This is where a constraint's entire effect lands — the representatives
+# and the class order they induce — so it is also the shape in which "no user
+# constraint reaches a matrix" is a statement one can check.
+function rank_pkg_info(
+    info  :: AbstractDict{P, PkgInfo{P,V}},
+    prob  :: Problem{P} = Problem(P[]),
+    info′ :: Dict{P, PkgInfo{P,V}} = Dict{P, PkgInfo{P,V}}();
+    order = nothing,
 ) where {P,V}
     perms = version_permutations(info, order)
-    keep = group ? class_representatives(info, prob, perms) : nothing
+    reps, cperms = class_ranking(info, prob, perms)
     # reordering reads every matrix while writing a differently laid out one,
-    # so the in-place shortcut is only available for the canonical order
-    perms === nothing || info′ !== info ||
+    # so the in-place shortcut is only available when nothing moves
+    cperms === nothing || info′ !== info ||
         (info′ = Dict{P, PkgInfo{P,V}}())
-    copy_marked!(info′, info, keep, perms)
-    filter_pkg_info!(info′, prob)
-    return info′
+    univ = Universe{P,V}(info′, Dict{P, Vector{Int}}())
+    return copy_ranked!(univ, info, reps, cperms)
 end
 
-# Copy `info` into `info′`, laid out in the order `perms` gives (the order it
-# already has when that is `nothing`) and marking active exactly the versions
-# `keep` selects (all of them when it is `nothing`); when the two are the same
-# dict, only the marks are written. This is how the collapse is handed to
-# `filter_pkg_info!`: as *marks* rather than as an already-shrunken universe, so
-# that the filter's own first `drop_unmarked!` materializes the collapse and its
-# own deletions together, in one rebuild instead of two. Every pass the filter
-# runs before that point reads the version flags as the version set, so they all
-# see the collapsed problem — which is the problem the interchangeability lemma
-# licenses substituting for the original.
-function copy_marked!(
-    info′ :: Dict{P, PkgInfo{P,V}},
+# Copy `info` into `univ`, laid out in the class order `perms` gives (the order
+# it already has when that is `nothing`), with every class and column marked
+# active — deactivation is `univ.reps`, not a flag, precisely so that the
+# filtering passes below can tell "nothing can choose this class" apart from
+# "this class is not in the universe". When the destination dict is the source,
+# only the flags are normalized.
+function copy_ranked!(
+    univ  :: Universe{P,V},
     info  :: AbstractDict{P, PkgInfo{P,V}},
-    keep  :: Union{Nothing, AbstractDict{P, BitVector}} = nothing,
+    reps  :: Dict{P, Vector{Int}},
     perms :: Union{Nothing, AbstractDict{P, Vector{Int}}} = nothing,
 ) where {P,V}
+    info′ = univ.info
+    reps′ = univ.reps
     src = Int[] # scratch: output column => source column
     for (p, info_p) in info
         X = info_p.conflicts
-        m = length(info_p.versions)
+        m = nclasses(info_p)
         n = size(X, 2) - 1
         if info′ === info
-            keep === nothing || (X[1:m, end] .= keep[p])
+            @assert perms === nothing
+            X[1:m, end] .= true
+            X[m+1, 1:n] .= true
+            reps′[p] = reps[p]
             continue
         end
         perm = perms === nothing ? nothing : get(perms, p, nothing)
         # a reordered partner's interaction block is indexed by that partner's
-        # versions, so its columns move with them; every other column stays put
+        # classes, so its columns move with them; every other column stays put
         cols = nothing
         if perms !== nothing
             for (q, off) in info_p.interacts
@@ -185,30 +297,33 @@ function copy_marked!(
         end
         X′ = perm === nothing && cols === nothing ? copy(X) :
              relaid_conflicts(X, m, n, perm, cols)
-        if keep === nothing
-            X′[1:m, end] .= true
-        elseif perm === nothing
-            X′[1:m, end] .= keep[p]
-        else
-            k = keep[p]
-            for r = 1:m
-                X′[r, end] = k[perm[r]]
-            end
-        end
+        X′[1:m, end] .= true
         X′[m+1, 1:n] .= true
-        info′[p] = PkgInfo(
-            perm === nothing ? copy(info_p.versions) : info_p.versions[perm],
-            copy(info_p.depends), copy(info_p.interacts), X′,
-            perm === nothing ? copy(info_p.classes) : info_p.classes[perm])
+        if perm === nothing
+            info′[p] = PkgInfo(
+                copy(info_p.versions), copy(info_p.classes),
+                copy(info_p.members), copy(info_p.depends),
+                copy(info_p.interacts), X′)
+            reps′[p] = copy(reps[p])
+        else
+            # the partition follows the classes: class `r` of the new layout is
+            # class `perm[r]` of the old one
+            inv = invperm(perm)
+            info′[p] = PkgInfo(
+                copy(info_p.versions), Int[inv[i] for i in info_p.classes],
+                info_p.members[perm], copy(info_p.depends),
+                copy(info_p.interacts), X′)
+            reps′[p] = reps[p][perm]
+        end
     end
-    return info′
+    return univ
 end
 
 # A conflicts matrix laid out under a reordering: row `r` reads source row
-# `perm[r]` (this package's versions) and column `j` reads source column
+# `perm[r]` (this package's classes) and column `j` reads source column
 # `cols[j]` (a reordered partner's block); `nothing` for either means unchanged.
-# Only the version rows of the `n` conflict columns are written — the caller
-# sets the flag row and the version-flag column. Columns whose rows do not move
+# Only the class rows of the `n` conflict columns are written — the caller
+# sets the flag row and the class-flag column. Columns whose rows do not move
 # are blitted word by word, which is the whole matrix whenever only partners
 # were reordered.
 function relaid_conflicts(
@@ -244,56 +359,51 @@ end
 filter_pkg_info!(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
-) where {P,V} = filter_pkg_info!(info, Problem(reqs))
+) where {P,V} = filter_pkg_info!(Universe(info), Problem(reqs))
 
 function filter_pkg_info!(
-    info :: Dict{P, PkgInfo{P,V}},
+    univ :: Universe{P,V},
     prob :: Problem{P},
 ) where {P,V}
+    info = univ.info
     reqs = prob.reqs
-    # user constraints enter as the exclusion masks of the virtual package
-    # that represents them (see Problem.jl): reachability treats an excluded
-    # version as one that conflicts with an always-present version, and
-    # redundancy treats the mask as one more conflict column. the masks are
-    # index-based, so they are rebuilt after every deletion round; only the
-    # constrained packages cost anything
-    excl = exclusion_masks(info, prob)
-    # the version flags on entry are the version set to filter: normally all
-    # of them, but `prepare_pkg_info` seeds them with the interchangeability
-    # collapse, so that the first `drop_unmarked!` below deletes the collapsed
-    # members along with everything the passes here find.
+    # the query's constraints reach the passes below as the *deactivated*
+    # classes and nothing else — no exclusion column, no virtual package, no
+    # row of their own — because a class its members all fail is the only mark
+    # a constraint can leave on a universe whose rows are classes. the masks
+    # are index-based, so they are rebuilt after every deletion round; only the
+    # packages with an empty class cost anything
     #
-    # arc consistency first: it needs no reachability marks and it is what
-    # makes the deletions safe — dropping a package while a kept version
+    # the installability prune first: it needs no reachability marks and it is
+    # what makes the deletions safe — dropping a package while a kept class
     # still depends on it would leave a dangling name. then redundancy
     # elimination — it needs no reachability marks and does most of the
     # shrinking — then alternate reachability and redundancy until neither
-    # deletes anything: each deleted version can expose more of both kinds
+    # deletes anything: each deleted class can expose more of both kinds
     # of pruning, and every round preserves the resolved answer (see the
     # theory docs on iterating the filter). requirement packages survive
-    # filtering unless they have no installable version at all — nothing
+    # filtering unless they have no installable class at all — nothing
     # can satisfy those — so the requirements remain valid across rounds.
-    # rounds strictly shrink the total version count, so the loop
-    # terminates
+    # rounds strictly shrink the total class count, so the loop terminates
     mark_installable!(info)
-    mark_necessary!(info, excl)
-    drop_unmarked!(info)
+    mark_necessary!(info, deactivations(univ))
+    drop_unmarked!(univ)
     while true
-        total = sum(length(i.versions) for i in values(info); init = 0)
-        excl = exclusion_masks(info, prob)
-        mark_reachable!(info, reqs, excl)
-        mark_necessary!(info, excl)
-        drop_unmarked!(info)
-        sum(length(i.versions) for i in values(info); init = 0) < total ||
+        total = sum(nclasses(i) for i in values(info); init = 0)
+        deact = deactivations(univ)
+        mark_reachable!(info, reqs, deact)
+        mark_necessary!(info, deact)
+        drop_unmarked!(univ)
+        sum(nclasses(i) for i in values(info); init = 0) < total ||
             break
     end
-    return info
+    return univ
 end
 
 """
     find_reachable(info, reqs) :: Dict{P, Int}
 
-This function finds a minimal "reachable" subset of package and versions that
+This function finds a minimal "reachable" subset of packages and classes that
 could appear in pareto-optimal solutions to version resolution for the given set
 of required "root" packages, using the following recursive logic:
 
@@ -302,21 +412,26 @@ of required "root" packages, using the following recursive logic:
 - P[i] reachable & P[i] conflicts w. reachable => P[i+1] reachable
 - D[end] conflicts w. reachable & P[i] depends on D => P[i+1] reachable
 
-The optional `excl` argument gives, per package, a mask of versions the user
-forbade. Those are the conflict rows of the always-present virtual package that
-represents the user constraints, so a reachable excluded version fires the same
-degradation rule as any other conflict:
+The optional `deact` argument gives, per package, a mask of its deactivated
+classes — the ones this query admits no member of. Such a class cannot be
+selected, so the package cannot be installed at it and the prefix has to
+continue past it, exactly as it continues past a class conflicting with
+something present:
 
-- P[i] reachable & P[i] excluded => P[i+1] reachable
+- P[i] reachable & P[i] deactivated => P[i+1] reachable
 
-The function returns a dictionary mapping packages to the maximum version index
+A deactivated class's dependencies are followed all the same, which is what
+keeps the cone behind it in the universe: it is precisely the cone a relaxation
+of whatever emptied the class would need to find still there.
+
+The function returns a dictionary mapping packages to the maximum class index
 of that package that could be reached in an optimal solution. If a package
 cannot appear in an optimal solution, it will not appear in this dictionary.
 """
 function find_reachable(
-    info :: Dict{P, PkgInfo{P,V}},
-    reqs :: SetOrVec{P} = keys(info),
-    excl :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
+    info  :: Dict{P, PkgInfo{P,V}},
+    reqs  :: SetOrVec{P} = keys(info),
+    deact :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
 ) where {P,V}
     # intern packages as integer indices so that the fixpoint loop below
     # hashes no package names; all derived tables are indexed by pkg id
@@ -324,20 +439,20 @@ function find_reachable(
     N = length(pkgs)
     ix = Dict{P,Int}(p => i for (i, p) in enumerate(pkgs))
     infos = Vector{PkgInfo{P,V}}(undef, N)
-    nvers = Vector{Int}(undef, N)
+    ncls = Vector{Int}(undef, N)
     # interned depends, same order (id 0: dependency absent from info,
-    # i.e. a package with no installable version — see below)
+    # i.e. a package with no installable class — see below)
     deps = Vector{Vector{Int}}(undef, N)
     partners = Vector{Vector{Tuple{Int,Int}}}(undef, N)
-    # interned exclusion masks (nothing: package unconstrained, the norm)
-    excls = Vector{Union{Nothing,BitVector}}(nothing, N)
+    # interned deactivation masks (nothing: nothing empty here, the norm)
+    deacts = Vector{Union{Nothing,BitVector}}(nothing, N)
     for p = 1:N
         info_p = info[pkgs[p]]
         infos[p] = info_p
-        nvers[p] = length(info_p.versions)
-        excls[p] = get(excl, pkgs[p], nothing)
+        ncls[p] = nclasses(info_p)
+        deacts[p] = get(deact, pkgs[p], nothing)
         deps[p] = Int[get(ix, q, 0) for q in info_p.depends]
-        # (partner id, offset of p's version block in the partner's matrix)
+        # (partner id, offset of p's class block in the partner's matrix)
         prt = Tuple{Int,Int}[
             (ix[q], info[q].interacts[pkgs[p]])
             for q in keys(info_p.interacts)
@@ -345,9 +460,9 @@ function find_reachable(
         partners[p] = sort!(prt)
     end
 
-    # meaning (both map packages to version indices):
-    #   - reach tracks fully processed reachable versions
-    #   - queue tracks newly reachable versions not yet processed
+    # meaning (both map packages to class indices):
+    #   - reach tracks fully processed reachable classes
+    #   - queue tracks newly reachable classes not yet processed
     reach = zeros(Int, N)
     queue = zeros(Int, N)
     stack = Int[] # packages with queued work
@@ -361,26 +476,26 @@ function find_reachable(
         end
     end
 
-    # add next active version of p *after* i to the queue
-    # do nothing if there's already version > i in reach/queue
+    # add next active class of p *after* i to the queue
+    # do nothing if there's already class > i in reach/queue
     function next(p::Int, i::Int)
         reach[p] > i && return false
         queue[p] > i && return false
-        m = nvers[p]
+        m = ncls[p]
         X = infos[p].conflicts
-        # first active version after i (the flag column is the active set)
+        # first active class after i (the flag column is the active set)
         j = col_min_from(X, size(X, 2), i + 1, m)
-        # j == 0: we're out of versions (i.e. saturated; see below)
+        # j == 0: we're out of classes (i.e. saturated; see below)
         enqueue(p, j == 0 ? m + 1 : j)
         return true
     end
 
     rdeps = [Dict{Int,Int}() for _ = 1:N] # reverse dependency map
     # rdeps[p][q] == k means
-    #   "k is latest reachable version of q that depends on p"
+    #   "k is latest reachable class of q that depends on p"
 
     for p in reqs
-        # a requirement with no installable version reaches nothing
+        # a requirement with no installable class reaches nothing
         i = get(ix, p, 0)
         i == 0 || enqueue(i, 1)
     end
@@ -388,19 +503,19 @@ function find_reachable(
     # notation:
     #   - p, q: packages
     #   - info_p = infos[p]
-    #   - indices of versions of package p: i, j
-    #   - indices of versions of package q: k
+    #   - indices of classes of package p: i, j
+    #   - indices of classes of package q: k
     while !isempty(stack)
-        # get unprocessed package + version
+        # get unprocessed package + class
         p = pop!(stack)
         instack[p] = false
         i = queue[p]
         queue[p] = 0
         info_p = infos[p]
-        m = nvers[p]
+        m = ncls[p]
         # check for saturation
         #   p saturated means: conflicts can force p to be uninstallable
-        #   saturation represented by i > nvers[p]
+        #   saturation represented by i > ncls[p]
         if i > m
             # p has become saturated
             for (q, k) in rdeps[p]
@@ -410,19 +525,20 @@ function find_reachable(
                 next(q, k)
             end
         end
-        # process each newly reachable version of p
-        excl_p = excls[p]
+        # process each newly reachable class of p
+        deact_p = deacts[p]
         for j = reach[p]+1:min(i, m)
-            # user constraints: p@j conflicts with the always-present
-            # version of the virtual package, so it can never be a resting
-            # point — p can only be installed past it
-            excl_p === nothing || !excl_p[j] || next(p, j)
+            # p@j is deactivated: it cannot be selected, so it cannot be
+            # what p is installed at — the prefix has to continue past it.
+            # its dependencies below are followed anyway, which is what keeps
+            # the packages behind it in the universe
+            deact_p === nothing || !deact_p[j] || next(p, j)
             # dependencies
             for (k, q) in enumerate(deps[p])
                 info_p.conflicts[j, k] || continue
                 # p@j depends on q
                 if q == 0
-                    # q has no installable version at all, so neither has
+                    # q has no installable class at all, so neither has
                     # p@j: p can only be installed past it
                     next(p, j)
                     continue
@@ -431,23 +547,23 @@ function find_reachable(
                 rdeps_q[p] = max(get(rdeps_q, p, 0), j)
                 next(q, 0) # q can be required
                 # check if q is saturated:
-                if reach[q] > nvers[q]
+                if reach[q] > ncls[q]
                     # p@j depends on q, therefore
                     # p@j conflicts with q being uninstallable
                     # q being saturated means that can happen
                     next(p, j)
                 end
             end
-            # find p@j's conflicts with reached versions of each partner:
+            # find p@j's conflicts with reached classes of each partner:
             # conflicts are stored symmetrically, so scan the partner-side
             # column Y[k, c+j] == X[j, b+k], which is contiguous
             for (q, c) in partners[p]
-                r = min(reach[q], nvers[q])
+                r = min(reach[q], ncls[q])
                 r > 0 || continue
                 k = col_max_upto(infos[q].conflicts, c + j, r)
                 k == 0 && continue
                 # p@j conflicts with q@k (the highest such k; pushing past
-                # it subsumes pushing past any lower conflicting version)
+                # it subsumes pushing past any lower conflicting class)
                 next(p, j)
                 next(q, k)
             end
@@ -460,13 +576,13 @@ function find_reachable(
 end
 
 function mark_reachable!(
-    info :: Dict{P, PkgInfo{P,V}},
-    reqs :: SetOrVec{P} = keys(info),
-    excl :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
+    info  :: Dict{P, PkgInfo{P,V}},
+    reqs  :: SetOrVec{P} = keys(info),
+    deact :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
 ) where {P,V}
-    reach = find_reachable(info, reqs, excl)
+    reach = find_reachable(info, reqs, deact)
     for (p, info_p) in info
-        r = min(get(reach, p, 0), length(info_p.versions))
+        r = min(get(reach, p, 0), nclasses(info_p))
         info_p.conflicts[1:r, end] .= true
         info_p.conflicts[r+1:end, end] .= false
     end
@@ -476,17 +592,18 @@ end
 function mark_installable!(
     info :: Dict{P, <: PkgInfo{P}},
 ) where {P}
-    # a package with no active versions cannot be installed, so no version
-    # depending on it can be either: deactivate those, to a fixpoint (each
-    # deactivation can empty another package's active set). this is the
-    # arc-consistency test — a sound approximation of deleting model-free
-    # versions (see the theory docs) — and it is also what keeps `depends`
-    # from naming a package that `drop_unmarked!` deletes as empty
+    # a package with no in-universe classes cannot be installed, so no class
+    # depending on it can be either: take those out too, and repeat until
+    # nothing more goes, since each removal can empty another package (the
+    # literature calls this arc consistency). It is a sound approximation of
+    # deleting the classes no valid solution contains (see the theory docs),
+    # and it is also what keeps `depends` from naming a package that
+    # `drop_unmarked!` deletes as empty
     #
     # a dependency naming a package that is not in `info` at all counts the
-    # same way: it cannot be satisfied either, and a deletion elsewhere (the
-    # class collapse, say, or an earlier `drop_unmarked!`) is exactly how one
-    # comes about. `info` does not change here, so the absentees are found once
+    # same way: it cannot be satisfied either, and a deletion elsewhere (an
+    # earlier `drop_unmarked!`, say) is exactly how one comes about. `info`
+    # does not change here, so the absentees are found once
     absent = Set{P}()
     for info_p in values(info), q in info_p.depends
         haskey(info, q) || push!(absent, q)
@@ -497,7 +614,7 @@ function mark_installable!(
         union!(empties, absent)
         for (p, info_p) in info
             X = info_p.conflicts
-            any(X[i, end] for i = 1:length(info_p.versions)) && continue
+            any(X[i, end] for i = 1:nclasses(info_p)) && continue
             push!(empties, p)
         end
         isempty(empties) && return info
@@ -507,7 +624,7 @@ function mark_installable!(
             for (k, q) in enumerate(info_p.depends)
                 q in empties || continue
                 # q is uninstallable, drop the p@i that depend on it
-                for i = 1:length(info_p.versions)
+                for i = 1:nclasses(info_p)
                     X[i, end] || continue
                     X[i, k] || continue
                     X[i, end] = false
@@ -520,8 +637,8 @@ function mark_installable!(
 end
 
 function mark_necessary!(
-    info :: Dict{P, PkgInfo{P,V}},
-    excl :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
+    info  :: Dict{P, PkgInfo{P,V}},
+    deact :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
 ) where {P,V}
     # intern packages as integer indices so that the work loop below
     # hashes no package names (sorted so the processing order — and with
@@ -530,17 +647,17 @@ function mark_necessary!(
     N = length(pkgs)
     ix = Dict{P,Int}(p => i for (i, p) in enumerate(pkgs))
     infos = Vector{PkgInfo{P,V}}(undef, N)
-    nvers = Vector{Int}(undef, N)
+    ncls = Vector{Int}(undef, N)
     partners = Vector{Vector{NTuple{3,Int}}}(undef, N)
-    # interned exclusion masks (nothing: package unconstrained, the norm)
-    excls = Vector{Union{Nothing,BitVector}}(nothing, N)
+    # interned deactivation masks (nothing: nothing empty here, the norm)
+    deacts = Vector{Union{Nothing,BitVector}}(nothing, N)
     for p = 1:N
         info_p = info[pkgs[p]]
         infos[p] = info_p
-        nvers[p] = length(info_p.versions)
-        excls[p] = get(excl, pkgs[p], nothing)
-        # (partner id, partner's version block offset in p's matrix,
-        #  p's version block offset in the partner's matrix)
+        ncls[p] = nclasses(info_p)
+        deacts[p] = get(deact, pkgs[p], nothing)
+        # (partner id, partner's class block offset in p's matrix,
+        #  p's class block offset in the partner's matrix)
         prt = NTuple{3,Int}[
             (ix[q], b, info[q].interacts[pkgs[p]])
             for (q, b) in info_p.interacts
@@ -548,31 +665,60 @@ function mark_necessary!(
         partners[p] = sort!(prt)
     end
     # some work buffers
-    A = UInt64[]        # active version mask
-    D = UInt64[]        # per-version domination candidate masks
-    T = UInt64[]        # mask of versions still tracked by the sweep
-    E = UInt64[]        # exclusion mask, padded to the column width
+    A = UInt64[]        # candidate class mask
+    D = UInt64[]        # per-class domination candidate masks
+    T = UInt64[]        # mask of classes still tracked by the sweep
     R = Int[]           # redundant indices vector
+
+    # the classes redundancy may reason about: the in-universe ones, less the
+    # deactivated ones — the pass is the one place that reads *both* per-class
+    # bits (see BitKernels.jl's header). a deactivated class must not be
+    # *deleted* — the relaxation that would want it back has to find it still
+    # there — and it must not *dominate*, because domination says "this better
+    # class will be chosen instead", which is worth nothing when the better
+    # class is one nothing can choose. dropping them from the candidate set
+    # does both — it takes them off both sides of the test — and it keeps the
+    # test itself activation-free: what a row says is compared in full,
+    # including conflicts against partner classes this query happens to have
+    # emptied
+    function candidates!(A::Vector{UInt64}, p::Int)
+        info_p = infos[p]
+        X = info_p.conflicts
+        resize!(A, col_words(X))
+        col_copy!(A, X, size(X, 2))
+        clear_rows_above!(A, ncls[p])
+        d = deacts[p]
+        if d !== nothing
+            dc = d.chunks
+            @inbounds for w = 1:min(length(A), length(dc))
+                A[w] &= ~dc[w]
+            end
+        end
+        return A
+    end
+
     # initialize active column flags
     for p = 1:N
         info_p = infos[p]
         X = info_p.conflicts
-        m = nvers[p]
+        m = ncls[p]
         n = size(X, 2) - 1
-        resize!(A, col_words(X))
-        col_copy!(A, X, n + 1)
-        clear_rows_above!(A, m)
+        candidates!(A, p)
         for j = 1:n
             # we don't have to look at columns that have no
-            # conflicts for any active versions of package
+            # conflicts for any candidate class of the package
             X[m+1, j] = col_intersects(X, j, A)
         end
-        # conflict columns for inactive partner versions are also
-        # irrelevant: no model over the active versions can include
-        # the partner, so the conflict cannot constrain anything
+        # conflict columns for deleted partner classes are also
+        # irrelevant: no model over the surviving classes can include
+        # the partner, so the conflict cannot constrain anything.
+        # a partner class that is merely *deactivated* is a different
+        # matter — it is still in the universe, so the conflict still
+        # counts, and the flag it is read from does not know about
+        # deactivation precisely so that it does
         for (q, b, c) in partners[p]
             Y = infos[q].conflicts
-            for k = 1:nvers[q]
+            for k = 1:ncls[q]
                 X[m+1, b+k] &= Y[k, end]
             end
         end
@@ -591,30 +737,28 @@ function mark_necessary!(
         # get conflicts & dimensions
         info_p = infos[p]
         X = info_p.conflicts
-        m = nvers[p]
-        m > 1 || continue # unique version cannot be redundant
+        m = ncls[p]
+        m > 1 || continue # unique class cannot be redundant
         n = size(X, 2) - 1
         W = col_words(X)
-        # active version mask
-        resize!(A, W)
-        col_copy!(A, X, n + 1)
-        clear_rows_above!(A, m)
+        # candidate class mask
+        candidates!(A, p)
         nact = 0
         @inbounds for w = 1:W
             nact += count_ones(A[w])
         end
-        nact > 1 || continue # unique version cannot be redundant
-        # find redundant versions: i < j and X[i, k] => X[j, k] for all
-        # active k means an earlier version is strictly more compatible,
+        nact > 1 || continue # unique class cannot be redundant
+        # find redundant classes: i < j and X[i, k] => X[j, k] for all
+        # active k means an earlier class is strictly more compatible,
         # therefore i will always be chosen instead of j. the candidates
-        # dominated by i are the active versions worse than i that have a
+        # dominated by i are the candidate classes worse than i that have a
         # constraint in every column i does. sweep the active columns
-        # once, restricting the candidates of every version with a bit in
-        # the column to the column's row set; versions whose candidate
-        # set empties drop out of the sweep. a version dominated only by
-        # dominated versions is also dominated by their (transitively
-        # live) dominators, so batching over the initial active set finds
-        # exactly the sequentially dominated versions.
+        # once, restricting the candidates of every class with a bit in
+        # the column to the column's row set; classes whose candidate
+        # set empties drop out of the sweep. a class dominated only by
+        # dominated classes is also dominated by their (transitively
+        # live) dominators, so batching over the initial candidate set finds
+        # exactly the sequentially dominated classes.
         resize!(D, m * W)
         resize!(T, W)
         copyto!(T, A)
@@ -623,7 +767,7 @@ function mark_necessary!(
             while !iszero(c)
                 i = ((w - 1) << 6) + trailing_zeros(c) + 1
                 c &= c - 1
-                # candidates of i: active versions worse than i
+                # candidates of i: candidate classes worse than i
                 o = (i - 1) * W
                 for w′ = 1:W
                     D[o + w′] = A[w′]
@@ -674,30 +818,7 @@ function mark_necessary!(
                 end
             end
         end
-        # the virtual package representing the user constraints contributes
-        # one more conflict column — the exclusion mask. its version is
-        # always present, so the column is always active: an excluded
-        # version must not dominate a non-excluded one
-        excl_p = excls[p]
-        if excl_p !== nothing
-            resize!(E, W)
-            fill!(E, 0)
-            copyto!(E, 1, excl_p.chunks, 1, min(W, length(excl_p.chunks)))
-            @inbounds for w = 1:W
-                c = E[w] & T[w]
-                while !iszero(c)
-                    i = ((w - 1) << 6) + trailing_zeros(c) + 1
-                    c &= c - 1
-                    o = (i - 1) * W
-                    live = UInt64(0)
-                    for w′ = 1:W
-                        live |= (D[o + w′] &= E[w′])
-                    end
-                    iszero(live) && (T[w] &= ~(UInt64(1) << ((i - 1) & 63)))
-                end
-            end
-        end
-        # union of all candidate sets = the dominated versions
+        # union of all candidate sets = the dominated classes
         fill!(T, UInt64(0)) # reuse as the union accumulator
         @inbounds for w = 1:W
             c = A[w]
@@ -719,10 +840,10 @@ function mark_necessary!(
             end
         end
         isempty(R) && continue
-        # deactivate redundant versions
+        # deactivate redundant classes
         X[R, end] .= false
         for (q, b, c) in partners[p]
-            infos[q].conflicts[nvers[q] + 1, c .+ R] .= false
+            infos[q].conflicts[ncls[q] + 1, c .+ R] .= false
             if !inwork[q] # can create new redundancies
                 inwork[q] = true
                 push!(queue, q)
@@ -731,73 +852,107 @@ function mark_necessary!(
     end
 end
 
+drop_unmarked!(univ::Universe) = drop_unmarked!(univ.info, univ.reps)
+
 function drop_unmarked!(
-    info′ :: Dict{P, <: PkgInfo{P}},
-    info  :: Dict{P, <: PkgInfo{P}} = info′,
+    info :: Dict{P, <: PkgInfo{P}},
+    reps :: Union{Nothing, Dict{P, Vector{Int}}} = nothing,
 ) where {P}
-    # first pass: per package, compute the kept versions and kept columns
-    # from the (definitive) version flags — all of it before any package
+    # This pass reads the *in-universe* bit and nothing else: it knows about
+    # the deleting passes' verdicts and knows nothing about deactivation, which
+    # is exactly why deactivation is not stored as that bit — an emptied class
+    # must come out of here intact (see BitKernels.jl's header). `reps` is
+    # carried along only to be renumbered with the classes it indexes.
+    #
+    # first pass: per package, compute the kept classes and kept columns
+    # from the (definitive) class flags — all of it before any package
     # is rebuilt, since kept columns are read off the partners' matrices
     masks = Dict{P, Tuple{BitVector, BitVector}}()
-    A = UInt64[] # active version mask buffer
+    A = UInt64[] # active class mask buffer
     for (p, info_p) in info
         X = info_p.conflicts
-        m = length(info_p.versions)
+        m = nclasses(info_p)
         n = size(X, 2) - 1
         W = col_words(X)
-        # active versions
+        # active classes
         I = X[1:m, end]
         resize!(A, W)
         col_copy!(A, X, n + 1)
         clear_rows_above!(A, m)
-        # kept columns: dependency columns some active version depends
-        # on, and conflict columns of active partner versions — a
-        # partner's column block must stay aligned with its version list,
-        # so kept partner versions keep their columns even if empty
+        # kept columns: dependency columns some active class depends
+        # on, and conflict columns of active partner classes — a
+        # partner's column block must stay aligned with its class list,
+        # so kept partner classes keep their columns even if empty
         K = falses(n)
         for k = 1:length(info_p.depends)
             K[k] = col_intersects(X, k, A)
         end
         for (q, b) in info_p.interacts
             Y = info[q].conflicts
-            copy_col_bits!(K.chunks, b, Y, size(Y, 2), length(info[q].versions))
+            copy_col_bits!(K.chunks, b, Y, size(Y, 2), nclasses(info[q]))
         end
         masks[p] = (I, K)
     end
-    # save original version counts (needed if info′ === info)
-    N = Dict{P,Int}(
-        p => length(info_p.versions)
-        for (p, info_p) in info
-    )
+    # save original class counts (the matrices are rebuilt in place)
+    N = Dict{P,Int}(p => nclasses(info_p) for (p, info_p) in info)
     # second pass: shrink each PkgInfo
-    for (p, info_p) in info
+    for p in collect(keys(info))
+        info_p = info[p]
         # abbreviate components
         V = info_p.versions
+        C = info_p.classes
+        M = info_p.members
         D = info_p.depends
         T = info_p.interacts
         X = info_p.conflicts
-        C = info_p.classes
-        m = length(V)
+        m = nclasses(info_p)
         n = size(X, 2) - 1
         W = col_words(X)
         I, K = masks[p]
         m′ = count(I)
-        # delete if no active versions
+        # delete if no active classes
         if m′ == 0
-            delete!(info′, p)
+            delete!(info, p)
+            reps === nothing || delete!(reps, p)
             continue
         end
         # keep as is if everything is active (with the column flags
         # normalized, as rebuilding would leave them)
         if m′ == m && all(K)
             X[m+1, 1:n] .= true
-            if info !== info′
-                info′[p] = PkgInfo(copy(V), copy(D), copy(T), copy(X), copy(C))
-            end
             continue
         end
+        # the surviving classes keep the versions they hold: a deleted class
+        # takes its members with it, since nothing is left to name them.
+        # dropping classes and columns can only *merge* row-equality classes
+        # (fewer rows to distinguish, fewer columns to differ in), so
+        # restricting the partition stays sound, if possibly finer than the
+        # truth; `pkg_info` is where it is computed exactly
+        keep = falses(length(V))
+        for i = 1:m
+            I[i] || continue
+            for j in M[i]
+                keep[j] = true
+            end
+        end
+        index = cumsum(keep) # old version index => new one (kept ones only)
+        V′ = V[keep]
+        C′ = Vector{Int}(undef, length(V′))
+        M′ = Vector{Vector{Int}}(undef, m′)
+        i′ = 0
+        for i = 1:m
+            I[i] || continue
+            i′ += 1
+            M′[i′] = mem = Int[index[j] for j in M[i]]
+            for j in mem
+                C′[j] = i′
+            end
+        end
+        if reps !== nothing
+            r = reps[p]
+            reps[p] = Int[iszero(r[i]) ? 0 : index[r[i]] for i = 1:m if I[i]]
+        end
         # compute shrunken components
-        V′ = V[I]
         D′ = D[K[1:length(D)]]
         T′ = Dict{P,Int}()
         b′ = length(D′)
@@ -813,11 +968,11 @@ function drop_unmarked!(
         X′ = falses(R′, b′ + 1)
         src = X.chunks
         dst = X′.chunks
-        # kept-version mask words for the gather below
+        # kept-class mask words for the gather below
         resize!(A, W)
         col_copy!(A, X, n + 1)
         clear_rows_above!(A, m)
-        prefix = findlast(I) == m′ # kept versions are 1:m′
+        prefix = findlast(I) == m′ # kept classes are 1:m′
         j′ = 0
         for j = 1:n
             K[j] || continue
@@ -825,7 +980,7 @@ function drop_unmarked!(
             sb = (j - 1) * W
             db = (j′ - 1) * W′
             if prefix
-                # kept versions are a prefix: straight word copy
+                # kept classes are a prefix: straight word copy
                 nw = (m′ + 63) >> 6
                 @inbounds for w = 1:nw
                     dst[db + w] = src[sb + w]
@@ -833,7 +988,7 @@ function drop_unmarked!(
                 r = m′ & 63
                 r != 0 && @inbounds (dst[db + nw] &= (UInt64(1) << r) - 1)
             else
-                # gather the kept versions' bits
+                # gather the kept classes' bits
                 acc = UInt64(0)
                 na = 0
                 dw = db + 1
@@ -857,39 +1012,26 @@ function drop_unmarked!(
             end
         end
         @assert j′ == b′
-        X′[1:m′, end] .= true  # kept versions are active
+        X′[1:m′, end] .= true  # kept classes are active
         X′[m′+1, 1:b′] .= true # kept columns are active
-        # the surviving versions keep the classes they were in: dropping
-        # versions and columns can only *merge* row-equality classes (fewer
-        # rows to distinguish, fewer columns to differ in), so restricting the
-        # partition stays sound, if possibly finer than the truth. `pkg_info`
-        # is where it is computed exactly
-        C′ = renumber_classes!(C[I])
-        # assign new struct into info′
-        info′[p] = PkgInfo(V′, D′, T′, X′, C′)
+        # assign new struct into info
+        info[p] = PkgInfo(V′, C′, M′, D′, T′, X′)
     end
-    return info′
-end
-
-function drop_excluded!(
-    info :: Dict{P, PkgInfo{P,V}},
-    drop :: SetOrVec{P},
-) where {P,V}
-    drop isa AbstractSet || (drop = Set{P}(drop))
-    for (p, info_p) in info
-        # deactivate all versions of dropped packages
-        p ∈ drop || continue
-        info_p.conflicts[:, end] .= false
-    end
-    # deactivate versions that depend on dropped packages
-    mark_installable!(info)
-    drop_unmarked!(info)
+    return info
 end
 
 function check_info_structure(
     info :: Dict{P, PkgInfo{P,V}},
 ) where {P,V}
     for (p, info_p) in info
+        length(info_p.classes) == length(info_p.versions) ||
+            return :classes, p, p
+        for (i, mem) in enumerate(info_p.members), j in mem
+            info_p.classes[j] == i ||
+                return :members, p, p
+        end
+        size(info_p.conflicts, 1) == padded_rows(nclasses(info_p)) ||
+            return :rows, p, p
         for q in info_p.depends
             q in keys(info) ||
                 return :depends, p, q
@@ -901,7 +1043,7 @@ function check_info_structure(
                     return :conflicts, p, q
             end
             if i < length(interacts)
-                b + length(info[q].versions) == interacts[i+1][2] ||
+                b + nclasses(info[q]) == interacts[i+1][2] ||
                     return :conflicts, p, q
             end
         end

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -1,29 +1,89 @@
+"""
+    PkgInfo{P,V}
+
+One package's slice of the universe. The conflict matrix has one row per
+interchangeability *class* — a set of versions nothing in the registry can tell
+apart — and the partition saying which versions those are is carried with it.
+
+  * `versions` — every version the package offers, in canonical (provider)
+    order. Untouched by the ordering a query asks for: the rank order is a
+    property of the *classes*, and it is the rows that move.
+  * `classes` / `members` — the partition, in both directions. `classes[i]` is
+    the matrix row version `i` belongs to; `members[c]` is class `c`'s version
+    indices, ascending. Both are stored because both directions are hot;
+    anything that drops or renumbers classes rebuilds them together.
+  * `depends` — the packages some class depends on, sorted; one matrix column
+    each, in that order.
+  * `interacts` — per partner package, the offset of its block of *class*
+    columns in this matrix.
+  * `conflicts` — `(m+1) × (n+1)` bits for `m` classes and `n` conflict
+    columns: the dependency columns followed by one block of partner classes
+    per partner, with the last row and column holding the *in-universe* flags
+    (see BitKernels.jl for the layout).
+
+Versions share a class when nothing in the registry can tell them apart — see
+[`version_classes`](@ref Resolver.version_classes). Since class members are
+indistinguishable by construction, a user constraint cannot split a class; all
+it can do is empty one, which is why constraints never enter these matrices
+(see [`prepare_pkg_info`](@ref Resolver.prepare_pkg_info)).
+
+## The two per-class bits
+
+A class carries two independent facts, and the matrix holds only one of them:
+
+  * **in-universe** — "this class is still part of the problem". This is the
+    flag row and column of `conflicts`. The passes that *delete* clear it
+    (`mark_installable!`, `mark_reachable!`, `mark_necessary!`), and
+    `drop_unmarked!` reads it and nothing else.
+  * **activated** — "this query admits some member of this class". This is
+    per-resolve state, not matrix state: it is `reps[c] != 0` on the
+    [`Universe`](@ref Resolver.Universe) built from this artifact.
+
+Deactivation never implies deletion: an emptied class keeps its row, its
+column in every partner, and its dependency columns. Keeping the two bits apart
+is what makes that possible, and BitKernels.jl's header spells out why one bit
+could not do both jobs.
+"""
 struct PkgInfo{P,V}
     versions  :: Vector{V}
+    classes   :: Vector{Int}
+    members   :: Vector{Vector{Int}}
     depends   :: Vector{P}
     interacts :: Dict{P, Int}
     conflicts :: BitMatrix
-    # the interchangeability partition of `versions`, as a class id per
-    # version (see `version_classes`): versions share a class when nothing in
-    # the registry can tell them apart. Derived from `conflicts`, and at the
-    # T1 boundary (`pkg_info`) exactly so
-    classes   :: Vector{Int}
 end
 
 PkgInfo(
     versions  :: Vector{V},
+    classes   :: Vector{Int},
     depends   :: Vector{P},
     interacts :: Dict{P,Int},
     conflicts :: BitMatrix,
-) where {P,V} = PkgInfo{P,V}(versions, depends, interacts, conflicts,
-    version_classes(conflicts, length(versions)))
+) where {P,V} = PkgInfo{P,V}(versions, classes, class_members(classes),
+    depends, interacts, conflicts)
 
-# `classes` is a function of `conflicts`, so it is not compared: in-place
-# shrinking (see `drop_unmarked!`) leaves a sound but possibly finer partition
-# than a recomputation would give, and that difference is not a difference of
-# content
+# the number of classes — i.e. of rows of the conflicts matrix
+nclasses(info::PkgInfo) = length(info.members)
+
+"""
+    class_members(classes, m = maximum(classes)) :: Vector{Vector{Int}}
+
+Invert a class-id-per-version vector into a version-index-per-class one. `m` is
+the number of classes, needed only when the last ones might be empty — which
+they never are for a partition, but the argument keeps the inverse total.
+"""
+function class_members(classes::Vector{Int}, m::Int = maximum(classes; init = 0))
+    members = [Int[] for _ = 1:m]
+    for (i, j) in enumerate(classes)
+        push!(members[j], i)
+    end
+    return members
+end
+
+# `members` is the inverse of `classes`, so it is not compared
 function Base.:(==)(a::PkgInfo, b::PkgInfo)
     a.versions  == b.versions  &&
+    a.classes   == b.classes   &&
     a.depends   == b.depends   &&
     a.interacts == b.interacts &&
     a.conflicts == b.conflicts
@@ -49,8 +109,11 @@ the other, and then they are genuinely distinguishable.)
 
 The partition is a property of the registry alone: it is independent of the
 requirements, of the version ordering, and of any user constraints. That is
-what puts it on the T1 side of the boundary, and what lets the collapse to
-class representatives be a per-resolve step (see `class_representatives`).
+what puts it on the T1 side of the boundary, and what lets a `PkgInfo`'s matrix
+be indexed by it: `pkg_info` computes the partition from rows it builds one per
+version, then emits the matrix with one row per class (`collapse_classes!`).
+Choosing which member of a class stands for it is the part that does depend on
+the query, and that is per-resolve state (see `class_ranking`).
 
 The scan is word-parallel over columns: one pass computes, for every adjacent
 pair of versions at once, whether their rows differ anywhere, which yields the
@@ -130,13 +193,89 @@ function version_classes!(ids::Vector{Int}, X::BitMatrix, m::Int)
     return ids
 end
 
-# renumber class ids to 1, 2, … in order of first appearance
-function renumber_classes!(ids::Vector{Int})
-    num = Dict{Int,Int}()
-    for (i, c) in enumerate(ids)
-        ids[i] = get!(() -> length(num) + 1, num, c)
+"""
+    collapse_classes!(info)
+
+The last step of building an artifact. `pkg_info` starts with a row per
+version, because that is what the partition is computed from; this computes it
+(`version_classes`) and rebuilds every matrix with one row per class of the
+package and one column per class of each partner, which is the shape everything
+downstream reads.
+
+The collapse is lossless in both directions. A class's members have identical
+rows by definition, so the class's row *is* any member's row. And members of a
+partner class have identical *columns* here: a conflict is recorded
+symmetrically in both partners' matrices, so partner rows that agree everywhere
+agree in particular about this package, and the columns they index are equal.
+Deleting duplicate columns cannot separate rows that agreed, so the partition
+this indexes is also exactly the partition it was computed from — collapsing
+does not have to be iterated to a fixpoint to be correct, only to be coarsest,
+and coarser is not what is claimed here.
+
+Called once, at the end of `pkg_info`.
+"""
+function collapse_classes!(info::Dict{P,PkgInfo{P,V}}) where {P,V}
+    cls = Dict{P,Vector{Int}}()
+    mem = Dict{P,Vector{Vector{Int}}}()
+    for (p, info_p) in info
+        c = version_classes(info_p.conflicts, length(info_p.versions))
+        cls[p] = c
+        mem[p] = class_members(c)
     end
-    return ids
+    for p in collect(keys(info))
+        info_p = info[p]
+        mem_p = mem[p]
+        m = length(mem_p)
+        # every class of this package and of every partner holds a single
+        # version, so the matrix is already the one this wants: only the
+        # partition has to be recorded
+        if m == length(info_p.versions) && all(
+            length(mem[q]) == length(info[q].versions)
+            for q in keys(info_p.interacts))
+            info[p] = PkgInfo{P,V}(info_p.versions, cls[p], mem_p,
+                info_p.depends, info_p.interacts, info_p.conflicts)
+            continue
+        end
+        # one column per dependency, then one per class of each partner
+        cols = collect(1:length(info_p.depends))
+        interacts = Dict{P,Int}()
+        for (q, b) in sort!(collect(info_p.interacts), by = last)
+            interacts[q] = length(cols)
+            for mem_q in mem[q]
+                push!(cols, b + first(mem_q))
+            end
+        end
+        rows = Int[first(mem_c) for mem_c in mem_p]
+        info[p] = PkgInfo{P,V}(info_p.versions, cls[p], mem_p,
+            info_p.depends, interacts,
+            gather_conflicts(info_p.conflicts, rows, cols))
+    end
+    return info
+end
+
+# `X′[i, j] = X[rows[i], cols[j]]`, in a freshly allocated matrix of the shape
+# `PkgInfo` wants: `length(cols)` conflict columns plus the flag column, all of
+# it marked active
+function gather_conflicts(X::BitMatrix, rows::Vector{Int}, cols::Vector{Int})
+    m = length(rows)
+    n = length(cols)
+    X′ = falses(padded_rows(m), n + 1)
+    W = col_words(X)
+    W′ = col_words(X′)
+    ch = X.chunks
+    ch′ = X′.chunks
+    @inbounds for j = 1:n
+        base = (cols[j] - 1) * W
+        base′ = (j - 1) * W′
+        for i′ = 1:m
+            i = rows[i′]
+            b = (ch[base + ((i - 1) >> 6) + 1] >> ((i - 1) & 63)) & 1
+            ch′[base′ + ((i′ - 1) >> 6) + 1] |= b << ((i′ - 1) & 63)
+        end
+    end
+    X′[1:m, end] .= true
+    X′[m+1, 1:n] .= true
+    return X′
 end
 
 function pkg_data(
@@ -211,19 +350,22 @@ pkg_info(
     pkg_info(data, reqs = all packages; filter = true) :: Dict{P,PkgInfo{P,V}}
 
 The **T1 artifact**: the dependency closure of `reqs`, encoded as one `PkgInfo`
-per package — conflict matrices, plus the
-preprocessing that depends on the registry *alone*, namely the arc-consistency
-prune (`mark_installable!`) and the interchangeability partition
-(`version_classes`). Nothing here depends on the version ordering, on user
-compat or pins, or (beyond the closure) on the requirements, so the result can
-be computed once and shared by, or cached across, arbitrarily many resolves.
+per package — one conflict matrix per package, indexed by its interchangeability
+classes (`version_classes`, `collapse_classes!`) — plus the one piece of
+preprocessing that depends on the registry *alone*: dropping the versions that
+cannot be installed whatever else is chosen, because they depend on a package
+with no installable version at all, applied repeatedly until nothing more drops
+(`mark_installable!`; the literature calls this arc consistency). Nothing here
+depends on the version ordering, on user compat or pins, or (beyond the closure)
+on the requirements, so the result can be computed once and shared by, or cached
+across, arbitrarily many resolves.
 
-`filter = false` skips the arc-consistency prune, leaving the conflict matrices
-exactly as the data spells them out.
+`filter = false` skips that prune, leaving the conflict matrices saying exactly
+what the data spells out.
 
 Requirement-specific and constraint-specific shrinking — reachability and
-redundancy elimination — happens per resolve instead, after the classes have
-been refined and collapsed: see `prepare_pkg_info`.
+redundancy elimination — happens per resolve instead, on the universe the
+query's representatives make of this one: see `prepare_pkg_info`.
 """
 function pkg_info(
     data :: AbstractDict{P,<:PkgData{P,V}},
@@ -362,12 +504,15 @@ function pkg_info(
         end
         offs[pi] = off
         # conflicts matrix: n+1 columns of padded_rows(m) bits each — rows
-        # 1:m are versions, row m+1 holds column-active flags, the rest is
-        # word-alignment padding (always zero); column n+1 holds the
-        # version-active flags
+        # 1:m are the singleton classes the build starts from (so one per
+        # version here), row m+1 holds the columns' in-universe flags, the rest
+        # is word-alignment padding (always zero); column n+1 holds the classes'
+        # in-universe flags. Nothing is ever deactivated in a T1 artifact: that
+        # is the query's business, and it is `Universe.reps` rather than a bit
+        # in here (see BitKernels.jl's header on the two per-class bits)
         m = nver[pi]
         X = falses(padded_rows(m), n + 1)
-        # mark all versions & columns as active; the column flags live at
+        # mark all classes & columns in-universe; the column flags live at
         # a fixed bit of each column's chunk span, so set them directly
         # rather than through one strided BitArray write per column
         X[1:m, end] .= true
@@ -438,36 +583,41 @@ function pkg_info(
         end
     end
 
-    # materialize the package-keyed PkgInfo structures. classes start out as
-    # singletons (always a sound partition) and are computed for real below,
-    # once the prune has settled which versions there are
+    # materialize the package-keyed PkgInfo structures. the build starts at the
+    # finest partition there is — one class per version — so that the matrices
+    # already have the shape the passes below expect, and one row still means
+    # one version, which is what the partition has to be computed from.
+    # `collapse_classes!` computes it and merges the rows
     info = Dict{P,PkgInfo{P,V}}()
     for pi = 1:N
         D = pkgs[depids[pi]]
         T = Dict{P,Int}(
             pkgs[qi] => offs[pi][k]
             for (k, qi) in enumerate(interacts[pi]))
+        m = nver[pi]
         info[pkgs[pi]] = PkgInfo{P,V}(
-            datas[pi].versions, D, T, mats[pi], collect(1:nver[pi]))
+            datas[pi].versions, collect(1:m), [[i] for i = 1:m],
+            D, T, mats[pi])
     end
 
-    # the T1 preprocessing: arc consistency, then interchangeability. Both are
-    # properties of the registry alone — the arc-consistency test deletes
-    # versions one of whose dependencies has no versions at all, which is a
-    # sound approximation of deleting model-free versions and, per the manual's
-    # Theory section, exactly the kind of deletion that is safe for *every*
-    # ordering and requirement set; the classes are row equality. Reachability
-    # and redundancy elimination are not of that kind — both are stated in
-    # terms of the version ordering, and reachability in terms of the
-    # requirements too — so they now run per resolve, in `prepare_pkg_info`.
+    # the T1 preprocessing: the installability prune, then the partition. Both
+    # are properties of the registry alone. The prune deletes versions one of
+    # whose dependencies has no versions at all, repeating until nothing more
+    # goes (the literature calls this arc consistency); that is a sound
+    # approximation of deleting versions no valid solution contains, and, per
+    # the manual's Theory section, exactly the kind of deletion that is safe
+    # for *every* ordering and requirement set. The partition is row equality.
+    # Reachability and redundancy elimination are not of that kind — both are
+    # stated in terms of the version ordering, and reachability in terms of the
+    # requirements too — so they run per resolve, in `prepare_pkg_info`.
+    #
+    # the prune runs first because it can only make the partition coarser:
+    # deleting versions removes rows to distinguish and columns to differ in.
     if filter
         mark_installable!(info)
         drop_unmarked!(info)
     end
-    for info_p in values(info)
-        version_classes!(info_p.classes, info_p.conflicts,
-                         length(info_p.versions))
-    end
+    collapse_classes!(info)
 
     return info
 end

--- a/src/PkgInfoFiles.jl
+++ b/src/PkgInfoFiles.jl
@@ -14,6 +14,10 @@ function save_pkg_info_file(
         for p in pv
             d = info[p]
             write_vals(io, d.versions)
+            # the matrix is indexed by the partition, so the partition has to
+            # be in the file: without it there is no saying which version a row
+            # stands for
+            write_ints(io, d.classes)
             write_vals(io, pm, d.depends)
             write_vals(io, pm, sort!(collect(keys(d.interacts))))
             write_bits(io, d.conflicts)
@@ -40,21 +44,19 @@ function load_pkg_info_file(
         info = Dict{P,PkgInfo{P,V}}()
         for p in pv
             versions  = read_vals(io, V)
+            classes   = read_ints(io)
             depends   = read_vals(io, pv)
             interacts = read_vals(io, pv)
-            conflicts = read_bits(io, padded_rows(length(versions)))
+            conflicts = read_bits(io, padded_rows(maximum(classes; init = 0)))
             interacts = Dict{P, Int}(q => 0 for q in interacts)
-            # the interchangeability classes are a function of the conflicts
-            # matrix, so the file need not carry them: the four-argument
-            # constructor recomputes them
-            info[p] = PkgInfo(versions, depends, interacts, conflicts)
+            info[p] = PkgInfo(versions, classes, depends, interacts, conflicts)
         end
-        # compute interacts dict values
+        # compute interacts dict values: one column block per partner *class*
         for (p, d) in info
             b = length(d.depends)
             for q in sort!(collect(keys(d.interacts)))
                 d.interacts[q] = b
-                b += length(info[q].versions)
+                b += nclasses(info[q])
             end
         end
         return info :: Dict{P,PkgInfo{P,V}} where {P<:P⁺,V<:V⁺}
@@ -63,7 +65,7 @@ end
 
 ## bespoke de/serialization functions ##
 
-const magic = "\xfa\x7d\xe1\0Resolver.jl PkgInfo File\0v2\0"
+const magic = "\xfa\x7d\xe1\0Resolver.jl PkgInfo File\0v3\0"
 
 function write_magic(io::IO)
     write(io, magic)
@@ -101,6 +103,18 @@ function read_int(io::IO, ::Type{T} = Int) where {T<:Integer}
         s += 7
     end
     return n
+end
+
+function write_ints(io::IO, v::Vector{<:Integer})
+    write_int(io, length(v))
+    for x in v
+        write_int(io, x)
+    end
+end
+
+function read_ints(io::IO)
+    n = read_int(io, Int)
+    return Int[read_int(io, Int) for _ = 1:n]
 end
 
 function write_vals(io::IO, v::Vector)

--- a/src/Problem.jl
+++ b/src/Problem.jl
@@ -76,14 +76,22 @@ adopt_kinds(kinds) = isempty(kinds) ? NoKinds :
 is_constrained(prob::Problem) =
     !isempty(prob.compat) || !isempty(prob.pins) || !isempty(prob.excludes)
 
-# The user constraints are read as a *virtual package*: one always-required
-# version, no dependencies, whose conflict rows are exactly the exclusions
-# below. Under that reading a constrained problem is an ordinary resolution
-# problem, so the filtering theorems (see the manual's Theory section) apply
-# verbatim. The implementation special-cases the virtual package as the
-# per-package exclusion masks computed here — one extra degradation trigger in
-# `find_reachable`, one extra conflict column in `mark_necessary!`, and one
-# selector-guarded clause group per constraint source in `SAT`.
+# What a user constraint does, and the only thing it does, is forbid *members*
+# of interchangeability classes. Members are indistinguishable to everything in
+# the registry, so forbidding some of them changes nothing a class can be asked
+# to do — unless it forbids all of them, and then the class is empty and cannot
+# be selected. Nothing of a constraint therefore appears in a conflict matrix.
+# Constraints are evaluated once, here, into the per-version masks below;
+# `class_ranking` turns those into each class's representative; and a class left
+# without one is deactivated in the universe (see `Universe`), which is a single
+# relaxable unit clause in the SAT instance and one degradation trigger in the
+# filter.
+#
+# The consequence worth naming: a constraint cannot make two versions'
+# constraint rows identical, because it does not touch the rows — and versions
+# whose rows *are* identical are one class sharing one column, so there is no
+# pair of separately-deletable objects for a partial relaxation to fall
+# between.
 
 # does the problem forbid version v of package p?
 function is_excluded(prob::Problem{P}, p::P, v) where {P}
@@ -105,27 +113,6 @@ exclusion_candidates(info::AbstractDict{P}, prob::Problem{P}) where {P} =
     isempty(prob.excludes) ?
         union(keys(prob.compat), keys(prob.pins)) : keys(info)
 
-# ... the same set in a deterministic order, for the places that number things
-constrained_packages(info::AbstractDict{P}, prob::Problem{P}) where {P} =
-    sort!(P[p for p in exclusion_candidates(info, prob)])
-
-# The constraints are read as a *virtual package*: one always-required version,
-# no dependencies, whose conflict rows are exactly the exclusions. This lists,
-# per source that says anything about `p`, the kind and a predicate on `p`'s
-# versions — one selector per source, so diagnostics can tell a compat bound, a
-# pin and an admission knob on the same package apart.
-function exclusion_sources(prob::Problem{P}, p::P) where {P}
-    srcs = Pair{Symbol,Any}[]
-    s = get(prob.compat, p, nothing)
-    s === nothing || push!(srcs, :compat => (v -> v ∉ s))
-    w = get(prob.pins, p, nothing)
-    w === nothing || push!(srcs, :pin => (v -> v != w))
-    for (kind, forbids) in prob.excludes
-        push!(srcs, kind => (v -> forbids(p, v)::Bool))
-    end
-    return srcs
-end
-
 """
     exclusion_masks(info, prob) :: AbstractDict{P, BitVector}
 
@@ -134,8 +121,10 @@ that package's version list in `info`. Only packages with a constraint that
 actually excludes something get an entry, so packages nothing constrains — the
 overwhelming majority, absent an admission knob — cost nothing downstream.
 
-Masks are index-based, so they must be recomputed whenever versions are
-dropped and renumbered (see `filter_pkg_info!`).
+This is the only place a constraint is ever evaluated, and what reads it is
+[`class_ranking`](@ref Resolver.class_ranking), which turns it into
+representatives. Masks are index-based, so they are read against the version
+list they were built from.
 """
 function exclusion_masks(
     info :: AbstractDict{P}, # a PkgInfo dict (declared before PkgInfo)

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -1,5 +1,5 @@
 # find the optimal solution determined by the priority ordering `by`:
-# a package => version-index dict, or nothing when the requirements are
+# a package => class-index dict, or nothing when the requirements are
 # not jointly satisfiable
 function resolve_core(
     sat  :: SAT{P},
@@ -23,11 +23,11 @@ function resolve_core(
     # dependencies of the chosen versions that still need optimizing
     function optimize!(opts::Set{P}, seen::Set{P})
         layer = sort!(collect(opts); by)
-        # optimistic joint probe: assume the best version of every
+        # optimistic joint probe: assume the best class of every
         # package in the layer that the current model doesn't already
         # have at its best. when jointly feasible — the common case —
         # one solve pins the whole layer, and joint feasibility of the
-        # best versions witnesses each of the sequential optimizations
+        # best classes witnesses each of the sequential optimizations
         # below, so the layered answer is unchanged. a failed probe
         # tells us nothing and the sequential path proceeds as usual
         # (skipped for a single package, whose own probe covers it)
@@ -40,11 +40,11 @@ function resolve_core(
         end
         for p in layer
             optimize_version!(sat, sol, p)
-            # fix optimized version
+            # fix optimized class
             sat_add(sat, p, sol[p])
             sat_add(sat)
         end
-        # next optimization set: new dependencies of the chosen versions
+        # next optimization set: new dependencies of the chosen classes
         opts′ = empty(opts)
         for p in opts
             info_p = sat.info[p]
@@ -118,7 +118,7 @@ a `SAT` instance. The `SAT` method also accepts `restore::Bool = true`: when
 true the instance's clauses are restored before returning so the instance
 can be reused; `restore = false` is faster for single-use instances.
 
-The other methods accept two more keywords:
+The other methods accept one more keyword:
 
   * `order`: the *version* preference ordering, as a callable mapping a package
     to a `lt` comparator over its versions ("is preferred to"). The default,
@@ -128,10 +128,12 @@ The other methods accept two more keywords:
     the valid solutions rather than changing which ones are valid, so it is a
     parameter here instead of part of the `Problem`, and one artifact serves
     every ordering.
-  * `group::Bool = true`: whether to collapse each package's interchangeable
-    versions to one representative before solving (see `prepare_pkg_info`).
-    Grouping is an optimization and cannot change the answer; `group = false` is
-    the escape hatch that says so.
+
+    The universe is built out of *interchangeability classes* — sets of versions
+    nothing in the registry can tell apart (see
+    [`pkg_info`](@ref Resolver.pkg_info)) — so `order` decides two things: which
+    class the answer picks, and which member of that class it names, namely the
+    best one the query admits.
 """
 function resolve(
     sat  :: SAT{P,V},
@@ -141,17 +143,18 @@ function resolve(
 ) where {P,V}
     sol = resolve_core(sat, reqs; by, restore)
     sol === nothing && return nothing
-    return Dict{P,V}(p => sat.info[p].versions[i] for (p, i) in sol)
+    # a solution names classes; the version each stands for is `reps`
+    return Dict{P,V}(
+        p => sat.info[p].versions[sat.reps[p][i]] for (p, i) in sol)
 end
 
-# resolve a universe that `prepare_pkg_info` has already laid out, collapsed
-# & filtered
+# resolve a universe that `prepare_pkg_info` has already ranked & filtered
 function resolve_prepared(
-    info :: Dict{P,PkgInfo{P,V}},
+    univ :: Universe{P,V},
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
 ) where {P,V}
-    sat = SAT(info, prob)
+    sat = SAT(univ)
     # the instance is single-use, so don't bother restoring its state
     try resolve(sat, prob.reqs; by, restore=false)
     finally
@@ -168,22 +171,20 @@ function resolve(
     deps :: DepsProvider{P},
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
-    group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
 ) where {P}
     info = pkg_info(deps, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob; by)
 end
 
 function resolve(
     data :: AbstractDict{P,<:PkgData{P}},
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
-    group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
 ) where {P}
     info = pkg_info(data, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; group, order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob; by)
 end
 
 # a caller-supplied info may be a reusable (or cached) T1 artifact, so this
@@ -192,10 +193,9 @@ function resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
-    group :: Bool = true, # collapse interchangeable versions
     order = nothing, # version ordering
 ) where {P,V}
-    resolve_prepared(prepare_pkg_info(info, prob; group, order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob; order), prob; by)
 end
 
 # convenience entry points: bare requirements, with the user constraints (if
@@ -207,9 +207,8 @@ resolve(
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
-    group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
-) where {P} = resolve(deps, Problem(reqs; compat, pins); by, group, order)
+) where {P} = resolve(deps, Problem(reqs; compat, pins); by, order)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
@@ -217,9 +216,8 @@ resolve(
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
-    group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
-) where {P} = resolve(data, Problem(reqs; compat, pins); by, group, order)
+) where {P} = resolve(data, Problem(reqs; compat, pins); by, order)
 
 resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},
@@ -227,9 +225,8 @@ resolve(
     compat :: AbstractDict{P} = EmptyDict{P,Any}(),
     pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
     by     :: Function = identity, # package ordering
-    group  :: Bool = true, # collapse interchangeable versions
     order  = nothing, # version ordering
-) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, group, order)
+) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, order)
 
 """
     issatisfiable(data, reqs; compat = ..., pins = ...) -> Bool
@@ -241,9 +238,8 @@ actual solution.
 
 `data` may be a `DepsProvider`, a dict of `PkgData`, a dict of `PkgInfo`, or a
 `SAT` instance, and a `Problem` may be passed in place of the requirements and
-keywords, as with `resolve`. The `by`, `order` and `group` keywords are not
-accepted since they affect which solution `resolve` picks, not whether one
-exists. The `SAT` method leaves the instance unchanged, so it can be reused.
+keywords, as with `resolve`. The `by` and `order` keywords are not accepted
+since they affect which solution `resolve` picks, not whether one exists. The `SAT` method leaves the instance unchanged, so it can be reused.
 """
 function issatisfiable(
     sat  :: SAT{P},
@@ -257,13 +253,12 @@ function issatisfiable(
     return is_satisfiable(sat, reqs)
 end
 
-# check a universe that `prepare_pkg_info` has already laid out, collapsed
-# & filtered
+# check a universe that `prepare_pkg_info` has already ranked & filtered
 function issatisfiable_prepared(
-    info :: Dict{P,PkgInfo{P,V}},
+    univ :: Universe{P,V},
     prob :: Problem{P},
 ) where {P,V}
-    sat = SAT(info, prob)
+    sat = SAT(univ)
     try issatisfiable(sat, prob.reqs)
     finally
         finalize(sat)

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -1,11 +1,15 @@
 mutable struct SAT{P,V}
     info :: Dict{P,PkgInfo{P,V}}
+    # per package, the version index each class stands for (0: deactivated) —
+    # what turns a solution over classes back into one over versions
+    reps :: Dict{P,Vector{Int}}
     pico :: Ptr{Cvoid}
     vars :: Dict{P,Int}
-    # selector variable => the user constraint it guards; internal, for
-    # diagnostics (the constraints are asserted as unit clauses inside a push
-    # frame, so popping it relaxes all of them at once)
-    sels :: Dict{Int,Tuple{Symbol,P}}
+    # the literals forbidding the deactivated classes, sorted; internal.
+    # they are asserted as unit clauses inside a push frame, so one sat_pop
+    # reactivates every class at once — after which any subset of them can be
+    # deactivated again by assumption, no clause rewriting involved
+    deact :: Vector{Int}
 end
 
 function Base.show(io::IO, sat::SAT)
@@ -15,15 +19,21 @@ function Base.show(io::IO, sat::SAT)
     c = PicoSAT.clause_count(sat.pico)
     print(io,
         "(packages: ", p,
-        ", versions: ", v-p,
+        ", classes: ", v-p,
         ", clauses: ", c, ")")
 end
 
 # variable indices:
 #   p     vars[p]     package p chosen
-#   p@i   vars[p]+i   version i of p chosen
-#   p@≤k  lads[p]+k   some version ≤ k of p chosen (prefix ladder,
-#                     only for packages with several versions)
+#   p@c   vars[p]+c   class c of p chosen
+#   p@≤k  lads[p]+k   some class ≤ k of p chosen (prefix ladder,
+#                     only for packages with several classes)
+#
+# A variable is a *class*, not a version: class members are indistinguishable
+# to everything in the registry, so no solution can depend on which member
+# stands for a class, and the instance is the smaller for it. `sat.reps` names
+# the member at the end.
+#
 # returns the (sorted) names, the two index maps, and the last used variable
 function sat_variables(
     info :: Dict{P, <: PkgInfo{P}},
@@ -35,9 +45,9 @@ function sat_variables(
     lads = Dict{P,Int}()
     for p in names
         vars[p] = N
-        n_p = length(info[p].versions)
+        n_p = nclasses(info[p])
         # 1 variable for package
-        # n_p variables for versions
+        # n_p variables for classes
         N += 1 + n_p
         if n_p ≥ 2
             # n_p prefix-ladder variables at lads[p]+1 : lads[p]+n_p
@@ -48,8 +58,8 @@ function sat_variables(
     return names, vars, lads, N - 1
 end
 
-# append the literals for "no version in lo:hi of the package
-# with variable base v, ladder base l, and n versions is chosen"
+# append the literals for "no class in lo:hi of the package
+# with variable base v, ladder base l, and n classes is chosen"
 function run_lits!(lits::Vector{Int}, v::Int, l::Int, lo::Int, hi::Int, n::Int)
     if lo == hi
         push!(lits, -(v + lo))
@@ -64,8 +74,9 @@ function run_lits!(lits::Vector{Int}, v::Int, l::Int, lo::Int, hi::Int, n::Int)
 end
 
 function SAT(
-    info :: Dict{P,PkgInfo{P,V}},
+    univ :: Universe{P,V},
 ) where {P,V}
+    info = univ.info
     names, vars, lads, N = sat_variables(info)
 
     # instantiate picosat solver
@@ -78,9 +89,9 @@ function SAT(
         # fewer spuriously-true packages ("junk"), which makes solves
         # faster and improvement steps land on better versions
         PicoSAT.set_global_default_phase(pico, 0)
-        # ... except each package's best version, which defaults to
+        # ... except each package's best class, which defaults to
         # true: when a package must be chosen the solver tries its best
-        # version first, so models land at or near the optimum and the
+        # class first, so models land at or near the optimum and the
         # descent's improvement loops mostly never need to run
         for v_p in values(vars)
             PicoSAT.set_default_phase_lit(pico, v_p + 1, 1)
@@ -89,10 +100,10 @@ function SAT(
         # generate SAT problem
         for p in names
             info_p = info[p]
-            n_p = length(info_p.versions)
+            n_p = nclasses(info_p)
             v_p = vars[p]
 
-            # package implies some version
+            # package implies some class
             #   p => OR_i p@i
             PicoSAT.add(pico, -v_p)
             for i = 1:n_p
@@ -100,7 +111,7 @@ function SAT(
             end
             PicoSAT.add(pico, 0)
 
-            # version implies its package
+            # class implies its package
             #   p@i => p
             for i = 1:n_p
                 PicoSAT.add(pico, -(v_p + i))
@@ -108,11 +119,11 @@ function SAT(
                 PicoSAT.add(pico, 0)
             end
 
-            # prefix ladder: L_k holds iff some version ≤ k is chosen.
-            # the two upward directions make chosen versions force their
+            # prefix ladder: L_k holds iff some class ≤ k is chosen.
+            # the two upward directions make chosen classes force their
             # ladder suffix true; the completion direction, together with
             # at-most-one below, forces the ladder prefix *below* the
-            # chosen version false — which the interval conflict literals
+            # chosen class false — which the interval conflict literals
             # rely on when they occur positively
             if n_p ≥ 2
                 l_p = lads[p]
@@ -138,8 +149,8 @@ function SAT(
                     PicoSAT.add(pico, l_p + k - 1)
                     PicoSAT.add(pico, 0)
                 end
-                # versions are mutually exclusive:
-                #   p@k => no version < k (linear via the ladder)
+                # classes are mutually exclusive:
+                #   p@k => no class < k (linear via the ladder)
                 for k = 2:n_p
                     PicoSAT.add(pico, -(v_p + k))
                     PicoSAT.add(pico, -(l_p + k - 1))
@@ -147,10 +158,10 @@ function SAT(
                 end
             end
 
-            # dependencies, one clause per maximal run of versions
+            # dependencies, one clause per maximal run of classes
             # sharing the dependency (dep sets change rarely across
             # versions, so runs are long):
-            #   (some version in run chosen) => q
+            #   (some class in run chosen) => q
             l_p = get(lads, p, 0)
             for (k, q) in enumerate(info_p.depends)
                 v_q = vars[q]
@@ -177,26 +188,26 @@ function SAT(
         end
 
         # conflicts, encoded as rectangles: within each interacting pair's
-        # conflict bitmap, group p's versions by their conflict pattern
+        # conflict bitmap, group p's classes by their conflict pattern
         # against q (identical patterns are the norm, since conflicts come
         # from shared compat entries) and split each pattern into maximal
-        # runs of q's versions. each (version group) × (run) rectangle
-        # becomes one clause forbidding "some version in the group chosen
-        # AND some version in the run chosen". a side contributes its
-        # version literal when it is a singleton, its package variable
-        # when every version is covered, prefix-ladder literals when it
+        # runs of q's classes. each (class group) × (run) rectangle
+        # becomes one clause forbidding "some class in the group chosen
+        # AND some class in the run chosen". a side contributes its
+        # class literal when it is a singleton, its package variable
+        # when every class is covered, prefix-ladder literals when it
         # is an interval — ¬L_hi ∨ L_(lo-1), correct because a chosen
-        # version in the interval forces L_hi true and (by at-most-one
+        # class in the interval forces L_hi true and (by at-most-one
         # plus ladder completion) L_(lo-1) false — and otherwise a shared
-        # auxiliary trigger defined by one implication per version.
+        # auxiliary trigger defined by one implication per class.
         # triggers occur only negatively, so their one-directional
         # definitions suffice for exact model projection.
-        psets = Dict{Tuple{Int,Vector{Int}},Int}() # (v_p, versions) => var
+        psets = Dict{Tuple{Int,Vector{Int}},Int}() # (v_p, classes) => var
         pat = UInt64[]
         runs = Tuple{Int,Int}[]
 
-        # literal for "some version in S of the package with variable
-        # base v and n versions is chosen" (non-contiguous S only)
+        # literal for "some class in S of the package with variable
+        # base v and n classes is chosen" (non-contiguous S only)
         function set_trigger(v::Int, S::Vector{Int})
             get!(() -> begin
                 t = PicoSAT.inc_max_var(pico)
@@ -211,20 +222,20 @@ function SAT(
 
         for p in names
             info_p = info[p]
-            n_p = length(info_p.versions)
+            n_p = nclasses(info_p)
             v_p = vars[p]
             l_p = get(lads, p, 0)
             for (q, b) in info_p.interacts
                 p < q || continue # conflicts are symmetrical
                 info_q = info[q]
-                n_q = length(info_q.versions)
+                n_q = nclasses(info_q)
                 v_q = vars[q]
                 l_q = get(lads, q, 0)
                 Y = info_q.conflicts
                 c = info_q.interacts[p]
                 W = col_words(Y)
                 resize!(pat, W)
-                # group p's versions by conflict pattern: the pattern of
+                # group p's classes by conflict pattern: the pattern of
                 # p@i is the contiguous column c+i of q's matrix
                 groups = Dict{Vector{UInt64},Vector{Int}}()
                 for i = 1:n_p
@@ -274,28 +285,8 @@ function SAT(
         PicoSAT.reset(pico)
         rethrow()
     end
-    finalizer(finalize, SAT(info, pico, vars, Dict{Int,Tuple{Symbol,P}}()))
-end
-
-# the structural SAT instance for `info`, plus `prob`'s constraints as
-# selector-guarded exclusion clauses: for each constraint source that forbids a
-# kept version — one per compat entry, one per pin, one per admission kind and
-# package — a fresh selector variable `s` and one clause `(¬s, "no version in
-# run")` per maximal run of forbidden versions. the selectors are then asserted
-# as unit clauses inside a sat_push frame, so production solves see them at
-# level 0 (no assumptions), while a single sat_pop relaxes every constraint at
-# once. nothing pops the frame in production; the frame exists so diagnostics
-# can.
-#
-# constraints on packages absent from `info`, constraints that forbid nothing,
-# and constraints that forbid only versions the filter already dropped emit no
-# selector and no clauses — with none at all the instance is exactly SAT(info)
-function SAT(
-    info :: Dict{P,PkgInfo{P,V}},
-    prob :: Problem{P},
-) where {P,V}
-    sat = SAT(info)
-    try add_exclusions!(sat, prob)
+    sat = finalizer(finalize, SAT(info, univ.reps, pico, vars, Int[]))
+    try deactivate_classes!(sat)
     catch
         finalize(sat)
         rethrow()
@@ -303,74 +294,51 @@ function SAT(
     return sat
 end
 
-function add_exclusions!(
-    sat  :: SAT{P,V},
-    prob :: Problem{P},
-) where {P,V}
-    is_constrained(prob) || return sat
-    info = sat.info
+# the structural instance for a bare artifact: every class stands for its best
+# member and nothing is deactivated, which is what an unconstrained query makes
+# of it (see `Universe`)
+SAT(info :: Dict{P,PkgInfo{P,V}}) where {P,V} = SAT(Universe(info))
+
+# Forbid the deactivated classes — the ones this query admits no member of.
+#
+# This is the *whole* of how a user constraint reaches the solver. It never
+# forbids a version, because a version is not something the instance can talk
+# about: the members of a class are indistinguishable, so a constraint that
+# spares one of them has left the class choosable and there is nothing to say.
+# What it can do is empty a class, and an empty class is one unit clause.
+#
+# The clauses go in a push frame of their own, so production solves see them at
+# level 0 (no assumptions) while a single `sat_pop` reactivates every class at
+# once — after which any subset can be deactivated again by assuming its
+# literal, with no clause rewritten. Nothing pops the frame in production; the
+# frame exists so that what is built on top of this can.
+function deactivate_classes!(sat::SAT{P,V}) where {P,V}
     pico = sat.pico
-    _, vars, lads = sat_variables(info)
-    lits = Int[]
-    mask = BitVector()
-    for p in constrained_packages(info, prob)
-        haskey(info, p) || continue # constraint on an absent package
-        vers = info[p].versions
-        n_p = length(vers)
-        n_p > 0 || continue # nothing to forbid, and no version variables
-        v_p = vars[p]
-        l_p = get(lads, p, 0)
-        resize!(mask, n_p)
-        # one selector per constraint source (see `exclusion_sources`), so
-        # diagnostics can tell a compat bound, a pin and an admission knob on
-        # the same package apart
-        for (kind, forbids) in exclusion_sources(prob, p)
-            fill!(mask, false)
-            found = false
-            for (i, v) in enumerate(vers)
-                forbids(v) || continue
-                mask[i] = true
-                found = true
-            end
-            found || continue # nothing left to forbid
-            sel = PicoSAT.inc_max_var(pico)
-            sat.sels[sel] = (kind, p)
-            # one clause per maximal run of forbidden versions, via the
-            # prefix ladder (same interval encoding as conflicts)
-            i = 1
-            while i ≤ n_p
-                if mask[i]
-                    lo = i
-                    while i < n_p && mask[i + 1]
-                        i += 1
-                    end
-                    empty!(lits)
-                    push!(lits, -sel)
-                    run_lits!(lits, v_p, l_p, lo, i, n_p)
-                    for x in lits
-                        PicoSAT.add(pico, x)
-                    end
-                    PicoSAT.add(pico, 0)
-                end
-                i += 1
+    for (p, reps_p) in sat.reps
+        v_p = sat.vars[p]
+        best = 0
+        for (i, r) in enumerate(reps_p)
+            if iszero(r)
+                push!(sat.deact, -(v_p + i))
+            elseif best == 0
+                best = i
             end
         end
-        # the structural instance defaults every package's best version to
-        # true, so that a package that must be chosen is tried at its best
-        # version first. when the user forbids that version, point the phase
-        # at the best version they do allow instead — otherwise the solver's
-        # first guess is infeasible for every constrained package at once
-        i = findfirst(v -> !is_excluded(prob, p, v), vers)
-        if i ≠ 1
+        # the structural instance defaults every package's best class to true,
+        # so that a package that must be chosen is tried at its best class
+        # first. when this query has emptied that class, point the phase at the
+        # best class it does admit instead — otherwise the solver's first guess
+        # is infeasible for every such package at once
+        if best != 1
             PicoSAT.set_default_phase_lit(pico, v_p + 1, 0)
-            isnothing(i) || PicoSAT.set_default_phase_lit(pico, v_p + i, 1)
+            best == 0 || PicoSAT.set_default_phase_lit(pico, v_p + best, 1)
         end
     end
-    # assert the selectors in a push frame of their own
-    isempty(sat.sels) && return sat
+    isempty(sat.deact) && return sat
+    sort!(sat.deact; by = abs) # dict order must not reach the solver
     sat_push(sat)
-    for sel in sort!(collect(keys(sat.sels)))
-        PicoSAT.add(pico, sel)
+    for l in sat.deact
+        PicoSAT.add(pico, l)
         PicoSAT.add(pico, 0)
     end
     return sat
@@ -411,7 +379,7 @@ end
 
 const is_unsatisfiable = !is_satisfiable
 
-# iterate the current solution's package => version-index assignments by
+# iterate the current solution's package => class-index assignments by
 # dereferencing the solver's assignment without re-solving: only valid right
 # after a solve that returned satisfiable, with no clauses added since --
 # ensuring that is the caller's responsibility
@@ -446,7 +414,7 @@ function solution(sat::SAT{P,V}) where {P,V}
     sol = Dict{P,V}()
     is_satisfiable(sat) || return sol
     each_solution_index(sat) do p, i
-        sol[p] = sat.info[p].versions[i]
+        sol[p] = sat.info[p].versions[sat.reps[p][i]]
     end
     return sol
 end
@@ -462,15 +430,15 @@ function with_temp_clauses(body::Function, sat::SAT)
     end
 end
 
-# improve package p to its best feasible version: repeatedly demand some
-# strictly better version until that becomes unsatisfiable, keeping the last
+# improve package p to its best feasible class: repeatedly demand some
+# strictly better class until that becomes unsatisfiable, keeping the last
 # good model in sol
 function optimize_version!(
     sat :: SAT{P},
     sol :: Dict{P,Int},
     p   :: P,
 ) where {P}
-    # cheap first try: after filtering, the best version is feasible more
+    # cheap first try: after filtering, the best class is feasible more
     # often than not, and probing it by assumption needs no temp clauses
     # at all — one solve replaces the whole improvement loop
     if sol[p] > 1
@@ -484,7 +452,7 @@ function optimize_version!(
     # empty, forcing a guaranteed-UNSAT solve
     while sol[p] > 1
         improved = with_temp_clauses(sat) do
-            # some strictly better version of p
+            # some strictly better class of p
             for i = 1:sol[p]-1
                 sat_add(sat, p, i)
             end
@@ -497,7 +465,9 @@ function optimize_version!(
     end
 end
 
-# fix a given set of versions
+# fix a given set of versions — as the classes that hold them, which is all
+# the instance can express (and all that is needed: a version's class is
+# interchangeable with it)
 
 function fix_versions(
     sat  :: SAT{P,V},
@@ -506,9 +476,10 @@ function fix_versions(
 ) where {P,V}
     for (p, v) in zip(pkgs, vers)
         v === nothing && continue
-        i = findfirst(==(v), sat.info[p].versions)
+        info_p = sat.info[p]
+        i = findfirst(==(v), info_p.versions)
         i === nothing && throw(ArgumentError("package $p: unknown version $v"))
-        sat_add(sat, p, i)
+        sat_add(sat, p, info_p.classes[i])
         sat_add(sat)
     end
 end

--- a/test/class_space.jl
+++ b/test/class_space.jl
@@ -1,0 +1,371 @@
+# The three preconditions the representation has to meet, and the primitives
+# they exist for.
+#
+# The partition itself is tested in classes.jl, and the answers it produces are
+# tested against the brute force everywhere. What is checked here is the shape
+# of the representation — the properties that make a *relaxation* of a user
+# constraint a well-posed question, which is why this lands before the
+# diagnostics that will ask one:
+#
+#   1. user constraints never enter the matrices;
+#   2. deactivated classes are retained as pressure-treated columns
+#      (reachability continues past one, the packages behind one stay, and
+#      redundancy never deletes one);
+#   3. domination is an activation-independent test.
+#
+# Nothing here is a diagnostic. The last testsets exercise the raw primitives —
+# flipping a class's activation by assumption, and probing what a reactivated
+# class finds waiting for it — as operations on a built instance.
+
+using Resolver: PkgData, PkgInfo, Problem, SAT, PicoSAT, pkg_info, nclasses,
+    rank_pkg_info, prepare_pkg_info, filter_pkg_info!, deactivations,
+    mark_installable!, mark_necessary!, class_ranking, finalize,
+    sat_assume, sat_pop, is_satisfiable, NoKinds
+
+const NODEPS = Dict{Symbol,Vector{Symbol}}()
+const NOCOMP = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+
+# A class named by what it holds rather than by where it sits: the set of
+# version *values* of its members. Class ids are per-query (the rank order is),
+# so this is how two universes over one artifact are compared.
+class_key(univ, p, c) =
+    (p, Set(univ.info[p].versions[i] for i in univ.info[p].members[c]))
+
+all_classes(univ) = Set{Any}(
+    class_key(univ, p, c) for (p, ip) in univ.info for c = 1:nclasses(ip))
+
+# the classes a filtering pass has struck from the universe (flag cleared)
+struck(univ) = Set{Any}(
+    class_key(univ, p, c)
+    for (p, ip) in univ.info for c = 1:nclasses(ip) if !ip.conflicts[c, end])
+
+# the classes this query has emptied
+emptied(univ) = Set{Any}(
+    class_key(univ, p, c)
+    for (p, rs) in univ.reps for c in eachindex(rs) if iszero(rs[c]))
+
+# every fact the matrices state, named so that the class *order* cannot show
+# through: which classes there are, what each depends on, and which pairs
+# conflict
+function universe_facts(univ)
+    facts = Set{Any}()
+    for (p, ip) in univ.info
+        for c = 1:nclasses(ip)
+            key = class_key(univ, p, c)
+            push!(facts, (:class, key))
+            for (j, q) in enumerate(ip.depends)
+                ip.conflicts[c, j] && push!(facts, (:depends, key, q))
+            end
+            for (q, b) in ip.interacts
+                for d = 1:nclasses(univ.info[q])
+                    ip.conflicts[c, b + d] || continue
+                    push!(facts, (:conflict, key, class_key(univ, q, d)))
+                end
+            end
+        end
+    end
+    return facts
+end
+
+# the redundancy pass on its own, on an unfiltered universe: the
+# installability prune first (it is what makes the deletions safe), then
+# domination
+function redundancy_only(info, prob)
+    univ = rank_pkg_info(info, prob)
+    mark_installable!(univ.info)
+    mark_necessary!(univ.info, deactivations(univ))
+    return univ
+end
+
+@testset "precondition 1: no user constraint reaches a matrix" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # A constrained query and an unconstrained one make the same universe out
+    # of an artifact, up to the class order the representatives put the rows
+    # in: the same partition, the same rows and columns, the same conflicts.
+    # Everything the constraint does is in `reps`.
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:25
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            info = pkg_info(data, keys(data); filter = false)
+            base = rank_pkg_info(info, Problem(reqs))
+            facts = universe_facts(base)
+            @test isempty(emptied(base)) # nothing constrains, nothing is empty
+            for cs = 1:4
+                compat, pins = random_constraints(m, n)
+                kinds = [:test => (p, v) -> v == rand(1:n)]
+                prob = Problem(reqs; compat, pins,
+                               excludes = iseven(cs) ? kinds : NoKinds)
+                univ = rank_pkg_info(info, prob)
+                # the partition is not refined: same classes, same members
+                @test all_classes(univ) == all_classes(base)
+                @test universe_facts(univ) == facts
+                # ... and no column has appeared to carry the constraint
+                @test all(size(univ.info[p].conflicts) ==
+                          size(base.info[p].conflicts) for p in keys(info))
+            end
+        end
+    end
+end
+
+@testset "precondition 2a: reachability continues past a dead class" begin
+    # :P's best class is emptied by the user's compat. Stopping the prefix there
+    # would keep only a class that cannot be selected, and :P would look
+    # uninstallable — when in fact it resolves at its next class.
+    data = Dict(
+        :P => PkgData([:v2, :v1], Dict(:v2 => [:Q]), NOCOMP),
+        :Q => PkgData([:w1], NODEPS, NOCOMP),
+    )
+    prob = Problem([:P]; compat = Dict(:P => [:v1]))
+    @test resolve(data, prob) == Dict(:P => :v1)
+    univ = prepare_pkg_info(pkg_info(data, prob), prob)
+    # both classes survive, the first of them deactivated
+    @test nclasses(univ.info[:P]) == 2
+    @test univ.reps[:P] == [0, 2]
+
+    # precondition 2b, on the same universe: :Q is depended on by nothing but
+    # the deactivated class, and it is in the universe all the same — it is
+    # exactly the cone a relaxation of that compat would have to find waiting
+    @test haskey(univ.info, :Q)
+    @test nclasses(univ.info[:Q]) == 1
+end
+
+@testset "precondition 2c: redundancy never deletes a dead class" begin
+    # :P's classes are {:v3, :v1} (no constraints at all) and {:v2} (conflicts
+    # with :Q@:w2), so the first dominates the second outright. Two different
+    # sources empty them: the compat bound takes the dominator, an admission
+    # kind takes the dominated one. Deleting the dominated class for being
+    # dominated would make relaxing the kind alone unanswerable, because the
+    # class it would return is the one that was deleted.
+    data = Dict(
+        :P => PkgData([:v3, :v2, :v1], NODEPS, Dict(:v2 => Dict(:Q => [:w1]))),
+        :Q => PkgData([:w2, :w1], NODEPS, NOCOMP),
+    )
+    info = pkg_info(data, [:P, :Q]; filter = false)
+    @test info[:P].members == [[1, 3], [2]]
+    prob = Problem([:P, :Q];
+        compat = Dict(:P => [:v2]),                 # empties {:v3, :v1}
+        excludes = [:pre => (p, v) -> v == :v2])    # empties {:v2}
+    univ = prepare_pkg_info(pkg_info(data, prob), prob)
+    @test nclasses(univ.info[:P]) == 2
+    @test univ.reps[:P] == [0, 0]
+    @test emptied(univ) == Set([class_key(univ, :P, 1), class_key(univ, :P, 2)])
+
+    sat = SAT(univ)
+    try
+        @test !is_satisfiable(sat, [:P])
+        # relax everything, then re-deactivate only what the compat emptied:
+        # the class the *kind* emptied is still there to be returned
+        sat_pop(sat)
+        sat_assume(sat, :P, 1; not = true)
+        @test is_satisfiable(sat, [:P])
+        @test PicoSAT.deref(sat.pico, sat.vars[:P] + 2) > 0
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "precondition 2c: swept" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # Two properties of the redundancy pass, over the tiny grids with random
+    # constraints on top.
+    #
+    # First, unconditionally: it never strikes a class this query has emptied.
+    # That is precondition 2's third obligation, and it holds whatever the
+    # query is.
+    #
+    # Second, for the queries that leave the class order alone: everything the
+    # pass strikes it would have struck with no constraints at all. This is the
+    # general form of "no deletion rests on anything a relaxation can change",
+    # and it is stated for the unreordered queries because the class *order* is
+    # the one thing about a universe that a constraint legitimately does move
+    # (§3: a class competes at its best admissible member, so forbidding that
+    # member can put the class behind one it otherwise outranks), and domination
+    # is a statement about the order — "the better class will be chosen
+    # instead". A reordering query can therefore license a deletion the
+    # unconstrained order does not, which is sound for the query it was
+    # computed for and is what the resolve path needs; whether it is enough for
+    # a later relaxation is a question about relaxation, not about this pass.
+    protected = reordered = 0
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2), (2, 5))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:25
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            info = pkg_info(data, keys(data); filter = false)
+            base = struck(redundancy_only(info, Problem(reqs)))
+            for _ = 1:4
+                compat, pins = random_constraints(m, n)
+                prob = Problem(reqs; compat, pins)
+                univ = redundancy_only(info, prob)
+                gone = struck(univ)
+                @test isempty(gone ∩ emptied(univ))
+                protected += length(emptied(univ) ∩ base)
+                if last(class_ranking(info, prob)) === nothing
+                    @test gone ⊆ base
+                else
+                    reordered += 1
+                end
+            end
+        end
+    end
+    # the sweep really did keep classes the unconstrained pass would strike ...
+    @test protected > 0
+    # ... and really did exercise both branches
+    @test reordered > 0
+end
+
+@testset "precondition 3: domination ignores activation" begin
+    # :P's best class conflicts with :Q@:w2 and its second has no constraints
+    # at all, so ignoring that one conflict — and only then — would make the
+    # first class's row a subset of the second's and delete the second. The
+    # query empties :Q's {:w2} class, and the conflict counts all the same,
+    # because what domination compares is the registry's rows and an emptied
+    # class is still a class. Were it not so, relaxing the compat on :Q would
+    # reactivate {:w2}, need :P@:v1, and find it deleted.
+    data = Dict(
+        :P => PkgData([:v2, :v1], NODEPS, Dict(:v2 => Dict(:Q => [:w1]))),
+        :Q => PkgData([:w2, :w1], NODEPS, NOCOMP),
+    )
+    info = pkg_info(data, [:P, :Q]; filter = false)
+    @test nclasses(info[:P]) == nclasses(info[:Q]) == 2
+
+    prob = Problem([:P, :Q]; compat = Dict(:Q => [:w1]))
+    univ = redundancy_only(info, prob)
+    @test univ.reps[:Q] == [0, 2]
+    @test isempty(struck(univ)) # :P's second class is not dominated
+
+    # the unconstrained universe reaches the same verdict, which is the
+    # property: the pass cannot tell the two queries apart
+    @test struck(univ) == struck(redundancy_only(info, Problem([:P, :Q])))
+
+    # and the end-to-end consequence: the class is still there to be reached
+    # once the constraint that emptied its partner is relaxed
+    full = prepare_pkg_info(pkg_info(data, prob), prob)
+    sat = SAT(full)
+    try
+        # under the constraint, :Q is at :w1 and :P at its best
+        @test is_satisfiable(sat, [:P, :Q])
+        sat_pop(sat)
+        # relaxed, :Q@:w2 is choosable — and :P has a class that admits it
+        sat_assume(sat, :Q, 1)
+        @test is_satisfiable(sat, [:P, :Q])
+        @test PicoSAT.deref(sat.pico, sat.vars[:P] + 2) > 0
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "fitness: activation flips by assumption" begin
+    # A class's activation literal is the negation of its class variable, so
+    # flipping it is an assumption and nothing else: no clause is added, no
+    # clause is rewritten, and the instance is exactly as reusable afterwards.
+    data = Dict(
+        :P => PkgData([:v3, :v2, :v1], NODEPS, NOCOMP),
+        :Q => PkgData([:w1], Dict(:w1 => [:P]), Dict(:w1 => Dict(:P => [:v2]))),
+    )
+    info = pkg_info(data, [:Q])
+    univ = prepare_pkg_info(info, Problem([:Q]))
+    sat = SAT(univ)
+    try
+        clauses = PicoSAT.clause_count(sat.pico)
+        @test isempty(sat.deact) # nothing is deactivated to begin with
+        @test is_satisfiable(sat, [:Q])
+        # :Q needs :P at the class holding :v2; deactivating that class by
+        # assumption makes the requirement unsatisfiable ...
+        c = univ.info[:P].classes[findfirst(==(:v2), univ.info[:P].versions)]
+        sat_assume(sat, :P, c; not = true)
+        @test !is_satisfiable(sat, [:Q])
+        # ... and the very next solve sees it active again, on an instance with
+        # exactly the clauses it started with
+        @test is_satisfiable(sat, [:Q])
+        @test PicoSAT.clause_count(sat.pico) == clauses
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "fitness: the D1′ shape is unrepresentable" begin
+    # Proposition D1′'s counterexample shape: a compat bound and a pin that
+    # between them forbid both versions of a package, where relaxing one of the
+    # two sources ought to bring one version back. What made a partial
+    # relaxation unsound in version space was that the constraints entered the
+    # rows, could make the two versions row-identical, and redundancy
+    # elimination could then delete the one the relaxation needed.
+    #
+    # Here the constraints are not rows, and versions with identical registry
+    # rows are one class sharing one column. There is no pair of separately
+    # deletable objects for a partial relaxation to fall between.
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), NOCOMP),
+        :B => PkgData([:w1], NODEPS, NOCOMP),
+    )
+    prob = Problem([:A]; compat = Dict(:A => [:v1]), pins = Dict(:A => :v2))
+    info = pkg_info(data, prob)
+    # nothing in the registry tells :v2 and :v1 apart, so they are one class
+    @test info[:A].classes == [1, 1]
+    @test info[:A].members == [[1, 2]]
+    @test nclasses(info[:A]) == 1
+    # the two sources empty that one class between them
+    univ = rank_pkg_info(info, prob)
+    @test univ.reps[:A] == [0]
+    @test resolve(data, prob) === nothing
+
+    # relaxing either source reactivates the same single class — there is no
+    # "half" of this constraint set to be unsound about, and nothing that could
+    # have been deleted for being dominated by the other half
+    for (relaxed, want) in ((Problem([:A]; pins = Dict(:A => :v2)), :v2),
+                            (Problem([:A]; compat = Dict(:A => [:v1])), :v1))
+        u = rank_pkg_info(info, relaxed)
+        @test nclasses(u.info[:A]) == 1
+        @test u.info[:A].members == [[1, 2]]
+        @test u.reps[:A] != [0]
+        @test resolve(data, relaxed) == Dict(:A => want, :B => :w1)
+    end
+
+    # the same in the SAT instance: one variable, one deactivating clause, and
+    # popping the frame is the whole relaxation
+    sat = SAT(univ)
+    try
+        @test sat.deact == [-(sat.vars[:A] + 1)]
+        @test !is_satisfiable(sat, [:A])
+        sat_pop(sat)
+        @test is_satisfiable(sat, [:A])
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "fitness: a reactivated class finds its cone" begin
+    # Precondition 2b end to end. :P@:v2 is the only thing in the registry that
+    # depends on :R, and the query's compat empties the class holding it. The
+    # universe still has to carry :R — otherwise "what if that compat were
+    # relaxed?" reactivates a class into a universe with nothing to satisfy it.
+    data = Dict(
+        :P => PkgData([:v2, :v1], Dict(:v2 => [:R]), NOCOMP),
+        :R => PkgData([:s2, :s1], NODEPS, NOCOMP),
+    )
+    prob = Problem([:P]; compat = Dict(:P => [:v1]))
+    univ = prepare_pkg_info(pkg_info(data, prob), prob)
+    @test univ.reps[:P] == [0, 2]
+    @test haskey(univ.info, :R)
+
+    sat = SAT(univ)
+    try
+        # :R has a variable of its own, and the dependency clause is there
+        @test haskey(sat.vars, :R)
+        @test is_satisfiable(sat, [:P])
+        # ... and :P's first class, the only thing that needs it, is out
+        sat_assume(sat, :P, 1)
+        @test !is_satisfiable(sat)
+        # reactivate, and the cone is right there: choosing :P's first class
+        # forces :R in
+        sat_pop(sat)
+        sat_assume(sat, :P, 1)
+        @test is_satisfiable(sat)
+        @test PicoSAT.deref(sat.pico, sat.vars[:R]) > 0
+    finally
+        finalize(sat)
+    end
+end

--- a/test/classes.jl
+++ b/test/classes.jl
@@ -9,13 +9,17 @@
 #     package's, constrains the two versions equally) — a completely different
 #     computation from the bit-matrix row scan it checks;
 #
-#   * for the *collapse*, the ungrouped resolve. Grouping is an optimization,
-#     so `resolve(…; group = true)` and `resolve(…; group = false)` must return
-#     the very same answer — and the very same `nothing` — everywhere,
-#     including where user constraints split classes.
+#   * for the *answer*, the brute force. Classes are the representation now, so
+#     there is no ungrouped resolve to compare against: what the collapse has to
+#     agree with is the universe itself. Every constrained resolve is checked
+#     against the resolve of the *baked* data — the registry with the forbidden
+#     versions deleted, which is what a constraint says — and, where the
+#     enumeration is affordable, against `ref_resolve` on that data, which knows
+#     nothing about matrices, classes or representatives at all.
 
 using Resolver: PkgData, PkgInfo, DepsProvider, Problem, pkg_info, pkg_data,
-    version_classes, class_representatives, prepare_pkg_info, is_excluded
+    version_classes, class_ranking, prepare_pkg_info, rank_pkg_info,
+    is_excluded, nclasses
 using .TestResolver: each_potential_solution, is_valid_solution
 
 # the class partition of package p, as a set of sets of version *values*
@@ -110,15 +114,27 @@ function test_class_swaps(data)
     @test bad === nothing
 end
 
-# grouping cannot change the answer, whatever the constraints or the ordering
-function test_collapse_invariance(data, prob; by::Function = identity)
-    @test resolve(data, prob; by, group = true) ==
-          resolve(data, prob; by, group = false)
+# The answer is the universe's answer, whatever the constraints or the
+# ordering. Two oracles, neither of which knows how the universe is
+# represented: the same problem with the forbidden versions deleted from the
+# data outright (a *different* registry, hence a different partition, resolved
+# with no deactivation anywhere), and — when the potential solutions are few
+# enough to enumerate — the brute force on that data.
+const REF⁺ = 256 # enumeration budget for the brute-force cross-check
+
+function test_class_space(data, prob; by::Function = identity)
+    baked = bake(data, prob)
+    sol = resolve(data, prob; by)
+    @test sol == resolve(baked, prob.reqs; by)
+    @test issatisfiable(data, prob) == (sol !== nothing)
+    Π = prod(init = 1.0, float(length(d.versions) + 1) for d in values(baked))
+    Π ≤ REF⁺ && @test sol == ref_resolve(baked, prob.reqs; by)
 end
 
-# the constraints that split classes: forbid exactly one member of a
-# multi-member class, or pin one member of it
-function class_splitting_problems(data, reqs)
+# the constraints that bear on multi-member classes: forbid exactly one member
+# of one, or pin one member of it. Neither can split the class — that is the
+# point — so each is a test that a class survives through the members left
+function class_emptying_problems(data, reqs)
     info = pkg_info(data, keys(data); filter = false)
     probs = []
     for p in sort!(collect(keys(data)))
@@ -175,14 +191,20 @@ end
     info = test_classes(data)
     @test info[:A].classes == [1, 2, 1]
 
-    # ... and the collapse keeps the best member of each of them
-    keep = class_representatives(info)
-    @test keep[:A] == BitVector([true, true, false])
+    # ... and each class stands at its best member
+    reps, cperms = class_ranking(info)
+    @test reps[:A] == [1, 2] # :v3 for {:v3, :v1}, :v2 for {:v2}
+    @test cperms === nothing # which is the order the artifact already has
 
-    # a pin inside a class refines it: the pinned version becomes a class of
-    # its own, so the collapse cannot drop it
+    # a pin inside a class does not *refine* it — a class is one column, and a
+    # user constraint has no way to split one. All it can do is move which
+    # member stands for the class, and empty the classes it admits nothing of
     prob = Problem([:A]; pins = Dict(:A => :v1))
-    @test class_representatives(info, prob)[:A] == BitVector([true, true, true])
+    reps, cperms = class_ranking(info, prob)
+    @test info[:A].members == [[1, 3], [2]] # the partition is untouched
+    @test reps[:A] == [3, 0]  # {:v3, :v1} stands at :v1; {:v2} is empty
+    @test cperms[:A] == [2, 1] # and the empty class ranks where :v2 would
+    @test resolve(data, prob) == Dict(:A => :v1)
 end
 
 @testset "classes: reference partition, complete data grids" begin
@@ -213,7 +235,7 @@ end
     end
 end
 
-@testset "collapse invariance: complete data grids" begin
+@testset "resolve vs. the oracles: complete data grids" begin
     Random.seed!(rand(RandomDevice(), UInt64))
     hi = p -> p
     lo = p -> -p
@@ -227,11 +249,11 @@ end
                 for reqs_bits = 0:2^m-1
                     reqs = collect(make_reqs(reqs_bits))
                     for by in (hi, lo)
-                        test_collapse_invariance(data, Problem(reqs); by)
+                        test_class_space(data, Problem(reqs); by)
                     end
                     for _ = 1:4
                         compat, pins = random_constraints(m, n)
-                        test_collapse_invariance(data, Problem(reqs; compat, pins))
+                        test_class_space(data, Problem(reqs; compat, pins))
                     end
                 end
             end
@@ -239,7 +261,7 @@ end
     end
 end
 
-@testset "collapse invariance: random grids" begin
+@testset "resolve vs. the oracles: random grids" begin
     Random.seed!(rand(RandomDevice(), UInt64))
     hi = p -> p
     lo = p -> -p
@@ -250,14 +272,14 @@ end
             reqs = collect(make_reqs(rand(1:2^m-1)))
             for _ = 1:4
                 compat, pins = random_constraints(m, n)
-                test_collapse_invariance(data, Problem(reqs; compat, pins);
-                                         by = rand((hi, lo)))
+                test_class_space(data, Problem(reqs; compat, pins);
+                                 by = rand((hi, lo)))
             end
         end
     end
 end
 
-@testset "collapse invariance: constraints that split classes" begin
+@testset "resolve vs. the oracles: constraints that empty classes" begin
     Random.seed!(rand(RandomDevice(), UInt64))
     hi = p -> p
     lo = p -> -p
@@ -270,20 +292,17 @@ end
             comp = make_comp(randbits(c) & randbits(c) & randbits(c))
             fill_data!(m, n, deps, comp, data)
             reqs = collect(make_reqs(rand(1:2^m-1)))
-            probs = class_splitting_problems(data, reqs)
+            probs = class_emptying_problems(data, reqs)
             splits += length(probs)
             for prob in probs, by in (hi, lo)
-                test_collapse_invariance(data, prob; by)
-                # ... and the grouped answer is also the answer the same
-                # universe with those versions deleted would give
-                test_bake_equivalence(data, prob; by)
+                test_class_space(data, prob; by)
             end
         end
     end
     @test splits > 1000 # the sweep really did split classes
 end
 
-@testset "collapse invariance: exhaustive constraint shapes" begin
+@testset "resolve vs. the oracles: exhaustive constraint shapes" begin
     Random.seed!(rand(RandomDevice(), UInt64))
     hi = p -> p
     lo = p -> -p
@@ -299,17 +318,17 @@ end
                     constrain!(compat, pins, p, shape, n)
                 end
                 prob = Problem(reqs; compat, pins)
-                test_collapse_invariance(data, prob; by = hi)
-                test_collapse_invariance(data, prob; by = lo)
+                test_class_space(data, prob; by = hi)
+                test_class_space(data, prob; by = lo)
             end
         end
     end
 end
 
-@testset "collapse invariance: adversarial" begin
+@testset "resolve vs. the oracles: adversarial" begin
     Random.seed!(rand(RandomDevice(), UInt64))
     # break the solution until it is unsolvable, with constraints in force the
-    # whole way, checking grouping against no grouping at every step
+    # whole way, checking the answer against the oracles at every step
     for m = 2:4, n = 2:3
         (m*n)^2 ≤ 128 || continue
         make_deps, make_comp, data, d, c, bit = tiny_data_makers(m, n)
@@ -321,7 +340,7 @@ end
             prob = Problem(reqs; compat, pins)
             while true
                 fill_data!(m, n, deps, comp, data)
-                test_collapse_invariance(data, prob)
+                test_class_space(data, prob)
                 sol = resolve(data, prob)
                 sol === nothing && break
                 p = rand(collect(keys(sol)))
@@ -365,11 +384,11 @@ permute_versions(data::AbstractDict, perms) = Dict(
                 for p = 1:m
                     @test class_sets(info, p) == class_sets(base, p)
                 end
-                # and the answer under the permuted ordering is the same
-                # whether or not it is reached by collapsing
-                test_collapse_invariance(perm, Problem(reqs))
+                # and the answer under the permuted ordering is the
+                # universe's answer all the same
+                test_class_space(perm, Problem(reqs))
                 compat, pins = random_constraints(m, n)
-                test_collapse_invariance(perm, Problem(reqs; compat, pins))
+                test_class_space(perm, Problem(reqs; compat, pins))
             end
         end
     end
@@ -422,5 +441,6 @@ end
     # ... and preparing it explicitly yields a universe of its own
     work = prepare_pkg_info(info, prob)
     @test info == before
-    @test work !== info
+    @test work.info !== info
+    @test all(info[p].members == before[p].members for p in keys(info))
 end

--- a/test/ordering.jl
+++ b/test/ordering.jl
@@ -12,7 +12,7 @@
 # down to the partner blocks of every conflicts matrix.
 
 using Resolver: PkgData, PkgInfo, DepsProvider, Problem, pkg_info,
-    prepare_pkg_info, version_permutations, class_representatives
+    prepare_pkg_info, version_permutations, class_ranking
 
 # a comparator over the tiny data's integer versions, from a ranking: `ranks[v]`
 # is how good v is, lower being better
@@ -43,14 +43,10 @@ function bake_order(data::AbstractDict{P}, order) where {P}
          for (p, data_p) in data)
 end
 
-# passing a comparator == baking the same order into the data, for both the
-# grouped and the ungrouped path
+# passing a comparator == baking the same order into the data
 function test_order_equivalence(data, prob, order; by::Function = identity)
     baked = bake_order(data, order)
-    for group in (true, false)
-        @test resolve(data, prob; by, order, group) ==
-              resolve(baked, prob; by, group)
-    end
+    @test resolve(data, prob; by, order) == resolve(baked, prob; by)
 end
 
 @testset "ordering: permutations and identity" begin
@@ -85,10 +81,20 @@ end
     info = pkg_info(data, keys(data); filter = false)
     @test info[:A].classes == [1, 2, 1] # :v3 and :v1 are interchangeable
     prob = Problem([:A])
-    @test class_representatives(info, prob)[:A] == BitVector([1, 1, 0])
+    reps, cperms = class_ranking(info, prob)
+    @test reps[:A] == [1, 2] # class 1 stands at :v3, class 2 at :v2
+    @test cperms === nothing # ... which is the order the artifact has
     up_perms = version_permutations(info, up)
-    @test class_representatives(info, prob, up_perms)[:A] ==
-          BitVector([0, 1, 1]) # reversed: :v1 now represents the class
+    reps, cperms = class_ranking(info, prob, up_perms)
+    @test reps[:A] == [3, 2]     # reversed: :v1 now represents the class
+    @test !haskey(cperms, :A)    # ... and it still outranks :v2
+    @test cperms[:B] == [2, 1]   # :B's own two classes do swap, though
+    # a constraint on the best member moves the class it is in: with :v3 out,
+    # class 1 competes at :v1 and falls behind the class holding :v2
+    prob = Problem([:A]; compat = Dict(:A => [:v2, :v1]))
+    reps, cperms = class_ranking(info, prob)
+    @test reps[:A] == [3, 2]
+    @test cperms[:A] == [2, 1]
 
     # and the answer follows the order: ascending picks the worst versions
     @test resolve(data, [:A, :B]) == Dict(:A => :v3, :B => :v2)

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -8,7 +8,8 @@
 # used to mean.
 
 using Resolver: Problem, PkgData, PkgInfo, pkg_info, SAT, PicoSAT,
-    exclusion_masks, is_excluded, finalize, sat_assume, sat_pop, is_satisfiable
+    exclusion_masks, is_excluded, finalize, sat_assume, sat_pop,
+    is_satisfiable, rank_pkg_info, prepare_pkg_info
 
 # delete the versions `prob` excludes from each package's data, old-style
 function bake(
@@ -236,61 +237,83 @@ end
     test_bake_equivalence(data, prob)
 end
 
-@testset "Problem: SAT selectors" begin
+@testset "Problem: constraints reach SAT as deactivated classes" begin
     nodeps = Dict{Symbol,Vector{Symbol}}()
     nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
     data = Dict(
         :A => PkgData([:v2, :v1], nodeps, nocomp),
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
+    # nothing distinguishes either package's versions, so each package is one
+    # class of two members -- which is exactly why a constraint sparing one
+    # member has nothing to say to the solver
     info = pkg_info(data, keys(data); filter = false)
+    @test info[:A].classes == info[:B].classes == [1, 1]
 
     # no constraints at all: exactly the structural instance
     plain = SAT(info)
-    same  = SAT(info, Problem([:A]))
+    same  = SAT(rank_pkg_info(info, Problem([:A])))
+    nvars = nclauses = 0
     try
-        @test isempty(plain.sels) && isempty(same.sels)
-        @test PicoSAT.var_count(plain.pico) == PicoSAT.var_count(same.pico)
-        @test PicoSAT.clause_count(plain.pico) == PicoSAT.clause_count(same.pico)
+        @test isempty(plain.deact) && isempty(same.deact)
+        nvars = PicoSAT.var_count(plain.pico)
+        nclauses = PicoSAT.clause_count(plain.pico)
+        @test nvars == PicoSAT.var_count(same.pico)
+        @test nclauses == PicoSAT.clause_count(same.pico)
     finally
         finalize(plain)
         finalize(same)
     end
 
-    # one selector per constraint source that forbids something; allow-all
-    # entries and entries for absent packages get none
+    # a constraint that leaves a member standing is likewise no clause at all:
+    # :A's class still has :v1, so the instance is the structural one again
+    sat = SAT(rank_pkg_info(info, Problem([:A]; compat = Dict(:A => [:v1]))))
+    try
+        @test isempty(sat.deact)
+        @test PicoSAT.var_count(sat.pico) == nvars
+        @test PicoSAT.clause_count(sat.pico) == nclauses
+    finally
+        finalize(sat)
+    end
+
+    # one literal per emptied class, whatever emptied it, and none for
+    # allow-all entries or entries for absent packages
     prob = Problem([:A];
         compat = Dict(:A => [:v1], :B => [:v1, :v2], :Z => Symbol[]),
-        pins   = Dict(:A => :v1, :Z => :v1))
-    sat = SAT(info, prob)
+        pins   = Dict(:A => :v2))
+    univ = rank_pkg_info(info, prob)
+    sat = SAT(univ)
     try
-        @test Set(values(sat.sels)) == Set([(:compat, :A), (:pin, :A)])
-        @test length(sat.sels) == 2
-        # every mask has a selector, every selector a mask
-        excl = exclusion_masks(info, prob)
-        @test Set(keys(excl)) == Set(p for (_, p) in values(sat.sels))
+        # compat allows only :v1, the pin only :v2: jointly nothing, so :A's
+        # one class is empty. :B's is untouched
+        @test univ.reps[:A] == [0]
+        @test univ.reps[:B] == [1]
+        @test sat.deact == [-(sat.vars[:A] + 1)]
+        @test !is_satisfiable(sat, [:A])
     finally
         finalize(sat)
     end
 end
 
-@testset "Problem: popping the frame relaxes the constraints" begin
-    # the user constraints are asserted as unit clauses in a push frame of
-    # their own: nothing pops it in production, but one pop makes every
-    # previously-forbidden assignment feasible again
+@testset "Problem: popping the frame reactivates the classes" begin
+    # the deactivations are asserted as unit clauses in a push frame of their
+    # own: nothing pops it in production, but one pop makes every deactivated
+    # class choosable again
     nodeps = Dict{Symbol,Vector{Symbol}}()
     nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    # :A@v2 conflicts with :B@v2, so each package has two classes of its own
     data = Dict(
-        :A => PkgData([:v2, :v1], nodeps, nocomp),
+        :A => PkgData([:v2, :v1], nodeps, Dict(:v2 => Dict(:B => [:v1]))),
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
     prob = Problem([:A, :B];
         compat = Dict(:A => [:v1]), pins = Dict(:B => :v2))
     info = pkg_info(data, prob; filter = false)
-    sat = SAT(info, prob)
+    univ = rank_pkg_info(info, prob)
+    sat = SAT(univ)
     try
-        @test length(sat.sels) == 2
-        # A@v2 is forbidden by compat, B@v1 by the pin
+        @test length(sat.deact) == 2
+        # :A's :v2 class is emptied by compat, :B's :v1 class by the pin
         sat_assume(sat, :A, 1)
         @test !is_satisfiable(sat)
         sat_assume(sat, :B, 2)
@@ -336,14 +359,30 @@ end
     @test resolve(data, prob) == resolve(data, both)
     test_bake_equivalence(data, prob)
 
-    # one selector per source, so a kind, a compat bound and a pin on the same
-    # package stay distinguishable
+    # sources are indistinguishable once they have emptied a class -- and here
+    # they have emptied none. Nothing tells :A's two versions apart, nor :B's,
+    # so each package is one class; the kind forbids :v2 of each and the class
+    # survives through :v1. Three constraint sources on two packages, and
+    # nothing at all for any of them to say to the solver
+    @test info[:A].classes == info[:B].classes == [1, 1]
     prob = Problem([:A]; compat = Dict(:A => [:v1, :v2]),
                          pins = Dict(:B => :v1), excludes = [odd])
-    sat = SAT(info, prob)
+    univ = rank_pkg_info(info, prob)
+    sat = SAT(univ)
     try
-        @test Set(values(sat.sels)) ==
-              Set([(:test, :A), (:test, :B), (:pin, :B)])
+        @test univ.reps[:A] == [2] # the class of {:v2, :v1}, standing at :v1
+        @test univ.reps[:B] == [2]
+        @test isempty(sat.deact)
+    finally
+        finalize(sat)
+    end
+    # ... whereas a pin the kind contradicts leaves the class nothing at all
+    prob = Problem([:A]; pins = Dict(:B => :v2), excludes = [odd])
+    univ = rank_pkg_info(info, prob)
+    sat = SAT(univ)
+    try
+        @test univ.reps[:B] == [0]
+        @test sat.deact == [-(sat.vars[:B] + 1)]
     finally
         finalize(sat)
     end
@@ -381,9 +420,7 @@ end
                           resolve(data, as_compat; by)
                     test_bake_equivalence(data, as_kind; by)
                 end
-                # ... and the collapse and the ordering stay orthogonal to it
-                @test resolve(data, as_kind; group = false) ==
-                      resolve(data, as_kind; group = true)
+                # ... and the ordering stays orthogonal to it
                 order = p -> (u, v) -> u > v
                 @test resolve(data, as_kind; order) ==
                       resolve(bake(data, as_kind), reqs; order)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,8 +166,26 @@ using Resolver: PkgData
     @test_throws ArgumentError("Required package MissingReq is not available in the package data") resolve(data, [:MissingReq])
 end
 
-using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file
+using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file, nclasses
 @testset "pkg info files" begin
+    # the file carries the partition, since the matrix is built over it rather
+    # than the other way round: a loaded artifact must be equal to the saved
+    # one class for class, and must resolve to the same answers
+    function roundtrip(data, reqs, probs)
+        for filter in (false, true)
+            info = pkg_info(data, reqs; filter)
+            path = save_pkg_info_file(info)
+            back = load_pkg_info_file(path)
+            @test back == info
+            @test all(back[p].members == info[p].members for p in keys(info))
+            @test all(nclasses(back[p]) == nclasses(info[p]) for p in keys(info))
+            for prob in probs
+                @test resolve(back, prob) == resolve(info, prob)
+                @test resolve(back, prob) == resolve(data, prob)
+            end
+            rm(path)
+        end
+    end
     # roundtrip with String package names & integer versions
     sdata = Dict(
         "A" => PkgData([2, 1], Dict(2 => ["B"], 1 => ["B"]),
@@ -175,12 +193,11 @@ using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file
         "B" => PkgData([2, 1], Dict{Int,Vector{String}}(),
                        Dict{Int,Dict{String,Vector{Int}}}()),
     )
-    for filter in (false, true)
-        info = pkg_info(sdata, ["A"]; filter)
-        path = save_pkg_info_file(info)
-        @test load_pkg_info_file(path) == info
-        rm(path)
-    end
+    roundtrip(sdata, ["A"], [
+        Problem(["A"]),
+        Problem(["A"]; compat = Dict("B" => [1])),
+        Problem(["A", "B"]; pins = Dict("A" => 1)),
+    ])
     # roundtrip with Symbol package names & Symbol versions
     ydata = Dict(
         :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]),
@@ -188,12 +205,11 @@ using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file
         :B => PkgData([:v2, :v1], Dict{Symbol,Vector{Symbol}}(),
                       Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()),
     )
-    for filter in (false, true)
-        info = pkg_info(ydata, [:A]; filter)
-        path = save_pkg_info_file(info)
-        @test load_pkg_info_file(path) == info
-        rm(path)
-    end
+    roundtrip(ydata, [:A], [
+        Problem([:A]),
+        Problem([:A]; compat = Dict(:B => [:v2])),
+        Problem([:A, :B]; pins = Dict(:B => :v1)),
+    ])
 end
 
 @testset "zero-version packages" begin
@@ -266,7 +282,6 @@ end
     )
     info = pkg_info(data, [:A]; filter = false)
     @test resolve(info, [:A]) === nothing
-    @test resolve(info, [:A]; group = false) === nothing
     data = Dict(
         :A => PkgData([:v2, :v1], Dict(:v2 => [:B]), nocomp),
         :B => PkgData(Symbol[], nodeps, nocomp),
@@ -274,13 +289,13 @@ end
     )
     info = pkg_info(data, [:C]; filter = false)
     @test resolve(info, [:C]) == Dict(:C => :v1, :A => :v1)
-    @test resolve(info, [:C]; group = false) == Dict(:C => :v1, :A => :v1)
 end
 
 include("unsat_cores.jl")
 include("problem.jl")
 include("satisfiable.jl")
 include("classes.jl")
+include("class_space.jl")
 include("ordering.jl")
 
 @testset "registry resolve" begin

--- a/test/satisfiable.jl
+++ b/test/satisfiable.jl
@@ -7,7 +7,8 @@
 # `test_resolver` (test/setup.jl) and `test_bake_equivalence` (test/problem.jl),
 # so every sweep in the suite checks it too.
 
-using Resolver: SAT, PicoSAT, DepsProvider, PkgData, pkg_info, finalize
+using Resolver: SAT, PicoSAT, DepsProvider, PkgData, pkg_info, finalize,
+    prepare_pkg_info
 
 # The number of solves an instance has run — or `nothing` when picosat's report
 # didn't reach us (see below). Picosat counts its own `picosat_sat` calls and
@@ -78,7 +79,7 @@ end
     end
 
     # ... and a SAT instance, the shape the others build internally
-    sat = SAT(info, Problem([:A]; compat, pins))
+    sat = SAT(prepare_pkg_info(info, Problem([:A]; compat, pins)))
     try
         @test issatisfiable(sat, [:A]) == (resolve(sat, [:A]) !== nothing)
         @test issatisfiable(sat) == (resolve(sat) !== nothing)
@@ -132,7 +133,7 @@ end
 
     # the verdict costs a single solve, and since the requirements are assumed
     # rather than asserted, the instance is left exactly as it was found
-    sat = SAT(info, prob)
+    sat = SAT(prepare_pkg_info(info, prob))
     try
         clauses = PicoSAT.clause_count(sat.pico)
         # can the solve count be read here? the clause counts below stand on
@@ -156,7 +157,7 @@ end
     # package it optimizes, so it both solves more than once (three times, on
     # this data) and — until the temporary clauses are rolled back — leaves
     # clauses behind
-    sat = SAT(info, prob)
+    sat = SAT(prepare_pkg_info(info, prob))
     try
         counts = solve_count(sat) !== nothing
         clauses = PicoSAT.clause_count(sat.pico)
@@ -187,9 +188,9 @@ end
                     (Dict{Int,Vector{Int}}(), Dict{Int,Int}()) : cs
                 prob = Problem(reqs; compat, pins)
                 verdict = issatisfiable(data, prob)
-                for by in (hi, lo), order in (nothing, up), group in (true, false)
+                for by in (hi, lo), order in (nothing, up)
                     @test verdict ==
-                        (resolve(data, prob; by, order, group) !== nothing)
+                        (resolve(data, prob; by, order) !== nothing)
                 end
             end
         end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -8,7 +8,7 @@ using Test
 module TestResolver
 
 using Resolver: resolve, issatisfiable, DepsProvider, PkgData, PkgInfo,
-    pkg_data, pkg_info, filter_pkg_info!
+    pkg_data, pkg_info, filter_pkg_info!, nclasses
 using Test
 
 export test_resolver, ref_resolve
@@ -96,11 +96,18 @@ function test_resolver(
         # @info "optimality testing full data"
         info = data # type unstable but 🤷
     else
-        # bound the enumeration by the *uncollapsed* filtered universe: the
-        # collapsed one is smaller, and enumerating fewer candidate solutions
-        # would only weaken the domination check below
-        info = filter_pkg_info!(pkg_info(data, reqs), reqs)
-        Π = prod(float(length(ip.versions)+1) for ip in values(info))
+        # bound the enumeration by the filtered universe, one candidate per
+        # surviving class: its representative. Class members are
+        # interchangeable, so a potential solution using a member is valid
+        # exactly when the one using its class's representative is, and the
+        # representative is the best member of the class — so any solution
+        # that dominates has a representatives-only counterpart that dominates
+        # too, and enumerating them is the same check over fewer candidates
+        univ = filter_pkg_info!(pkg_info(data, reqs), reqs)
+        info = Dict{P,Vector{V}}(
+            p => V[univ.info[p].versions[r] for r in univ.reps[p] if r != 0]
+            for p in keys(univ.info))
+        Π = prod(float(length(vs)+1) for vs in values(info))
         if Π > Π⁺
             # @info "no optimality testing"
             return sol
@@ -318,9 +325,18 @@ end
 
 PkgVers{P,V} = Union{PkgData{P,V},PkgInfo{P,V}}
 
-function each_potential_solution(
+# the enumeration domain is a version list per package; anything with a
+# `.versions` field supplies one
+each_potential_solution(
     body :: Function, # callback
     data :: AbstractDict{P,<:PkgVers{P,V}},
+    pkgs :: AbstractVector{P},
+) where {P,V} = each_potential_solution(
+    body, Dict{P,Vector{V}}(p => collect(d.versions) for (p, d) in data), pkgs)
+
+function each_potential_solution(
+    body :: Function, # callback
+    data :: AbstractDict{P,<:AbstractVector{V}},
     pkgs :: AbstractVector{P},
 ) where {P,V}
     L = length(pkgs)
@@ -330,7 +346,7 @@ function each_potential_solution(
         i ≤ L || (body(s); return)
         # otherwise iterate versions of next package:
         p = pkgs[i]
-        vers_p = haskey(data, p) ? data[p].versions : V[]
+        vers_p = haskey(data, p) ? data[p] : V[]
         for r = 0:length(vers_p)
             v = get(vers_p, r, nothing)
             s[i] = v

--- a/test/unsat_cores.jl
+++ b/test/unsat_cores.jl
@@ -54,9 +54,10 @@ struct Cand
     pred :: Function
 end
 
-# "package p is installed" for every package, plus "not p's first version" for
-# every package with versions, so that negative literals — the shape the
-# diagnostics rebuild will use — get exercised too
+# "package p is installed" for every package, plus "not p's first class" for
+# every package with classes, so that negative literals — the shape the
+# diagnostics rebuild will use — get exercised too. A class variable stands for
+# every member of its class at once, which is what the predicate has to say
 function candidates(
     sat  :: SAT{P},
     pkgs :: AbstractVector{P};
@@ -68,10 +69,10 @@ function candidates(
     end
     versions || return cands
     for (i, p) in enumerate(pkgs)
-        vers = sat.info[p].versions
-        isempty(vers) && continue
-        v = vers[1]
-        push!(cands, Cand(-(sat.vars[p] + 1), s -> s[i] ≠ v))
+        info_p = sat.info[p]
+        isempty(info_p.members) && continue
+        mem = Set(info_p.versions[j] for j in info_p.members[1])
+        push!(cands, Cand(-(sat.vars[p] + 1), s -> s[i] ∉ mem))
     end
     return cands
 end


### PR DESCRIPTION
Closes #58.

A `PkgInfo`'s conflict matrix now has one row per interchangeability class — a set of versions nothing in the registry can tell apart — and one column per partner class, with the partition carried alongside it in both directions (`classes`, `members`). Registry-wide that is **157,936 versions in 87,860 rows**.

Building an artifact takes a row per version first, since that is what the partition is computed from, then merges the rows (`collapse_classes!`). Nothing is lost in the merge: members of a class have equal rows by definition, and members of a partner class index equal columns, conflicts being recorded symmetrically.

What a query determines is, per class, which member it stands for (`class_ranking`). The result is a `Universe`: the artifact plus `reps`, a version index per class or `0` for a class the query admits no member of. A class competes at the rank of the member it stands for, so the classes are laid out in the order their representatives put them in. A class with no admissible member is empty, hence **deactivated**: it cannot be selected.

That is the whole of what a user constraint does. It forbids members; members are indistinguishable, so forbidding some of them only moves which one stands for the class, and forbidding all of them empties it. **Nothing of a constraint appears in a matrix.** In the SAT instance a variable is a class and a deactivated class is one unit clause, asserted inside a pushed frame so a single pop reactivates every class at once and any subset can then be deactivated again by assumption.

### The two per-class facts

A class carries two independent facts, stored in two places:

| | where | who reads it |
|---|---|---|
| **in-universe** — still part of the problem | flag row/column of the matrix | cleared only by the three passes that mean *delete*; read only by `drop_unmarked!` |
| **activated** — this query admits some member | `reps[i] != 0`, per-resolve | reachability, redundancy, and the SAT instance |

Deactivation is therefore never deletion: a deactivated class keeps its row, its column in every partner, and its dependency columns. Reachability continues its prefix past one but still follows its dependencies; redundancy elimination takes it off *both* sides of the domination test; and domination stays activation-free, so a conflict against an emptied partner class still counts. Conflating the two in either direction breaks one of those readings.

Deactivation is read off `reps` because `reps` has to exist anyway — a class's representative names the version in the answer and is what the class competes at when ranked — so a class with no admissible member simply has no representative. A second flag bit in the matrix would work equally well; it would just encode a fact `reps` already carries. The query's state is a value of its own rather than a field of `PkgInfo` to keep one invariant checkable: the artifact is query-independent, a function of the registry alone, which is what lets it be cached and shared across queries that constrain and prefer different things.

### Changes for callers

- `resolve`'s `group` keyword is **removed**, along with the threading behind it.
- `resolve`'s return contract, `issatisfiable`, `Problem` and `Resolver.UnsatCores` are unchanged.
- `PkgInfoFiles` stores the partition, so the format version becomes **v3**.

### Why this lands before the diagnostics rebuild

Three properties of the representation are what make a later question about relaxing a user constraint well posed. `test/class_space.jl` pins each — a hand-built case naming the failure it rules out, and for two of them a sweep over the tiny grids:

1. **no user constraint reaches a matrix** — a constrained and an unconstrained query make universes with the same classes, members, rows, columns and conflicts, differing only in their representatives;
2. **deactivated classes are retained as pressure-treated columns** — reachability continues past one, the packages behind one stay in the universe, and redundancy never deletes one, including when the class that dominates it is emptied by a *different* source;
3. **domination ignores activation** — a conflict against an emptied partner class still counts, so the class it protects is still there when that partner comes back.

Plus the raw primitives the diagnostics will be built out of, as operations and not as diagnostics: a class's activation flips by assumption on a built instance with no clause touched; the D1′ counterexample shape — a compat bound and a pin jointly forbidding both versions of a package — is **unrepresentable**, because the two versions are one class sharing one column; and a reactivated class finds its dependency cone waiting for it.

### Verification

- **Brute-force oracle unchanged.** `ref_resolve` runs on raw `PkgData` and does not care how the universe is represented. `test/classes.jl`'s sweeps, which compared `group = true` against `group = false`, now compare against the resolve of the baked data and, where the enumeration is affordable, against the brute force on it.
- **Registry-scale output equality.** `bin/resolve.jl` over a 48-scenario matrix (four projects × plain, `--julia` at 1.6/1.10/1.11/1.12, `--min`, `--max-minor`, `--min=@deps`, `--allow-pre`, `--allow-yanked`, and two combinations) gives **byte-identical stdout and exit status** against `main`.
- Full suite green; docs build clean.

### Measurements

Whole registry, 14,060 packages:

| | before | after |
|---|---|---|
| matrix bits (allocated) | 63.99 MiB | 34.84 MiB (1.84×) |
| matrix bits (logical) | 29.95 MiB | 11.16 MiB (2.68×) |
| artifact file / gzip -9 | 65.66 / 2.11 MiB | 36.67 / 1.96 MiB |
| T1 build | 3.52 s | 3.94 s |

The allocated figure lags the logical one because every matrix pays a 64-row minimum and 99.2% of packages fit inside it. On the DifferentialEquations closure, where packages are larger relative to that floor, the matrices shrink 3.25× (10.66 → 3.28 MiB). Prepare is 1.1–1.3× faster; solve is unchanged.

Two questions answered without acting on them:

- **Does the resolve path still need reachability and redundancy?** Yes, decisively. Arc-consistency only: prepare 0.085–0.098 s but solve **3.2–5.5 s**, against 0.66–0.67 + 0.02–0.07 s for the full pipeline.
- **Would a coarser partition help?** No. A second pass merges **0 of 87,860** classes. That is not luck: members of a partner class index equal columns, so collapsing them removes only duplicate columns, which cannot separate rows that already agreed — the first pass is already the fixpoint.

### Known caveat, filed separately

A query can legitimately *reorder* classes, and domination is a statement about that order, so a reordering query can license a redundancy deletion the unconstrained order would not. Sound for the query it was computed for, and no answer is affected — but it is the one input to a deletion that a relaxation can still move, so it wants deciding before the diagnostics licensing argument leans on it. Written up with the counterexample shape, the measured rate, three fixes that do not work and one candidate that might: **#70**.

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code); design review and every judgement call are Stefan's.

Session: https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7
