### PR TITLE
Diagnose an unsatisfiable resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Resolver.jl separates *what* to optimize from *how* to solve, handing the solvin
     - a version's dependencies must be present, and
     - conflicting versions cannot both be chosen.
 - Before solving, the problem is shrunk by **reachability analysis** (keeping only versions that could appear in a solution) and **redundancy elimination** (dropping versions that are strictly dominated by others).
-- The solution is optimized **lexicographically, one package at a time**, against a caller-supplied priority order — the resolver returns the unique optimal resolution that order determines (`nothing` if the requirements are unsatisfiable), and it is **Pareto-optimal**: no valid resolution is strictly better.
+- The solution is optimized **lexicographically, one package at a time**, against a caller-supplied priority order. If the problem is satisfiable, the resolver returns the unique Pareto-optimal resolution that version order and package priority determine. If it is unsatisfiable, it returns a **diagnosis**: which requirements and user constraints are in conflict, why, and a menu of verified fixes.
 - Because the preference order is supplied per package, different strategies — newest, oldest/downgrade, prefer-installed, keep-current — can be mixed **within a single resolve**.
 
 The core resolver in [`src/`](src/) is generic: it knows nothing about Julia versions or registries. The [`bin/resolve.jl`](bin/resolve.jl) command-line tool adapts it to Julia's real registries and can emit a `Manifest.toml`.

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -94,6 +94,7 @@ import Pkg.Registry: JULIA_UUID, PkgEntry, RegistryInstance,    init_package_inf
 import Pkg.Types: Context, EnvCache, Manifest, PackageEntry, get_last_stdlibs, write_manifest
 import Pkg.Versions: VersionSpec, semver_spec
 import Resolver: Resolver, DepsProvider, PkgData, Problem, resolve
+import Resolver.Diagnostics
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS
 import TOML
 
@@ -526,9 +527,46 @@ function yanked_notes()
     return notes
 end
 
-if sol === nothing
-    notes = yanked_notes()
-    error(join(["Unsatisfiable"; notes], "\n"))
+# A diagnosis is plain data, keyed by whatever the universe is keyed by -- here
+# uuids, which is not what the reader knows the packages as. So rebuild it over
+# names before printing it: exactly the "render your own report" the type is
+# shaped for, minus the rendering, since the default one is what we want.
+
+function named(d::Resolver.Diagnosis, name::Function)
+    Resolver.Diagnosis(
+        [Diagnostics.Conflict{String,VersionNumber}(
+            String[name(p) for p in c.reqs],
+            Diagnostics.Fact[named(f, name) for f in c.chain])
+         for c in d.conflicts],
+        [Diagnostics.Fix{String,VersionNumber}(
+            [Diagnostics.Action(a.kind, name(a.pkg)) for a in fix.actions],
+            Dict{String,VersionNumber}(
+                name(p) => v for (p, v) in fix.solution))
+         for fix in d.fixes])
+end
+
+named(f::Diagnostics.Requirement, name::Function) =
+    Diagnostics.Requirement(name(f.pkg))
+named(f::Diagnostics.Availability, name::Function) =
+    Diagnostics.Availability(name(f.pkg), f.members, f.excluded)
+
+function package_name(uuid::UUID)
+    uuid == JULIA_UUID && return "julia"
+    haskey(workspace_pkgs, uuid) && return workspace_pkgs[uuid][1]
+    haskey(packages, uuid) && return first(packages[uuid]).name
+    for (_, this_stdlibs) in STDLIBS_BY_VERSION
+        haskey(this_stdlibs, uuid) && return this_stdlibs[uuid].name
+    end
+    haskey(UNREGISTERED_STDLIBS, uuid) && return UNREGISTERED_STDLIBS[uuid].name
+    return string(uuid)
+end
+
+if sol isa Resolver.Diagnosis
+    show(stderr, MIME("text/plain"), named(sol, package_name))
+    for note in yanked_notes()
+        println(stderr, note)
+    end
+    exit(1)
 end
 
 ## output results

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -94,7 +94,7 @@ end
 function resolves(reqs::Vector{UUID}; julia::VersionSpec)
     prob = make_problem(reqs; julia)
     info = Resolver.pkg_info(reg, prob)
-    verdict = Resolver.resolve(info, prob) !== nothing
+    verdict = Resolver.resolve(info, prob; diagnose = false) !== nothing
     # this is exactly what `issatisfiable` answers on its own, so it must agree
     # with the descent's verdict here -- on real registry data, with the Julia
     # bound and the admission kinds in force
@@ -305,8 +305,10 @@ end
             prob = Resolver.Problem(reqs;
                 prerelease = prerelease_exclusion(allow_pre))
             old = bake(data, prob) # the versions deleted, as the provider used to
-            @test Resolver.resolve(data, prob) == Resolver.resolve(old, reqs)
-            @test Resolver.resolve(info, prob) == Resolver.resolve(old, reqs)
+            @test Resolver.resolve(data, prob; diagnose = false) ==
+                  Resolver.resolve(old, reqs; diagnose = false)
+            @test Resolver.resolve(info, prob; diagnose = false) ==
+                  Resolver.resolve(old, reqs; diagnose = false)
         end
 
         # and it is not inert: every Wine_jll in the registry is a prerelease, so
@@ -401,11 +403,13 @@ end
         for pre in ((;), (; prerelease = prerelease_exclusion(no_pre)))
             old = Resolver.Problem(reqs; yanked, pre...)
             new = Resolver.Problem(reqs; pre...)
-            @test Resolver.resolve(reg, new) == Resolver.resolve(kept, old)
-            @test Resolver.resolve(info, new) == Resolver.resolve(kept, old)
+            @test Resolver.resolve(reg, new; diagnose = false) ==
+                  Resolver.resolve(kept, old; diagnose = false)
+            @test Resolver.resolve(info, new; diagnose = false) ==
+                  Resolver.resolve(kept, old; diagnose = false)
             order = u -> (<)
-            @test Resolver.resolve(info, new; order) ==
-                  Resolver.resolve(kept, old; order)
+            @test Resolver.resolve(info, new; order, diagnose = false) ==
+                  Resolver.resolve(kept, old; order, diagnose = false)
         end
 
         # end to end: libsodium_jll's newest registered version is yanked, so
@@ -557,7 +561,7 @@ end
         end
         # and a bound no Julia satisfies is unsatisfiable, not silently widened
         @test isnothing(Resolver.resolve(info,
-            make_problem(reqs; julia = VersionSpec("99"))))
+            make_problem(reqs; julia = VersionSpec("99")); diagnose = false))
         @test !Resolver.issatisfiable(info,
             make_problem(reqs; julia = VersionSpec("99")))
     end
@@ -662,5 +666,32 @@ end
         @test !isnothing(tilde)
         @test tilde[STATISTICS] ∈ bundled_versions(VersionSpec("1.10"))[STATISTICS]
         @test tilde[JULIA_UUID] ∈ VersionSpec("1.10")
+    end
+
+    # An unsatisfiable project gets a report rather than a verdict: which
+    # requirements cannot be satisfied, which constraint is responsible, and
+    # what to change. The exit status is unchanged -- nonzero, which is what
+    # `resolve_versions` reads as "no solution".
+    @testset "an unsatisfiable project gets a report" begin
+        err = IOBuffer()
+        @test isnothing(resolve_versions("LinearAlgebra = \"99\"";
+            deps = ["LinearAlgebra" => LINEAR_ALGEBRA], err))
+        msg = String(take!(err))
+        @test occursin("Unsatisfiable", msg)
+        @test occursin("1 conflict", msg)
+        # the requirement, the package your bound emptied, and the imperative —
+        # by name, since a uuid is not what the reader knows the package as
+        @test occursin("cannot be satisfied", msg)
+        @test occursin("you require LinearAlgebra", msg)
+        @test occursin("no version of LinearAlgebra is available", msg)
+        # (the report is filled to a line width, so the clause may be broken)
+        @test occursin("are excluded by", msg)
+        @test occursin("Verified fixes:", msg)
+        @test occursin("relax your compat on LinearAlgebra", msg)
+        @test !occursin(string(LINEAR_ALGEBRA), msg)
+        # and nothing of how the answer was found
+        for word in ("class", "literal", "assum", "clause", "solver")
+            @test !occursin(word, msg)
+        end
     end
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(
             "The layered solution & filtering" => "theory/layered.md",
             "Pareto front optimality" => "theory/front.md",
             "Relaxation-stable filtering" => "theory/relaxation.md",
+            "Diagnosing an unsatisfiable resolve" => "theory/diagnostics.md",
         ],
     ],
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,6 +4,25 @@
 resolve
 issatisfiable
 Problem
+Diagnosis
+```
+
+## Diagnostics
+
+What a `Diagnosis` is made of. All of it is plain data, so a caller can render
+its own report without asking the resolver anything further.
+
+```@docs
+Resolver.Diagnostics
+Resolver.Diagnostics.Conflict
+Resolver.Diagnostics.Fix
+Resolver.Diagnostics.Action
+Resolver.Diagnostics.action_phrase
+Resolver.Diagnostics.Fact
+Resolver.Diagnostics.Requirement
+Resolver.Diagnostics.Availability
+Resolver.Diagnostics.unavailable
+Resolver.Diagnostics.diagnose
 ```
 
 ## Internals

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,8 +3,9 @@
 A package version resolver built on a real SAT solver (PicoSAT). Given
 package data — versions, dependencies, and compatibility constraints — and a
 set of required packages, [`resolve`](@ref) returns a single optimal solution
-mapping each needed package to a version, or `nothing` when the requirements
-cannot be satisfied.
+mapping each needed package to a version, or a [`Diagnosis`](@ref) — which
+requirements cannot hold together, why, and a menu of verified fixes — when
+they cannot be satisfied.
 
 What "optimal" means, precisely, and why the resolver's aggressive problem
 filtering provably does not change the answer, is worked out in the Theory
@@ -19,6 +20,12 @@ section:
   declarative notion of optimality that was fully worked out and ultimately
   set aside; its theorems and counterexamples illuminate why the layered
   semantics and its filter fit together as well as they do.
+- [Relaxation-stable filtering](theory/relaxation.md) — the stronger property
+  that a universe filtered for one query answers every relaxation of it, which
+  is what lets a failed resolve be explained rather than merely reported.
+- [Diagnosing an unsatisfiable resolve](theory/diagnostics.md) — what
+  licenses the questions a `Diagnosis` is assembled from, and why the
+  versions it shows come from a resolve rather than from the instance.
 
 For the package's motivation and project status, see the
 [README](https://github.com/StefanKarpinski/Resolver.jl).

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -1,0 +1,143 @@
+# Diagnosing an unsatisfiable resolve
+
+When the requirements cannot be satisfied there is more to say than that
+they cannot: which of them cannot hold together, why, and what a user
+could change so that they can. Every one of those answers comes from
+putting further questions to the universe the resolve was run against and
+the instance it failed on, and this page states what licenses them.
+
+Everything here is short, and two earlier results are why. Class space (see
+[the layered page](layered.md#Preprocessing-for-caching)) makes a user
+constraint's whole effect on the universe the set of classes it empties, so
+there is exactly one kind of thing to relax and it is already a unit fact of
+the instance. Relaxation-stable filtering (see the
+[previous page](relaxation.md)) makes the filtered universe answer for every
+relaxation, so there is exactly one universe to ask.
+
+## Relaxations
+
+Write ``Q`` for the failed query, ``\mathrm{reqs}_Q`` for its requirements,
+and ``E_Q`` for the set of classes its constraints empty — a class ``Q``
+admits no member of cannot be selected, and that is the whole of what a
+constraint does to the universe.
+
+A **withdrawal** from ``Q`` is a pair ``(A, B)`` with
+``A \subseteq \mathrm{reqs}_Q`` and ``B \subseteq E_Q``: it requires only
+``A`` and leaves empty only ``B``, so the requirements outside ``A`` are
+dropped and the classes in ``E_Q \setminus B`` are given back. A *solution*
+of it is one covering ``A`` and using no class in ``B``.
+
+!!! note "Observation (a withdrawal is an assumption subset)"
+    In the instance built for ``Q``, "``p`` is installed" is the unit
+    assumption ``p`` and "class ``c`` of ``p`` is empty" is the unit
+    assumption ``\lnot p@c``. Every other clause — dependency edges,
+    registry conflicts, the structural at-most-one — is the registry's and
+    is the same for every withdrawal. So ``(A, B)`` is satisfiable exactly
+    when the instance is satisfiable assuming
+    ``\{p : p \in A\} \cup \{\lnot p@c : p@c \in B\}``, and asking is one
+    solve.
+
+Every relaxation ``R \le Q`` in the previous page's sense is a withdrawal,
+but not conversely: nothing says some set of constraints picks out an
+arbitrary ``B \subseteq E_Q``. The questions below stay on the relaxations,
+and the reason is the *package* granularity they are asked at.
+
+## A package at a time
+
+A report is written a package at a time — what has become of a package's
+versions is one thing to say, and which of its constraints to relax is one
+thing to do — so the questions are asked a package at a time too, over one
+variable per package implying all of that package's assumptions
+(`with_emptied_packages`). Defining such a variable is a conservative
+extension: it occurs positively only in what is assumed, so every model of
+the instance extends to one of the instance with the definition.
+
+That granularity is also what keeps the questions on relaxations rather than
+on withdrawals at large, and it is worth saying why, because a per-class
+question would not.
+
+!!! note "Observation (a package's worth of ``E_Q`` is a constraint's worth)"
+    Let ``S`` be a set of packages and ``E_S`` the classes of ``E_Q``
+    belonging to them. Then the withdrawal ``(A, E_Q \setminus E_S)`` is the
+    relaxation ``R \le Q`` that requires ``A`` and lifts, for every
+    ``p \in S``, every kind of ``Q`` that excludes any version of ``p``.
+
+    *Proof.* After lifting those kinds nothing of ``Q`` forbids any version
+    of a ``p \in S``, so every class of every such ``p`` has an admitted
+    member and none of them is empty. The kinds are lifted for ``S`` alone,
+    so every other package's classes are emptied exactly as ``Q`` emptied
+    them. Hence ``R``'s empty set is ``E_Q \setminus E_S``, and its
+    requirements are ``A``. ∎
+
+The diagnosis only ever assumes a subset of the requirement literals and a
+subset of the package literals, so every question it puts to the solver is
+of that form — a genuine point of the previous page's lattice. A question
+about *one* class of a package would not be: no constraint need pick out one
+of a package's empty classes and leave its siblings empty.
+
+## The filtered universe answers for every relaxation
+
+The instance a resolve fails on is built over a universe that has been
+filtered — reachability and redundancy elimination, run with ``Q``'s
+constraints in force. The questions above are asked of that instance, so
+what has to hold is that filtering for ``Q`` did not delete anything a
+relaxation of ``Q`` would need.
+
+That is Theorem C of the previous page: ``\mathrm{Lay}(F_Q(D), R) =
+\mathrm{Lay}(D, R)`` for every ``R \le Q``, which is stronger than the
+satisfiability statement the questions here need and covers it. The filter
+is run under the rules that make it true, so nothing further is required of
+a diagnosis than to stay below ``Q`` in the order — which, by the
+observation above, everything it asks does.
+
+What the proof turns on is a design decision worth naming here too: a class
+the query empties is **deactivated, not deleted**. It keeps its row, its
+column in every partner, and its dependency columns, which is exactly what
+a question about giving it back needs to find still there.
+
+## Versions come from a resolve, not from the instance
+
+Theorem C is about the answer, but the questions above only ask about
+satisfiability. A report also says what the user would *get*, and that is
+the layered answer, which depends on the version ordering.
+
+The ordering a universe is laid out in belongs to the query. A class ranks
+where its best admitted member ranks (`class_ranking`), and a relaxation
+admits more members — so under a relaxation a class can compete at a better
+version than it competes at here. A version read off the failed instance is
+therefore a version of the query's universe, not of the relaxation's.
+
+So no version in a report is ever read off the failed instance. A fix is
+turned back into the withdrawal it is — the requirements it names dropped,
+the constraint kinds it names lifted for the packages they name — and
+[`relax`](@ref Resolver.relax) derives the relaxed problem from the query
+and computes what the relaxation makes of the classes the query laid out:
+the member each class stands for, and the order those members rank the
+classes in. Resolving that on the failed resolve's own instance runs the
+descent again under the relaxation's ranking, and the solution that comes
+back is what the report shows. It is the solution the user will get,
+because Theorem C says it is what a resolve of the relaxed problem from
+scratch would give.
+
+That a fix resolves at all is that theorem plus monotonicity: relaxing a
+constraint admits at least the version the repair asked for, and admitting
+more versions only adds models.
+
+## Attribution needs no license
+
+Why a class is empty is not a question about the instance. A constraint
+forbids versions, a class is empty when every member of it is forbidden,
+and which kinds forbid which version is read straight off the `Problem`
+(`exclusion_kinds`, `class_exclusions`). No solver is involved, so nothing
+has to be preserved by anything:
+
+```math
+\mathrm{reps}[p][c] = 0
+\quad\Longleftrightarrow\quad
+\text{every member of class } c \text{ of } p \text{ has an excluding kind.}
+```
+
+This is the one place a report can name a *user's* constraint at all —
+registry compatibility is in the conflict matrices, where it is
+indistinguishable from any other conflict — and it is why a story can say
+which bound emptied a class without asking anything.

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -1,0 +1,618 @@
+"""
+    Resolver.Diagnostics
+
+Why a resolve failed and what would make it succeed. `diagnose` puts further
+questions to the universe a failed resolve was run against and the instance it
+failed on, and answers with a [`Diagnosis`](@ref): the independent
+[`Conflict`](@ref Resolver.Diagnostics.Conflict)s — sets of requirements that
+cannot hold together, each with a chain of
+[`Fact`](@ref Resolver.Diagnostics.Fact)s about the packages that says why —
+and a menu of [`Fix`](@ref Resolver.Diagnostics.Fix)es, each a set of
+[`Action`](@ref Resolver.Diagnostics.Action)s the user could carry out together
+with the solution that carrying them out yields.
+
+A `Diagnosis` is plain data, so a caller can render its own report from one
+without asking the resolver anything further; `show(io, MIME("text/plain"), d)`
+and [`action_phrase`](@ref Resolver.Diagnostics.action_phrase) are the report
+this module writes.
+
+These names are this module's API. `Resolver` exports `Diagnosis`, since it is
+what `resolve` answers with when the requirements cannot be satisfied, and
+re-exports none of the others.
+"""
+module Diagnostics
+
+export Diagnosis, Conflict, Fix, Action, Fact, Requirement, Availability,
+    unavailable, action_phrase, diagnose
+
+using ..Resolver: SAT, Problem, Universe, relax, resolve, installed_lit,
+    with_temp_clauses, with_classes_relaxed, sat_new_variable, sat_add_var,
+    sat_add, exclusion_kinds, class_exclusions
+using ..UnsatCores: sat_mus, sat_disjoint_muses, sat_mcses
+
+# What an unsatisfiable resolve says, and how it is found.
+#
+# A diagnosis answers two questions about a query the resolver could not
+# satisfy: which requirements cannot hold together, and what the user could
+# change so that they can. Both are questions about *relaxations* of the
+# problem — the same problem with some requirements dropped and some of the
+# classes this query emptied made choosable again — and both are put to the
+# universe the resolve was run against and the instance it failed on, before
+# they are discarded.
+#
+# Two things can be relaxed, and nothing else:
+#
+#   * a requirement, which the instance states as `installed_lit(sat, p)`;
+#   * a class this query emptied, which it states as `forbidden_lit(sat, p, c)`.
+#
+# Everything else is a clause the diagnosis never touches: dependency edges,
+# registry conflicts, the structural at-most-one, and the classes that are not
+# empty. Every query below is therefore a solve under a subset of one fixed set
+# of assumptions — which is what `UnsatCores` answers, and what the licensing
+# argument on the manual's Diagnostics page covers.
+#
+# Candidate order is the one knob those answers take, and both uses here put
+# the requirements first, for reasons that happen to agree: a repair is grown
+# by keeping candidates in order, so requirements are kept and the menu prefers
+# relaxing a constraint to dropping a dependency; a conflict is shrunk by
+# deleting candidates in order, so a requirement the story does not need drops
+# out of it.
+#
+# Both are asked a *package* at a time, over one assumable literal per package
+# the query left short (`with_emptied_packages`). That is the granularity of
+# both answers: a report says what has become of a package's versions, and a
+# fix says which of a package's constraints to relax, neither of which is a
+# sentence about one class. It is also what keeps the menu short — a package's
+# classes usually go the same way, and one repair per class of each of them
+# would be the same handful of instructions over and over.
+#
+# And it is what keeps every question a *constraint* relaxation, which is what
+# the filtered universe is entitled to answer. Giving a package's empty classes
+# back is exactly what lifting every kind that excludes anything of it does;
+# giving one class back and leaving its siblings empty need be no constraint's
+# doing at all. See the manual's Diagnostics page.
+#
+# A version named in a report always comes from a real resolve of a real
+# problem — never from a model of the failed instance. The instance's classes
+# were given representatives under constraints a fix relaxes, and were laid out
+# in the order those representatives induce, so a version read off it is a
+# version that fix would not produce. A fix is verified by resolving the
+# relaxation `relax` derives from it, and the solution that comes back is what
+# the report shows.
+
+## the report
+
+"""
+    Resolver.Diagnostics.Fact
+
+One statement in a conflict's chain: something true of the packages that helps
+explain why the requirements cannot hold together. The two kinds are
+[`Requirement`](@ref Resolver.Diagnostics.Requirement) — "you require this
+package" — and [`Availability`](@ref Resolver.Diagnostics.Availability) — "this
+is what your constraints leave of the package's versions".
+
+Facts are plain data, so a caller can render its own report from a
+[`Diagnosis`](@ref) without asking the resolver anything further.
+"""
+abstract type Fact end
+
+"""
+    Resolver.Diagnostics.Requirement{P}(pkg)
+
+The fact that the query requires `pkg`.
+"""
+struct Requirement{P} <: Fact
+    pkg :: P
+end
+
+"""
+    Resolver.Diagnostics.Availability{P,V}(pkg, members, excluded)
+
+A package's whole offering, and what the query's own constraints make of it:
+the versions of `pkg` the resolve could have chosen, each paired with the
+constraint kinds that rule that version out. A conflict's chain carries one of
+these for every package the query took versions away from, so that a reader can
+see why the package could not supply what the conflict needed.
+
+  * `members` — every version of `pkg` the resolve had to choose between, in
+    the order the package lists them (best first). Empty when the package has
+    no installable version at all, which is a fact about the registry rather
+    than about this query.
+  * `excluded` — per member, the kinds of the [`Problem`](@ref)'s constraints
+    that forbid it: `:compat` for an allowed-version set the version is not in,
+    `:pin` for a pin at another version, and its own name for each other kind
+    whose predicate holds. A member with no kind against it is one this query
+    admits.
+
+The whole of the offering is here, so what the fact leaves the resolver is what
+it does not exclude: the package is
+[unavailable](@ref Resolver.Diagnostics.unavailable) exactly when every member
+has a kind against it, and relaxing the kinds against any one member is enough
+to give that version back.
+"""
+struct Availability{P,V} <: Fact
+    pkg      :: P
+    members  :: Vector{V}
+    excluded :: Vector{Vector{Symbol}}
+end
+
+"""
+    Resolver.Diagnostics.unavailable(fact::Availability) :: Bool
+
+Whether the fact leaves its package with no version at all — every version it
+offers excluded, or none to offer in the first place.
+"""
+unavailable(f::Availability) = all(!isempty, f.excluded)
+
+"""
+    Resolver.Diagnostics.Action{P}(kind, pkg)
+
+One thing the user could change about `pkg`. All but one `kind` is the kind of
+a [`Problem`](@ref) constraint, and the action is to take that constraint off
+that package: `:compat` to widen the allowed-version set, `:pin` to take the
+pin off, `:prerelease` to admit what that kind forbids, and so on for whatever
+kinds the problem was built with.
+
+The exception is `:drop`, which names a *requirement* rather than a constraint:
+the action is to stop requiring the package, and no constraint of the problem
+is touched. It is not a kind — it is the one action that is about the
+requirements — so a problem that names a constraint kind `:drop` has two things
+called by one name here.
+"""
+struct Action{P}
+    kind :: Symbol
+    pkg  :: P
+end
+
+Base.:(==)(a::Action, b::Action) = a.kind == b.kind && a.pkg == b.pkg
+Base.hash(a::Action, h::UInt) = hash(a.pkg, hash(a.kind, hash(:Action, h)))
+
+Base.:(==)(a::Requirement, b::Requirement) = a.pkg == b.pkg
+Base.hash(a::Requirement, h::UInt) = hash(a.pkg, hash(:Requirement, h))
+
+Base.:(==)(a::Availability, b::Availability) =
+    a.pkg == b.pkg && a.members == b.members && a.excluded == b.excluded
+Base.hash(a::Availability, h::UInt) =
+    hash(a.pkg, hash(a.members, hash(a.excluded, hash(:Availability, h))))
+
+"""
+    Resolver.Diagnostics.Fix{P,V}(actions, solution)
+
+One repair of the whole problem: a set of
+[`Action`](@ref Resolver.Diagnostics.Action)s to carry out, and `solution`,
+what resolving with them carried out actually yields. The solution is a real
+resolve of the relaxed problem, so the versions in it are the versions the user
+would get.
+
+No fix's actions are a superset of another's, and no two fixes ask for the same
+things.
+"""
+struct Fix{P,V}
+    actions  :: Vector{Action{P}}
+    solution :: Dict{P,V}
+end
+
+"""
+    Resolver.Diagnostics.Conflict{P,V}(reqs, chain)
+
+One independent reason the query fails: the requirements `reqs`, which cannot
+hold together, and `chain`, a short sequence of
+[`Fact`](@ref Resolver.Diagnostics.Fact)s about the packages that says why.
+Every fact in the chain is load-bearing — take any one of them away and the
+rest of the conflict dissolves.
+
+Conflicts within a [`Diagnosis`](@ref) share no requirement, so each is a
+separate thing to fix.
+"""
+struct Conflict{P,V}
+    reqs  :: Vector{P}
+    chain :: Vector{Fact}
+end
+
+"""
+    Diagnosis{P,V}
+
+What [`resolve`](@ref) returns instead of a solution when the requirements
+cannot be satisfied: the independent
+[`Conflict`](@ref Resolver.Diagnostics.Conflict)s, each with the chain of facts
+that explains it, and a menu of verified
+[`Fix`](@ref Resolver.Diagnostics.Fix)es, each of which repairs the whole
+problem.
+
+`show(io, MIME("text/plain"), d)` prints the report; the fields are plain data,
+so a caller that wants a different report can build one from them without
+asking the resolver anything further.
+
+Pass `diagnose = false` to [`resolve`](@ref) for the bare `nothing` when only
+the verdict is wanted.
+"""
+struct Diagnosis{P,V}
+    conflicts :: Vector{Conflict{P,V}}
+    fixes     :: Vector{Fix{P,V}}
+end
+
+## rendering
+#
+# The report states what is true about the packages. Classes, literals,
+# assumptions and the solver are how the answer was found, not what it says, so
+# none of them is ever named.
+
+# how a constraint kind is named to the user: `:compat` and `:pin` are what the
+# user calls them too, anything else goes by its own name
+kind_phrase(kind::Symbol) =
+    kind === :compat ? "your compat" :
+    kind === :pin    ? "your pin" :
+                       "your $kind setting"
+
+kinds_phrase(kinds) = join(map(kind_phrase, kinds), " and ")
+
+"""
+    Resolver.Diagnostics.action_phrase(action) :: String
+
+An [`Action`](@ref Resolver.Diagnostics.Action) as an imperative the user could
+carry out — "drop requirement Foo", "relax your compat on Bar".
+"""
+action_phrase(a::Action) =
+    a.kind === :drop   ? "drop requirement $(a.pkg)" :
+    a.kind === :compat ? "relax your compat on $(a.pkg)" :
+    a.kind === :pin    ? "unpin $(a.pkg)" :
+                         "allow $(a.kind) versions of $(a.pkg)"
+
+# a run of a package's versions, compressed: packages list their versions best
+# first, so a run reads low to high
+range_phrase(members, i::Int, j::Int) =
+    i == j ? string(members[i]) : "$(members[j])–$(members[i])"
+
+# join a list of phrases into an English list
+function list_phrase(parts::Vector{String})
+    length(parts) ≤ 1 && return join(parts)
+    length(parts) == 2 && return "$(parts[1]) and $(parts[2])"
+    return join(parts[1:end-1], ", ") * " and " * parts[end]
+end
+
+# An availability fact as one line. The fact runs over the package's whole
+# version list, so every maximal run of versions excluded by the same kinds is a
+# range and gets one clause, and the runs it admits are simply not mentioned;
+# the clauses after the first drop the verb, as an English list of them would.
+function availability_phrase(f::Availability)
+    members, excluded = f.members, f.excluded
+    clauses = String[]
+    i = 1
+    while i ≤ length(members)
+        j = i
+        while j < length(members) && excluded[j+1] == excluded[i]
+            j += 1
+        end
+        if !isempty(excluded[i])
+            verb = i == j ? "is" : "are"
+            by = kinds_phrase(excluded[i])
+            push!(clauses, isempty(clauses) ?
+                "$(range_phrase(members, i, j)) $verb excluded by $by" :
+                "$(range_phrase(members, i, j)) by $by")
+        end
+        i = j + 1
+    end
+    head = unavailable(f) ? "no version of $(f.pkg) is available" : string(f.pkg)
+    return isempty(clauses) ? head : "$head: $(join(clauses, ", "))"
+end
+
+# print `text` filled to `width` columns, `lead` before the first line and
+# `rest` before every later one
+function print_wrapped(io::IO, text::AbstractString, lead::String, rest::String;
+                       width::Int = 78)
+    col = textwidth(lead)
+    print(io, lead)
+    for (k, word) in enumerate(split(text))
+        w = textwidth(word)
+        if k > 1
+            if col + 1 + w > width
+                print(io, "\n", rest)
+                col = textwidth(rest)
+            else
+                print(io, " ")
+                col += 1
+            end
+        end
+        print(io, word)
+        col += w
+    end
+    println(io)
+end
+
+count_phrase(n::Int, one::String, many::String) =
+    n == 0 ? "no $many" : n == 1 ? "1 $one" : "$n $many"
+
+function Base.show(io::IO, d::Diagnosis)
+    print(io, "Diagnosis: ",
+        count_phrase(length(d.conflicts), "conflict", "conflicts"), ", ",
+        count_phrase(length(d.fixes), "fix", "fixes"))
+end
+
+function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis{P,V}) where {P,V}
+    println(io, "Unsatisfiable — ",
+        count_phrase(length(d.conflicts), "conflict", "conflicts"), ", ",
+        count_phrase(length(d.fixes), "fix", "fixes"), ":")
+    for (k, c) in enumerate(d.conflicts)
+        println(io)
+        subject = list_phrase(String[string(p) for p in c.reqs])
+        println(io, "Conflict $k: $subject cannot be satisfied",
+            length(c.reqs) > 1 ? " together." : ".")
+        for f in c.chain
+            f isa Requirement ?
+                println(io, "  • you require $(f.pkg)") :
+                print_wrapped(io,
+                    availability_phrase(f::Availability), "  • ", "    ")
+        end
+    end
+    isempty(d.fixes) && return
+    println(io)
+    println(io, "Verified fixes:")
+    # the versions worth showing are the ones the report has been talking about
+    named = P[]
+    for c in d.conflicts, f in c.chain
+        p = f isa Requirement ? f.pkg : (f::Availability).pkg
+        p in named || push!(named, p)
+    end
+    sort!(named)
+    for (k, fix) in enumerate(d.fixes)
+        print_wrapped(io, list_phrase(map(action_phrase, fix.actions)),
+            lpad(k, 3) * ". ", "     ")
+        # what the fix gets the user, of the packages the report has named; a
+        # fix that installs none of them has nothing to show here
+        allows = String["$p $(fix.solution[p])" for p in named
+                        if haskey(fix.solution, p)]
+        isempty(allows) ||
+            print_wrapped(io, join(allows, ", "), "     → allows: ", "       ")
+    end
+end
+
+## the diagnosis
+
+# How many repairs to enumerate before settling for the ones already found.
+# Independent conflicts multiply, so there can be exponentially many, and a menu
+# is only useful while it is short; deduplication and dominance cut this down
+# further. What is enumerated over is the requirements and the packages this
+# query left short, of which there are few, so this is a ceiling rather than the
+# usual stopping point.
+const MAX_FIXES = 32
+
+# The literals a diagnosis assumes, read back as what they say about the
+# universe. Package variables are laid out in blocks — the package itself, then
+# one variable per class — so the block a literal falls in names the package
+# and the offset within it names the class, with offset 0 the package itself.
+# The instance hands out variables in package-name order, so `pkgs` is sorted,
+# and asking whether the instance has a package at all is a search of it.
+struct VarMap{P}
+    bases :: Vector{Int}
+    pkgs  :: Vector{P}
+end
+
+function VarMap(sat::SAT{P}) where {P}
+    bases = sort!(collect(values(sat.vars)))
+    pkgs = Vector{P}(undef, length(bases))
+    for (p, v) in sat.vars
+        pkgs[searchsortedfirst(bases, v)] = p
+    end
+    return VarMap{P}(bases, pkgs)
+end
+
+# whether the instance has variables for `p` at all — its universe holds an
+# installable version of the package
+Base.haskey(vm::VarMap{P}, p::P) where {P} = insorted(p, vm.pkgs)
+
+# `(p, 0)` for "package p is installed", `(p, c)` for "class c of p is forbidden"
+function decode(vm::VarMap{P}, l::Integer) where {P}
+    v = abs(l)
+    i = searchsortedlast(vm.bases, v)
+    return vm.pkgs[i], v - vm.bases[i]
+end
+
+# What this query's constraints do to `p`'s versions, as a fact. The versions a
+# class holds and the kinds excluding each of them are `class_exclusions`;
+# taking every class at once is what lets the fact say which versions the query
+# leaves standing as well as which it takes away, and a package is one thing to
+# say a sentence about however many of its classes the story needed.
+availability_fact(sat::SAT{P,V}, prob::Problem{P}, p::P) where {P,V} =
+    Availability{P,V}(p, copy(sat.info[p].versions),
+        Vector{Symbol}[exclusion_kinds(prob, p, v)
+                       for v in sat.info[p].versions])
+
+# One assumable literal per package this query emptied something of, and the
+# packages they stand for, in package-name order.
+#
+# A story is told a package at a time — what has become of a package's versions
+# is one thing to say, however many of its classes the query emptied — so it is
+# minimized a package at a time, and that takes a literal per package to
+# minimize over. Each is a fresh variable that forbids every class of its
+# package the query emptied, defined by one clause per class inside a frame of
+# its own, so the instance is exactly as it was found afterwards. The variable
+# occurs positively only in what is assumed, so defining it costs the instance
+# no model of its own variables.
+function with_emptied_packages(body::Function, sat::SAT{P}, vm::VarMap{P}) where {P}
+    with_temp_clauses(sat) do
+        lits = Int[]
+        pkgs = P[]
+        for l in sat.deact # sorted by variable, hence by package name
+            p, _ = decode(vm, l)
+            if isempty(pkgs) || last(pkgs) != p
+                push!(pkgs, p)
+                push!(lits, sat_new_variable(sat))
+            end
+            sat_add_var(sat, -last(lits))
+            sat_add_var(sat, l)
+            sat_add(sat)
+        end
+        body(lits, pkgs)
+    end
+end
+
+# The story of one conflict: the smallest set of the query's own facts that is
+# still unsatisfiable. Deletion is attempted in the order given, so putting the
+# requirements first drops the ones the story does not need and keeps the facts
+# the user can act on. The answer is a subsequence of what was asked, so the
+# requirements come back in the problem's requirement order and the emptied
+# packages in package order.
+function conflict_story(
+    sat      :: SAT{P,V},
+    prob     :: Problem{P},
+    vm       :: VarMap{P},
+    cluster  :: Vector{Int},
+    emptied  :: Dict{Int,P}, # per package literal, the package
+    pkg_lits :: Vector{Int},
+) where {P,V}
+    mus = sat_mus(sat, [cluster; pkg_lits])
+    reqs = P[]
+    chain = Fact[]
+    avails = Fact[]
+    for l in mus
+        p = get(emptied, l, nothing)
+        if p === nothing
+            q, _ = decode(vm, l)
+            push!(reqs, q)
+            push!(chain, Requirement(q))
+        else
+            push!(avails, availability_fact(sat, prob, p))
+        end
+    end
+    append!(chain, avails)
+    return Conflict{P,V}(reqs, chain)
+end
+
+# The user actions one correction set asks for. Dropping a requirement is
+# already an action; giving a package's versions back is not, since what the
+# user relaxes is a *constraint* — so for each class the query emptied, take the
+# member that costs the fewest kinds (ties going to the better version) and name
+# those kinds. Admitting one member is enough to make a class choosable again,
+# so the union over the package's emptied classes gives all of them back.
+function correction_actions(
+    sat     :: SAT{P},
+    prob    :: Problem{P},
+    vm      :: VarMap{P},
+    emptied :: Dict{Int,P}, # per package literal, the package
+    mcs     :: Vector{Int},
+    dropped :: Vector{P},
+) where {P}
+    actions = Action{P}[]
+    for l in mcs
+        p = get(emptied, l, nothing)
+        if p === nothing
+            q, _ = decode(vm, l)
+            push!(actions, Action{P}(:drop, q))
+            continue
+        end
+        reps_p = sat.reps[p]
+        for c in eachindex(reps_p)
+            iszero(reps_p[c]) || continue
+            ex = class_exclusions(prob, p, sat.info[p], c)
+            best = argmin(i -> (length(ex[i][2]), i), eachindex(ex))
+            for kind in ex[best][2]
+                push!(actions, Action{P}(kind, p))
+            end
+        end
+    end
+    for p in dropped
+        push!(actions, Action{P}(:drop, p))
+    end
+    unique!(actions)
+    # relaxations before drops, so the menu reads as an instruction
+    sort!(actions; by = a -> (a.kind === :drop, a.pkg, a.kind))
+    return actions
+end
+
+# The withdrawal a set of actions asks for, in the two parts `relax` takes it:
+# the requirements to stop requiring, and per constraint kind, the packages to
+# lift that kind for. An action is already one or the other, so nothing here
+# translates anything — which is the whole reason `Action` speaks in the
+# problem's own kinds rather than a vocabulary of its own.
+function withdrawal(actions::Vector{Action{P}}) where {P}
+    drop_reqs = P[]
+    drop_constraints = Dict{Symbol,Set{P}}()
+    for a in actions
+        a.kind === :drop ?
+            push!(drop_reqs, a.pkg) :
+            push!(get!(Set{P}, drop_constraints, a.kind), a.pkg)
+    end
+    return drop_reqs, drop_constraints
+end
+
+"""
+    Resolver.Diagnostics.diagnose(sat, prob, univ; by, order) :: Diagnosis
+
+Why the resolve of `prob` against the instance `sat` failed, and what would
+make it succeed. `univ` is the universe `sat` was built from — the one
+`prepare_pkg_info(info, prob; order)` produced, filtered for `prob` — and each
+fix is verified by resolving on it the relaxation of `prob` that carrying the
+fix out gives, with the same `by` and `order` the failed resolve used. The
+solution that comes back is the fix's witness. Filtering for `prob` deletes
+nothing such a relaxation needs, which is the manual's Theorem C, so no fix
+needs a universe of its own.
+
+`sat` must be the instance exactly as the failed query posed it — the
+deactivation frame in place and no clause added since — and is left that way.
+"""
+function diagnose(
+    sat  :: SAT{P,V},
+    prob :: Problem{P},
+    univ :: Universe{P,V};
+    by   :: Function = identity,
+    order = nothing,
+) where {P,V}
+    vm = VarMap(sat)
+    # the same package required twice is one thing to assume and one to drop
+    reqs = unique(prob.reqs)
+    # a requirement the universe holds no installable version of is not
+    # something the instance can be asked about: it has no variable, and no
+    # constraint of this query is what took it away, since a constraint empties
+    # classes rather than deleting them. It is a conflict of its own, and every
+    # fix has to drop it
+    gone = P[p for p in reqs if !haskey(vm, p)]
+    req_lits = Int[installed_lit(sat, p) for p in reqs if haskey(vm, p)]
+
+    conflicts = Conflict{P,V}[
+        Conflict{P,V}([p], Fact[Requirement(p),
+            Availability{P,V}(p, V[], Vector{Symbol}[])]) for p in gone]
+
+    # partition the requirements into independent conflicts, with the query
+    # exactly as production posed it
+    clusters = sat_disjoint_muses(sat, req_lits)
+
+    # distinct correction sets can ask for the same actions, and one action set
+    # can be a strict superset of another; keep the minimal ones, in
+    # enumeration order. Doing this before the witnesses are resolved saves the
+    # resolves the surviving fixes do not need
+    action_sets = Vector{Action{P}}[]
+    seen = Set{Set{Action{P}}}()
+    with_classes_relaxed(sat) do
+        with_emptied_packages(sat, vm) do pkg_lits, pkgs
+            emptied = Dict{Int,P}(zip(pkg_lits, pkgs))
+            for cluster in clusters
+                push!(conflicts,
+                    conflict_story(sat, prob, vm, cluster, emptied, pkg_lits))
+            end
+            # every minimal repair, requirements first so they are kept and the
+            # menu prefers relaxing a constraint to dropping a dependency
+            for mcs in sat_mcses(sat, [req_lits; pkg_lits]; limit = MAX_FIXES)
+                actions = correction_actions(sat, prob, vm, emptied, mcs, gone)
+                key = Set(actions)
+                key in seen && continue
+                push!(seen, key)
+                push!(action_sets, actions)
+            end
+        end
+    end
+    filter!(a -> !any(b -> Set(b) ⊊ Set(a), action_sets), action_sets)
+
+    # the instance is back as the query posed it, which is what answering a
+    # relaxation on it needs — the deactivation frame in place for it to lift
+    fixes = Fix{P,V}[]
+    for actions in action_sets
+        sol = resolve(sat, relax(univ, prob, withdrawal(actions)...; order); by)
+        # relaxing a kind admits at least what the correction set asked for and
+        # never less, so a repair the instance verified resolves here too
+        @assert sol !== nothing
+        push!(fixes, Fix{P,V}(actions, sol))
+    end
+    return Diagnosis{P,V}(conflicts, fixes)
+end
+
+end # module

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -94,14 +94,21 @@ function resolve_core(
 end
 
 """
-    resolve(data, prob::Problem; by = identity) -> Union{Dict{P,V}, Nothing}
-    resolve(data, reqs; by = identity)
+    resolve(data, prob::Problem; by = identity, diagnose = true)
+        -> Union{Dict{P,V}, Diagnosis{P,V}, Nothing}
+    resolve(data, reqs; by = identity, diagnose = true)
 
 Resolve the requirements `reqs` against the package universe described by
 `data`, returning the optimal solution as a dict mapping each needed package
-to its chosen version, or `nothing` when the requirements are not jointly
-satisfiable. The solution covers every requirement and is exactly the
+to its chosen version, or a [`Diagnosis`](@ref) when the requirements are not
+jointly satisfiable. The solution covers every requirement and is exactly the
 dependency closure of the requirements under its own chosen versions.
+
+A `Diagnosis` says which requirements cannot hold together, why, and what the
+user could change to make them; `show`ing it prints the report. Pass
+`diagnose = false` for the bare `nothing` instead, which is what a caller that
+only wants the verdict should do — the diagnosis costs several more solves and
+one resolve per fix it offers.
 
 A [`Problem`](@ref) additionally constrains the admissible versions with user
 constraints; the answer is the one the same universe with those versions
@@ -116,9 +123,11 @@ manual's Theory section for the precise semantics and the guarantees it
 carries.
 
 `data` may be a `DepsProvider`, a dict of `PkgData`, a dict of `PkgInfo`, or
-a `SAT` instance. The `SAT` method also accepts `restore::Bool = true`: when
-true the instance's clauses are restored before returning so the instance
-can be reused; `restore = false` is faster for single-use instances.
+a `SAT` instance. The `SAT` method takes bare requirements and so has no
+constraints to attribute a failure to: it answers `nothing`, and accepts
+`restore::Bool = true` instead of `diagnose` — when true the instance's clauses
+are restored before returning so the instance can be reused, and
+`restore = false` is faster for single-use instances.
 
 The other methods accept one more keyword:
 
@@ -155,10 +164,22 @@ function resolve_prepared(
     univ :: Universe{P,V},
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
+    order = nothing, # version ordering
+    diagnose :: Bool = false,
 ) where {P,V}
     sat = SAT(univ)
-    # the instance is single-use, so don't bother restoring its state
-    try resolve(sat, prob.reqs; by, restore=false)
+    try
+        # the instance is single-use, so don't bother restoring its state. an
+        # unsatisfiable resolve adds no clause anyway — it stops at the
+        # feasibility check, which only assumes — so the instance a diagnosis
+        # gets is the one the query posed, whichever way this is asked
+        sol = resolve(sat, prob.reqs; by, restore=false)
+        sol === nothing || return sol
+        diagnose || return nothing
+        # every question a diagnosis asks is a relaxation of `prob`, which this
+        # universe was filtered for and so answers (Theorem C): the artifact
+        # behind it is not needed and does not have to have been kept
+        return Diagnostics.diagnose(sat, prob, univ; by, order)
     finally
         finalize(sat)
     end
@@ -295,9 +316,11 @@ function resolve(
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
     order = nothing, # version ordering
+    diagnose :: Bool = true,
 ) where {P}
     info = pkg_info(deps, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob;
+        by, order, diagnose)
 end
 
 function resolve(
@@ -305,9 +328,11 @@ function resolve(
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
     order = nothing, # version ordering
+    diagnose :: Bool = true,
 ) where {P}
     info = pkg_info(data, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob;
+        by, order, diagnose)
 end
 
 # a caller-supplied info may be a reusable (or cached) T1 artifact, so this
@@ -317,8 +342,10 @@ function resolve(
     prob :: Problem{P};
     by   :: Function = identity, # package ordering
     order = nothing, # version ordering
+    diagnose :: Bool = true,
 ) where {P,V}
-    resolve_prepared(prepare_pkg_info(info, prob; order), prob; by)
+    resolve_prepared(prepare_pkg_info(info, prob; order), prob;
+        by, order, diagnose)
 end
 
 # convenience entry points: bare requirements, with the user constraints (if
@@ -329,29 +356,32 @@ resolve(
     reqs :: SetOrVec{P} = deps.packages;
     by     :: Function = identity, # package ordering
     order  = nothing, # version ordering
-) where {P} = resolve(deps, Problem(reqs); by, order)
+    diagnose :: Bool = true,
+) where {P} = resolve(deps, Problem(reqs); by, order, diagnose)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
     reqs :: SetOrVec{P} = keys(data);
     by     :: Function = identity, # package ordering
     order  = nothing, # version ordering
-) where {P} = resolve(data, Problem(reqs); by, order)
+    diagnose :: Bool = true,
+) where {P} = resolve(data, Problem(reqs); by, order, diagnose)
 
 resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info);
     by     :: Function = identity, # package ordering
     order  = nothing, # version ordering
-) where {P,V} = resolve(info, Problem(reqs); by, order)
+    diagnose :: Bool = true,
+) where {P,V} = resolve(info, Problem(reqs); by, order, diagnose)
 
 """
     issatisfiable(data, reqs) -> Bool
 
-Compute `resolve(data, reqs; ...) !== nothing` more efficiently, with a single
-satisfiability check instead of a full optimizing resolve. Use this when you
-want to know whether the requirements can be satisfied but don't need an
-actual solution.
+Compute `resolve(data, reqs; ..., diagnose = false) !== nothing` more
+efficiently, with a single satisfiability check instead of a full optimizing
+resolve. Use this when you want to know whether the requirements can be
+satisfied but don't need an actual solution — or a report on why not.
 
 `data` may be a `DepsProvider`, a dict of `PkgData`, a dict of `PkgInfo`, or a
 `SAT` instance, and a `Problem` may be passed in place of the requirements and

--- a/src/Resolver.jl
+++ b/src/Resolver.jl
@@ -1,6 +1,6 @@
 module Resolver
 
-export resolve, issatisfiable, Problem
+export resolve, issatisfiable, Problem, Diagnosis
 
 include("BitKernels.jl")
 include("DepsProvider.jl")
@@ -13,5 +13,7 @@ include("SAT.jl")
 include("UnsatCores.jl")
 using .UnsatCores # the API; not re-exported from Resolver
 include("Resolve.jl")
+include("Diagnostics.jl")
+using .Diagnostics: Diagnosis # `resolve`'s answer; nothing else re-exported
 
 end # module

--- a/test/class_space.jl
+++ b/test/class_space.jl
@@ -309,7 +309,7 @@ end
     # the two kinds empty that one class between them
     univ = rank_pkg_info(info, prob)
     @test univ.reps[:A] == [0]
-    @test resolve(data, prob) === nothing
+    @test resolve(data, prob; diagnose = false) === nothing
 
     # relaxing either kind reactivates the same single class — there is no
     # "half" of this constraint set to be unsound about, and nothing that could

--- a/test/classes.jl
+++ b/test/classes.jl
@@ -124,8 +124,8 @@ const REF⁺ = 256 # enumeration budget for the brute-force cross-check
 
 function test_class_space(data, prob; by::Function = identity)
     baked = bake(data, prob)
-    sol = resolve(data, prob; by)
-    @test sol == resolve(baked, prob.reqs; by)
+    sol = resolve(data, prob; by, diagnose = false)
+    @test sol == resolve(baked, prob.reqs; by, diagnose = false)
     @test issatisfiable(data, prob) == (sol !== nothing)
     Π = prod(init = 1.0, float(length(d.versions) + 1) for d in values(baked))
     Π ≤ REF⁺ && @test sol == ref_resolve(baked, prob.reqs; by)
@@ -341,7 +341,7 @@ end
             while true
                 fill_data!(m, n, deps, comp, data)
                 test_class_space(data, prob)
-                sol = resolve(data, prob)
+                sol = resolve(data, prob; diagnose = false)
                 sol === nothing && break
                 p = rand(collect(keys(sol)))
                 v = sol[p]
@@ -411,11 +411,14 @@ end
                 specific = pkg_info(deps, reqs) # T1 over the closure of reqs
                 compat, pin = random_constraints(m, n)
                 for prob in (Problem(reqs), Problem(reqs; compat, pin))
-                    @test resolve(all_reqs, prob) == resolve(specific, prob)
-                    @test resolve(all_reqs, prob) == resolve(data, prob)
+                    @test resolve(all_reqs, prob; diagnose = false) ==
+                          resolve(specific, prob; diagnose = false)
+                    @test resolve(all_reqs, prob; diagnose = false) ==
+                          resolve(data, prob; diagnose = false)
                     # the T1 artifacts are reusable: resolving does not
                     # consume them
-                    @test resolve(all_reqs, prob) == resolve(all_reqs, prob)
+                    @test resolve(all_reqs, prob; diagnose = false) ==
+                          resolve(all_reqs, prob; diagnose = false)
                 end
             end
         end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -1,0 +1,554 @@
+# Diagnosing an unsatisfiable resolve (src/Diagnostics.jl).
+#
+# Two oracles, neither of which asks the diagnosis anything:
+#
+#   * for the conflicts, the instance itself. A chain of facts claims that
+#     assuming exactly those facts is unsatisfiable and that every one of them
+#     is needed for that, and both halves are put to the solver directly.
+#   * for the fixes, a resolve from the artifact. A fix claims that carrying
+#     out its actions yields its solution, so the actions are turned into a
+#     withdrawal here — independently of how the diagnosis turns them into one
+#     — and the relaxed problem is prepared and resolved from scratch. That is
+#     the path production dropped: the diagnosis answers on the universe the
+#     failed resolve was run against, and this checks the two agree, which is
+#     Theorem C where a report can see it. What the two share is `relax`'s
+#     withdrawal of demands from a `Problem`, which is not this file's to check
+#     (test/problem.jl and test/relaxation_stable.jl do).
+#
+# What the report says is checked separately, against hand-built cases, since
+# there is no oracle for English.
+
+using Resolver: Problem, PkgData, PkgInfo, SAT, Diagnosis, pkg_info, relax,
+    prepare_pkg_info, finalize, is_satisfiable, installed_lit, forbidden_lit,
+    with_classes_relaxed, class_exclusions, exclusion_kinds, nclasses,
+    sat_assume_var
+using Resolver.Diagnostics: Diagnostics, Conflict, Fix, Action, Fact,
+    Requirement, Availability, unavailable, action_phrase
+
+using Pkg.Versions: VersionSpec
+
+# `random_problem` and `SHAPES` (relaxation.jl) are the constraint generator,
+# and `verdicts` (relaxation.jl) the instance-comparison battery; that file
+# runs before this one.
+
+## helpers
+
+# the instance a resolve of `prob` fails on, the universe behind it, and the
+# artifact that universe was prepared from
+function failed_instance(data, prob; order = nothing)
+    info = pkg_info(data, prob)
+    univ = prepare_pkg_info(info, prob; order)
+    return SAT(univ), univ, info
+end
+
+# the literals a fact claims: the requirement it names, or every class this
+# query emptied of the package it names. A fact is one package's worth of the
+# story, so this is what taking the fact away would give back
+fact_literals(sat::SAT{P}, f::Requirement{P}) where {P} =
+    haskey(sat.vars, f.pkg) ? Int[installed_lit(sat, f.pkg)] : Int[]
+
+fact_literals(sat::SAT{P}, f::Availability{P}) where {P} =
+    haskey(sat.vars, f.pkg) ? Int[forbidden_lit(sat, f.pkg, c)
+        for c in eachindex(sat.reps[f.pkg]) if iszero(sat.reps[f.pkg][c])] : Int[]
+
+conflict_literals(sat::SAT, c::Conflict) =
+    reduce(vcat, (fact_literals(sat, f) for f in c.chain); init = Int[])
+
+# is the instance satisfiable assuming exactly `lits`?
+function sat_assuming(sat::SAT, lits)
+    for l in lits
+        sat_assume_var(sat, l)
+    end
+    return is_satisfiable(sat)
+end
+
+# the withdrawal a set of actions asks for, read off here rather than taken
+# from the diagnosis: `:drop` names a requirement to stop requiring, every
+# other kind names a constraint of the problem and a package to lift it for
+function withdrawal(actions::Vector{Action{P}}) where {P}
+    drop_reqs = P[a.pkg for a in actions if a.kind === :drop]
+    drop_constraints = Dict{Symbol,Set{P}}()
+    for a in actions
+        a.kind === :drop && continue
+        push!(get!(Set{P}, drop_constraints, a.kind), a.pkg)
+    end
+    return drop_reqs, drop_constraints
+end
+
+# what carrying `actions` out gets you, the slow way: the relaxed problem
+# prepared and resolved from the artifact, filter and all
+fix_resolve(info, prob::Problem{P}, actions::Vector{Action{P}};
+            order = nothing, by = identity) where {P} =
+    resolve(info, relax(prob, withdrawal(actions)...); order, by, diagnose = false)
+
+# every property a `Diagnosis` of `prob` claims, checked against the instance
+# it was drawn from and against fresh resolves of the artifact. Returns the
+# diagnosis, or `nothing` when the problem is satisfiable after all
+function check_diagnosis(data, prob::Problem{P}; order = nothing,
+                         by = identity) where {P}
+    d = resolve(data, prob; order, by)
+    d isa Diagnosis || return nothing
+    sat, univ, info = failed_instance(data, prob; order)
+    try
+        ## the instance is left as it was found
+        #
+        # `diagnose` pops the deactivation frame, pushes a frame of definitional
+        # clauses inside it, and resolves a relaxation per fix — so run it here
+        # too and check that all of that came back. The checks below, and
+        # anything else that reuses an instance, are entitled to find it as they
+        # left it. The battery is one solve per class, so on a large universe
+        # the verdict on the failed query is what is affordable
+        battery = sum(nclasses(i) for i in values(sat.info); init = 0) ≤ 64
+        before = battery ? verdicts(sat) : Bool[]
+        deact = copy(sat.deact)
+        @test Diagnostics.diagnose(sat, prob, univ; by, order) isa Diagnosis
+        @test sat.deact == deact
+        @test !issatisfiable(sat, prob.reqs)
+        battery && @test verdicts(sat) == before
+
+        ## conflicts
+
+        # independent: no requirement is in two of them, and each names only
+        # requirements
+        seen = Set{P}()
+        for c in d.conflicts
+            @test !isempty(c.reqs)
+            @test c.reqs ⊆ prob.reqs
+            @test isempty(intersect(seen, c.reqs))
+            union!(seen, c.reqs)
+            # the chain names the conflict's requirements, then packages
+            @test [f.pkg for f in c.chain if f isa Requirement] == c.reqs
+            @test allunique(f.pkg for f in c.chain if f isa Availability)
+        end
+
+        with_classes_relaxed(sat) do
+            for c in d.conflicts
+                lits = conflict_literals(sat, c)
+                if isempty(lits)
+                    # a requirement the universe holds no version of: there is
+                    # nothing to ask the instance, and the chain says as much
+                    @test all(f -> !haskey(sat.vars, f.pkg), c.chain)
+                    continue
+                end
+                # the chain is a conflict: assuming just these facts fails
+                @test !sat_assuming(sat, lits)
+                # ... and every fact in it is load-bearing: take one away and
+                # what is left of the conflict is satisfiable
+                for f in c.chain
+                    drop = Set(fact_literals(sat, f))
+                    @test sat_assuming(sat, filter(∉(drop), lits))
+                end
+            end
+        end
+
+        # availability facts say what the problem says about the versions, class
+        # for class
+        for c in d.conflicts, f in c.chain
+            f isa Availability || continue
+            if haskey(sat.info, f.pkg)
+                info_p = sat.info[f.pkg]
+                @test f.members == info_p.versions
+                @test f.excluded ==
+                    [exclusion_kinds(prob, f.pkg, v) for v in f.members]
+                for k = 1:nclasses(info_p)
+                    ex = class_exclusions(prob, f.pkg, info_p, k)
+                    @test [f.members[i] for i in info_p.members[k]] == first.(ex)
+                    @test [f.excluded[i] for i in info_p.members[k]] == last.(ex)
+                end
+                # a package with a version left over is not unavailable
+                @test unavailable(f) == all(iszero, sat.reps[f.pkg])
+            else
+                # nothing of the package is in the universe to talk about
+                @test isempty(f.members) && isempty(f.excluded)
+                @test unavailable(f)
+            end
+        end
+
+        ## fixes
+
+        for fix in d.fixes
+            @test !isempty(fix.actions)
+            @test allunique(fix.actions)
+            # the central property: carrying the actions out resolves, and to
+            # exactly the solution the fix shows — the diagnosis answered the
+            # relaxation on the universe filtered for the query, this answers it
+            # on a universe filtered for the relaxation itself
+            @test fix_resolve(info, prob, fix.actions; order, by) == fix.solution
+        end
+        # minimal and distinct: no fix asks for a strict superset of another's
+        # actions, and no two ask for the same things
+        sets = [Set(fix.actions) for fix in d.fixes]
+        @test allunique(sets)
+        for a in sets, b in sets
+            @test !(b ⊊ a)
+        end
+    finally
+        finalize(sat)
+    end
+    return d
+end
+
+## hand-built instances
+
+const DEPS_NONE = Dict{Symbol,Vector{Symbol}}()
+const COMP_NONE = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+
+# A needs C@v1, B needs C@v2, and E and F disagree about G the same way: two
+# conflicts that share nothing
+const two_conflicts = Dict(
+    :A => PkgData([:v1], Dict(:v1 => [:C]), Dict(:v1 => Dict(:C => [:v1]))),
+    :B => PkgData([:v1], Dict(:v1 => [:C]), Dict(:v1 => Dict(:C => [:v2]))),
+    :C => PkgData([:v2, :v1], DEPS_NONE, COMP_NONE),
+    :E => PkgData([:v1], Dict(:v1 => [:G]), Dict(:v1 => Dict(:G => [:v1]))),
+    :F => PkgData([:v1], Dict(:v1 => [:G]), Dict(:v1 => Dict(:G => [:v2]))),
+    :G => PkgData([:v2, :v1], DEPS_NONE, COMP_NONE),
+)
+
+# one requirement, one dependency, and room for a bound to take the dependency
+# away. Nothing in this registry tells :B's versions apart, so they are one
+# class and it takes every one of them to empty it
+const needs_dep = Dict(
+    :A => PkgData([:v1], Dict(:v1 => [:B]), COMP_NONE),
+    :B => PkgData([:w3, :w2, :w1], DEPS_NONE, COMP_NONE),
+)
+
+@testset "diagnosis: independent conflicts come out separately" begin
+    d = check_diagnosis(two_conflicts, Problem([:A, :B, :E, :F]))
+    @test d isa Diagnosis
+    @test length(d.conflicts) == 2
+    @test Set(Set(c.reqs) for c in d.conflicts) ==
+        Set([Set([:A, :B]), Set([:E, :F])])
+    # repairing needs one requirement out of each conflict: 2 × 2 ways
+    @test length(d.fixes) == 4
+    @test Set(Set(a.pkg for a in fix.actions) for fix in d.fixes) ==
+        Set(Set([x, y]) for x in (:A, :B), y in (:E, :F))
+    @test all(a.kind === :drop for fix in d.fixes for a in fix.actions)
+    # and the requirements the conflict does not need stay out of it
+    d = check_diagnosis(two_conflicts, Problem([:A, :B, :C]))
+    @test length(d.conflicts) == 1
+    @test d.conflicts[1].reqs == [:A, :B]
+end
+
+@testset "diagnosis: one conflict does not split" begin
+    # three requirements that fail only together: each pair agrees on a version
+    # of :D, all three on none
+    data = Dict(
+        :A => PkgData([:v1], Dict(:v1 => [:D]), Dict(:v1 => Dict(:D => [:v1, :v2]))),
+        :B => PkgData([:v1], Dict(:v1 => [:D]), Dict(:v1 => Dict(:D => [:v2, :v3]))),
+        :C => PkgData([:v1], Dict(:v1 => [:D]), Dict(:v1 => Dict(:D => [:v3, :v1]))),
+        :D => PkgData([:v3, :v2, :v1], DEPS_NONE, COMP_NONE),
+    )
+    d = check_diagnosis(data, Problem([:A, :B, :C]))
+    @test length(d.conflicts) == 1
+    @test d.conflicts[1].reqs == [:A, :B, :C]
+    # every pair of them is fine, which is what makes it one conflict
+    for pair in ([:A, :B], [:A, :C], [:B, :C])
+        @test resolve(data, Problem(pair); diagnose = false) !== nothing
+    end
+end
+
+@testset "diagnosis: the story names the constraint" begin
+    prob = Problem([:A]; compat = Dict(:B => [:w1]), pin = Dict(:B => :w2))
+    d = check_diagnosis(needs_dep, prob)
+    @test length(d.conflicts) == 1
+    c = only(d.conflicts)
+    @test c.reqs == [:A]
+    @test c.chain == Fact[Requirement(:A),
+        Availability{Symbol,Symbol}(:B, [:w3, :w2, :w1],
+            [[:compat, :pin], [:compat], [:pin]])]
+    @test unavailable(c.chain[2])
+    # the cheapest version to give back costs one kind, so that is the fix —
+    # and not requiring :A is the other
+    @test [fix.actions for fix in d.fixes] ==
+        [[Action(:compat, :B)], [Action(:drop, :A)]]
+    @test d.fixes[1].solution == Dict(:A => :v1, :B => :w2)
+    @test isempty(d.fixes[2].solution)
+end
+
+@testset "diagnosis: a package with a version left over" begin
+    # :R@r1 needs :P and rules out :P@p1, and the bound takes :P@p2 away — so
+    # :P is left with a version, just not one that works here
+    data = Dict(
+        :R => PkgData([:r1], Dict(:r1 => [:P]), Dict(:r1 => Dict(:P => [:p2]))),
+        :P => PkgData([:p2, :p1], DEPS_NONE, COMP_NONE),
+    )
+    d = check_diagnosis(data, Problem([:R]; compat = Dict(:P => [:p1])))
+    f = d.conflicts[1].chain[2]::Availability
+    @test f.pkg == :P
+    @test f.members == [:p2, :p1]
+    @test f.excluded == [[:compat], Symbol[]]
+    @test !unavailable(f)
+    @test sprint(show, MIME("text/plain"), d) == """
+        Unsatisfiable — 1 conflict, 2 fixes:
+
+        Conflict 1: R cannot be satisfied.
+          • you require R
+          • P: p2 is excluded by your compat
+
+        Verified fixes:
+          1. relax your compat on P
+             → allows: P p2, R r1
+          2. drop requirement R
+        """
+end
+
+@testset "diagnosis: any kind is a constraint like any other" begin
+    prob = Problem([:A];
+        prerelease = (p, v) -> p === :B && v !== :w1,
+        yanked     = (p, v) -> p === :B && v === :w1)
+    d = check_diagnosis(needs_dep, prob)
+    f = d.conflicts[1].chain[2]::Availability
+    @test f.excluded == [[:prerelease], [:prerelease], [:yanked]]
+    # one kind is enough to give the package back, and the best version it
+    # would give back costs the prerelease one
+    @test [fix.actions for fix in d.fixes] ==
+        [[Action(:prerelease, :B)], [Action(:drop, :A)]]
+    @test d.fixes[1].solution == Dict(:A => :v1, :B => :w3)
+    @test occursin("allow prerelease versions of B",
+        sprint(show, MIME("text/plain"), d))
+end
+
+@testset "diagnosis: a requirement with nothing to install" begin
+    data = Dict(
+        :A => PkgData(Symbol[], DEPS_NONE, COMP_NONE),
+        :B => PkgData([:v1], DEPS_NONE, COMP_NONE),
+    )
+    d = check_diagnosis(data, Problem([:A, :B]))
+    @test length(d.conflicts) == 1
+    @test d.conflicts[1].reqs == [:A]
+    @test d.conflicts[1].chain == Fact[Requirement(:A),
+        Availability{Symbol,Symbol}(:A, Symbol[], Vector{Symbol}[])]
+    # nothing this query does is what took it away, so dropping it is all that
+    # could help — and :B still resolves once it is gone
+    @test [fix.actions for fix in d.fixes] == [[Action(:drop, :A)]]
+    @test only(d.fixes).solution == Dict(:B => :v1)
+    @test occursin("no version of A is available",
+        sprint(show, MIME("text/plain"), d))
+end
+
+@testset "diagnosis: the instance is left as it was found" begin
+    # Diagnosing takes the instance apart and puts it back: the deactivation
+    # frame comes off, a frame of definitional clauses goes on inside it, both
+    # are undone, and then a relaxation is resolved on the instance per fix. An
+    # instance is reusable, so what has to be true afterwards is that it answers
+    # every question exactly as it did — the emptied classes still emptied,
+    # every verdict what it was.
+    #
+    # What the instance answers is the whole of the contract, and it is the
+    # only thing worth asserting: the solver's clause and variable counts both
+    # grow, since popping a frame satisfies its clauses rather than removing
+    # them and the definitional variables outlive the clauses that defined
+    # them. Neither moves an answer, and a bare lift with no diagnosis at all
+    # grows the clause count exactly the same way.
+    unavailable_dep = Problem([:A];
+        compat = Dict(:B => [:w1]), pin = Dict(:B => :w2))
+    one_left = Problem([:R]; compat = Dict(:P => [:p1]))
+    left_over = Dict(
+        :R => PkgData([:r1], Dict(:r1 => [:P]), Dict(:r1 => Dict(:P => [:p2]))),
+        :P => PkgData([:p2, :p1], DEPS_NONE, COMP_NONE),
+    )
+    cases = [
+        # a query that emptied classes of one package ...
+        needs_dep => unavailable_dep,
+        left_over => one_left,
+        # ... of several ...
+        needs_dep => Problem([:A]; compat = Dict(:A => Symbol[], :B => Symbol[])),
+        # ... and one that emptied none at all, so there is no frame to lift
+        two_conflicts => Problem([:A, :B, :E, :F]),
+    ]
+    for (data, prob) in cases
+        sat, univ, _ = failed_instance(data, prob)
+        try
+            before = verdicts(sat)
+            deact = copy(sat.deact)
+            # diagnosing twice over, since restoring has to be repeatable
+            for _ = 1:2
+                @test Diagnostics.diagnose(sat, prob, univ) isa Diagnosis
+                @test verdicts(sat) == before
+                @test sat.deact == deact
+                @test !issatisfiable(sat, prob.reqs)
+            end
+            # and the frame is genuinely back rather than never having been
+            # there: re-imposing it by assumption says what it says
+            @test verdicts(sat, sat.deact) == before
+        finally
+            finalize(sat)
+        end
+    end
+end
+
+## the API
+
+@testset "diagnosis: what resolve returns" begin
+    prob = Problem([:A]; compat = Dict(:B => Symbol[]))
+    for src in (needs_dep, pkg_info(needs_dep, prob))
+        @test resolve(src, Problem([:A])) isa Dict{Symbol,Symbol}
+        @test resolve(src, prob) isa Diagnosis{Symbol,Symbol}
+        @test resolve(src, prob; diagnose = false) === nothing
+        # ... and through the bare-requirements form, which is the
+        # unconstrained problem and so diagnoses the same way
+        @test resolve(src, [:A]) isa Dict{Symbol,Symbol}
+    end
+    # `issatisfiable` is untouched by any of it
+    @test !issatisfiable(needs_dep, prob)
+    @test issatisfiable(needs_dep, Problem([:A]))
+    # a caller-supplied T1 artifact comes through a diagnosed resolve intact,
+    # as it does through any other
+    info = pkg_info(needs_dep, prob)
+    before = deepcopy(info)
+    @test resolve(info, prob) isa Diagnosis
+    @test info == before
+    # ... and the data-dict entry point, whose artifact the resolve is allowed
+    # to consume, diagnoses just the same
+    @test resolve(copy(needs_dep), prob) isa Diagnosis
+end
+
+## rendering
+
+@testset "diagnosis: the report" begin
+    d = resolve(two_conflicts, Problem([:A, :B, :E, :F]))
+    @test sprint(show, MIME("text/plain"), d) == """
+        Unsatisfiable — 2 conflicts, 4 fixes:
+
+        Conflict 1: A and B cannot be satisfied together.
+          • you require A
+          • you require B
+
+        Conflict 2: E and F cannot be satisfied together.
+          • you require E
+          • you require F
+
+        Verified fixes:
+          1. drop requirement B and drop requirement F
+             → allows: A v1, E v1
+          2. drop requirement B and drop requirement E
+             → allows: A v1, F v1
+          3. drop requirement A and drop requirement F
+             → allows: B v1, E v1
+          4. drop requirement A and drop requirement E
+             → allows: B v1, F v1
+        """
+    # the one-line summary
+    @test sprint(show, d) == "Diagnosis: 2 conflicts, 4 fixes"
+
+    # every kind that excludes a version is named, and a long line is filled
+    d = resolve(needs_dep,
+        Problem([:A]; compat = Dict(:B => [:w1]), pin = Dict(:B => :w2)))
+    @test sprint(show, MIME("text/plain"), d) == """
+        Unsatisfiable — 1 conflict, 2 fixes:
+
+        Conflict 1: A cannot be satisfied.
+          • you require A
+          • no version of B is available: w3 is excluded by your compat and your pin,
+            w2 by your compat, w1 by your pin
+
+        Verified fixes:
+          1. relax your compat on B
+             → allows: A v1, B w2
+          2. drop requirement A
+        """
+end
+
+@testset "diagnosis: the report says nothing about how it was found" begin
+    # classes, literals, assumptions, cores and the solver are how the answer
+    # was found; what it says is about packages, versions and constraints
+    cases = [
+        two_conflicts => Problem([:A, :B, :E, :F]),
+        needs_dep => Problem([:A]; compat = Dict(:B => Symbol[])),
+        needs_dep => Problem([:A]; pin = Dict(:B => :w9)),
+        needs_dep => Problem([:A]; compat = Dict(:B => Symbol[]),
+                                   pin = Dict(:A => :v9)),
+    ]
+    for (data, prob) in cases
+        d = resolve(data, prob)
+        @test d isa Diagnosis
+        report = sprint(show, MIME("text/plain"), d)
+        for word in ("class", "literal", "assum", "MUS", "MCS", "core",
+                     "solver", "SAT", "clause", "variable", "deactivat")
+            @test !occursin(word, report)
+        end
+    end
+    # an action reads as something the user could carry out, whatever the kind
+    # of the constraint it lifts is called
+    @test action_phrase(Action(:drop, :A)) == "drop requirement A"
+    @test action_phrase(Action(:compat, :A)) == "relax your compat on A"
+    @test action_phrase(Action(:pin, :A)) == "unpin A"
+    @test action_phrase(Action(:prerelease, :A)) ==
+        "allow prerelease versions of A"
+end
+
+## sweeps
+
+@testset "diagnosis: verified fixes over generated data" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    diagnoses = fixes = relaxations = 0
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:10
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            for shape in SHAPES, by in (identity, p -> -p)
+                prob = random_problem(reqs, m, n, shape)
+                diag = check_diagnosis(data, prob; by)
+                diag === nothing && continue
+                diagnoses += 1
+                fixes += length(diag.fixes)
+                relaxations += count(a.kind !== :drop
+                    for fix in diag.fixes for a in fix.actions)
+            end
+        end
+    end
+    # the sweep really did diagnose, the diagnoses really did offer fixes, and
+    # the fixes really did include relaxing a constraint rather than only
+    # dropping requirements
+    @test diagnoses > 0
+    @test fixes > diagnoses
+    @test relaxations > 0
+end
+
+@testset "diagnosis: verified fixes under a version ordering" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    diagnosed = 0
+    up = p -> (u, v) -> u > v # prefer the lowest version
+    for (m, n) in ((2, 3), (3, 2), (3, 3))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:8
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            prob = random_problem(reqs, m, n, :all)
+            for order in (nothing, up)
+                diagnosed += check_diagnosis(data, prob; order) !== nothing
+            end
+        end
+    end
+    @test diagnosed > 0
+end
+
+@testset "diagnosis: registry-scale" begin
+    rp = registry.provider()
+    # a bound that leaves DataFrames' table printer with nothing, on a
+    # DataFrames new enough to need one
+    prob = Problem(["DataFrames"];
+        compat = Dict("DataFrames" => VersionSpec("1"),
+                      "PrettyTables" => VersionSpec("99")))
+    d = check_diagnosis(rp, prob)
+    @test d isa Diagnosis{String,VersionNumber}
+    c = only(d.conflicts)
+    @test c.reqs == ["DataFrames"]
+    # the story is the requirement, the bound that forces a modern DataFrames,
+    # and the bound that leaves it without a table printer
+    @test any(f isa Availability && f.pkg == "PrettyTables" && unavailable(f)
+              for f in c.chain)
+    # relaxing either bound is a fix, and so is not requiring DataFrames
+    sets = Set(Set(fix.actions) for fix in d.fixes)
+    @test Set([Action(:compat, "PrettyTables")]) ∈ sets
+    @test Set([Action(:drop, "DataFrames")]) ∈ sets
+    for fix in d.fixes
+        fix.actions == [Action(:compat, "PrettyTables")] || continue
+        @test fix.solution["DataFrames"] ∈ VersionSpec("1")
+        @test haskey(fix.solution, "PrettyTables")
+    end
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("no version of PrettyTables is available", report)
+    @test occursin("relax your compat on PrettyTables", report)
+end

--- a/test/ordering.jl
+++ b/test/ordering.jl
@@ -46,7 +46,8 @@ end
 # passing a comparator == baking the same order into the data
 function test_order_equivalence(data, prob, order; by::Function = identity)
     baked = bake_order(data, order)
-    @test resolve(data, prob; by, order) == resolve(baked, prob; by)
+    @test resolve(data, prob; by, order, diagnose = false) ==
+          resolve(baked, prob; by, diagnose = false)
 end
 
 @testset "ordering: permutations and identity" begin
@@ -146,8 +147,9 @@ end
                 # ... and the ordering must not disturb the bake-equivalence of
                 # the user constraints either
                 prob = Problem(reqs; compat, pin)
-                @test resolve(data, prob; by, order) ==
-                      resolve(bake(bake_order(data, order), prob), reqs; by)
+                @test resolve(data, prob; by, order, diagnose = false) ==
+                      resolve(bake(bake_order(data, order), prob), reqs;
+                              by, diagnose = false)
             end
         end
     end
@@ -196,10 +198,11 @@ end
                 for prob in (Problem(reqs), Problem(reqs; compat, pin)),
                     order in (CANONICAL, reversed(m, n), shuffled(m, n))
                     baked = bake_order(data, order)
-                    @test resolve(all_reqs, prob; order) == resolve(baked, prob)
+                    @test resolve(all_reqs, prob; order, diagnose = false) ==
+                          resolve(baked, prob; diagnose = false)
                     # ... and the same artifact answers the next query too
-                    @test resolve(all_reqs, prob; order) ==
-                          resolve(all_reqs, prob; order)
+                    @test resolve(all_reqs, prob; order, diagnose = false) ==
+                          resolve(all_reqs, prob; order, diagnose = false)
                 end
             end
             @test all_reqs == before

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -96,8 +96,11 @@ end
 # `resolve(data, prob)` must agree with the unconstrained resolve of the baked
 # data — including when both are `nothing`
 function test_bake_equivalence(data, prob; by::Function = identity)
-    sol = resolve(data, prob; by)
-    @test sol == resolve(bake(data, prob), prob.reqs; by)
+    # the answer, not the report an unsatisfiable resolve otherwise returns:
+    # the two sides here agree on the verdict, and a report about constraints
+    # only one side has is a different thing to compare (see test/diagnostics.jl)
+    sol = resolve(data, prob; by, diagnose = false)
+    @test sol == resolve(bake(data, prob), prob.reqs; by, diagnose = false)
     # and the cheap verdict agrees with the descent's, constraints and all
     @test issatisfiable(data, prob) == (sol !== nothing)
 end
@@ -278,7 +281,7 @@ end
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
     prob = Problem([:A]; compat = Dict(:B => Symbol[]))
-    @test resolve(data, prob) === nothing
+    @test resolve(data, prob; diagnose = false) === nothing
     test_bake_equivalence(data, prob)
 
     # an excluded version must not dominate a non-excluded one: B@v2 has no
@@ -416,7 +419,8 @@ end
     # ... and it is the same problem as the equivalent compat bounds
     both = Problem([:A]; compat = Dict(:A => [:v1], :B => [:v1]))
     @test exclusion_masks(info, both) == excl
-    @test resolve(data, prob) == resolve(data, both)
+    @test resolve(data, prob; diagnose = false) ==
+          resolve(data, both; diagnose = false)
     test_bake_equivalence(data, prob)
 
     # kinds are indistinguishable once they have emptied a class -- and here
@@ -477,14 +481,14 @@ end
                 as_compat = Problem(reqs;
                     compat = mergewith!(∩, Dict(compat), Dict(allowed)), pin)
                 for by in (identity, p -> -p)
-                    @test resolve(data, as_kind; by) ==
-                          resolve(data, as_compat; by)
+                    @test resolve(data, as_kind; by, diagnose = false) ==
+                          resolve(data, as_compat; by, diagnose = false)
                     test_bake_equivalence(data, as_kind; by)
                 end
                 # ... and the ordering stays orthogonal to it
                 order = p -> (u, v) -> u > v
-                @test resolve(data, as_kind; order) ==
-                      resolve(bake(data, as_kind), reqs; order)
+                @test resolve(data, as_kind; order, diagnose = false) ==
+                      resolve(bake(data, as_kind), reqs; order, diagnose = false)
             end
         end
     end
@@ -525,7 +529,8 @@ end
     lo = p -> -Int(first(string(p))) # reverse alphabetical priority
     for (data, prob) in cases, by in (identity, lo)
         baked = bake(data, prob)
-        @test resolve(data, prob; by) == ref_resolve(baked, prob.reqs; by)
+        @test resolve(data, prob; by, diagnose = false) ==
+              ref_resolve(baked, prob.reqs; by)
         test_bake_equivalence(data, prob; by)
     end
     for (data, prob) in cases
@@ -620,7 +625,7 @@ end
             while true
                 fill_data!(m, n, deps, comp, data)
                 test_bake_equivalence(data, prob)
-                sol = resolve(data, prob)
+                sol = resolve(data, prob; diagnose = false)
                 sol === nothing && break
                 p = rand(collect(keys(sol)))
                 v = sol[p]

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -9,8 +9,7 @@
 
 using Resolver: Problem, PkgData, PkgInfo, pkg_info, SAT, PicoSAT,
     exclusion_masks, is_excluded, finalize, sat_assume, sat_pop,
-    is_satisfiable, rank_pkg_info, prepare_pkg_info, Constraint, Compat, Pins,
-    Predicate, excludes, named, relax
+    is_satisfiable, rank_pkg_info, prepare_pkg_info, Constraint, relax
 
 # delete the versions `prob` excludes from each package's data, old-style
 function bake(

--- a/test/relaxation_stable.jl
+++ b/test/relaxation_stable.jl
@@ -155,7 +155,7 @@ revivals(univ, rp) = count(
                 for rp in sample_relaxations(info, univ, Q, 4)
                     R = rp.prob
                     # Theorem C: reuse answers R exactly as a fresh resolve does
-                    @test resolve(sat, rp) == resolve(info, R)
+                    @test resolve(sat, rp) == resolve(info, R; diagnose = false)
                     # Theorem B, the sharper statement: nothing a fresh filter
                     # for R keeps is missing from the universe filtered for Q
                     @test isempty(setdiff(classkeys(prepare_pkg_info(info, R)), have))
@@ -371,7 +371,8 @@ end
         Q = Problem(reqs; compat, pin, test = (p, v) -> v == bad)
         univ = prepare_pkg_info(info, Q)
         rels = sample_relaxations(info, univ, Q, 8)
-        want = Dict(i => resolve(info, rp.prob) for (i, rp) in enumerate(rels))
+        want = Dict(i => resolve(info, rp.prob; diagnose = false)
+                    for (i, rp) in enumerate(rels))
         sat = SAT(univ)
         try
             # `verdicts` (relaxation.jl) is the instance's answers to every

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,7 +110,7 @@ end
 @testset "resolve: single solution" begin
     for ex in tiny_data.examples
         data, reqs = ex.data, ex.reqs
-        sol = resolve(data, reqs)
+        sol = resolve(data, reqs; diagnose = false)
         # a package => version dict covering the requirements, or nothing
         if sol !== nothing
             @test sol isa Dict{Int,Int}
@@ -118,8 +118,8 @@ end
         end
         # deterministic: resolving again, and with the requirements supplied
         # in a different order, yields the same solution
-        @test resolve(data, reqs) == sol
-        @test resolve(data, reverse(collect(reqs))) == sol
+        @test resolve(data, reqs; diagnose = false) == sol
+        @test resolve(data, reverse(collect(reqs)); diagnose = false) == sol
     end
 end
 
@@ -135,7 +135,8 @@ end
             fill_data!(m, n, deps, comp, data)
             for reqs_bits = 0:2^m-1, by in (hi, lo)
                 reqs = collect(make_reqs(reqs_bits))
-                @test resolve(data, reqs; by) == ref_resolve(data, reqs; by)
+                @test resolve(data, reqs; by, diagnose = false) ==
+                      ref_resolve(data, reqs; by)
             end
         end
     end
@@ -180,8 +181,10 @@ using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file, nclasses
             @test all(back[p].members == info[p].members for p in keys(info))
             @test all(nclasses(back[p]) == nclasses(info[p]) for p in keys(info))
             for prob in probs
-                @test resolve(back, prob) == resolve(info, prob)
-                @test resolve(back, prob) == resolve(data, prob)
+                @test resolve(back, prob; diagnose = false) ==
+                      resolve(info, prob; diagnose = false)
+                @test resolve(back, prob; diagnose = false) ==
+                      resolve(data, prob; diagnose = false)
             end
             rm(path)
         end
@@ -224,8 +227,8 @@ end
         :A => PkgData(Symbol[], nodeps, nocomp),
         :B => PkgData([:v1], nodeps, nocomp),
     )
-    @test resolve(data, [:A]) === nothing
-    @test resolve(data, [:A, :B]) === nothing
+    @test resolve(data, [:A]; diagnose = false) === nothing
+    @test resolve(data, [:A, :B]; diagnose = false) === nothing
     @test resolve(data, [:B]) == Dict(:B => :v1)
     @test isempty(resolve(data, Symbol[]))
     @test !haskey(pkg_info(data, [:A]), :A)
@@ -237,7 +240,7 @@ end
         :A => PkgData([:v1], Dict(:v1 => [:B]), nocomp),
         :B => PkgData(Symbol[], nodeps, nocomp),
     )
-    @test resolve(data, [:A]) === nothing
+    @test resolve(data, [:A]; diagnose = false) === nothing
     @test isempty(resolve(data, Symbol[]))
     @test isempty(pkg_info(data, [:A]))
     @test isempty(pkg_info(data, Symbol[]))
@@ -253,7 +256,7 @@ end
         :B => PkgData(Symbol[], nodeps, nocomp),
         :C => PkgData([:v1], Dict(:v1 => [:A]), nocomp),
     )
-    @test resolve(data, [:C]) === nothing
+    @test resolve(data, [:C]; diagnose = false) === nothing
     @test isempty(pkg_info(data, [:C]))
     test_resolver(data, [:C])
 
@@ -281,7 +284,7 @@ end
         :B => PkgData(Symbol[], nodeps, nocomp),
     )
     info = pkg_info(data, [:A]; filter = false)
-    @test resolve(info, [:A]) === nothing
+    @test resolve(info, [:A]; diagnose = false) === nothing
     data = Dict(
         :A => PkgData([:v2, :v1], Dict(:v2 => [:B]), nocomp),
         :B => PkgData(Symbol[], nodeps, nocomp),
@@ -299,6 +302,7 @@ include("classes.jl")
 include("class_space.jl")
 include("relaxation.jl")
 include("relaxation_stable.jl")
+include("diagnostics.jl")
 include("ordering.jl")
 
 @testset "registry resolve" begin
@@ -325,7 +329,7 @@ include("ordering.jl")
     # pin at a version that doesn't exist
     missing_pin = Resolver.Problem(["JSON"]; pin = Dict("JSON" => v"0.0.0"))
     @test !issatisfiable(rp, missing_pin)
-    @test resolve(rp, missing_pin) === nothing
+    @test resolve(rp, missing_pin; diagnose = false) === nothing
 end
 
 @testset "yanked packages" begin

--- a/test/satisfiable.jl
+++ b/test/satisfiable.jl
@@ -64,14 +64,15 @@ end
                      Problem([:A]; pin = Dict(:B => :v9)),
                      Problem([:A, :B]; compat = Dict(:Z => Symbol[])),
                      Problem(Symbol[]))
-            @test issatisfiable(src, prob) == (resolve(src, prob) !== nothing)
+            @test issatisfiable(src, prob) ==
+                  (resolve(src, prob; diagnose = false) !== nothing)
         end
         # bare requirements are the unconstrained problem
         @test issatisfiable(src, [:A]) == issatisfiable(src, Problem([:A]))
         # requirements may be a set as well as a vector, and default to the
         # whole universe
         @test issatisfiable(src, Set([:A])) == issatisfiable(src, [:A])
-        @test issatisfiable(src) == (resolve(src) !== nothing)
+        @test issatisfiable(src) == (resolve(src; diagnose = false) !== nothing)
     end
 
     # ... and a SAT instance, the shape the others build internally
@@ -157,7 +158,8 @@ end
     try
         counts = solve_count(sat) !== nothing
         clauses = PicoSAT.clause_count(sat.pico)
-        @test resolve(sat, reqs; restore = false) == resolve(data, reqs)
+        @test resolve(sat, reqs; restore = false) ==
+              resolve(data, reqs; diagnose = false)
         @test !counts || solve_count(sat) > 1
         @test PicoSAT.clause_count(sat.pico) > clauses
     finally
@@ -186,7 +188,7 @@ end
                 verdict = issatisfiable(data, prob)
                 for by in (hi, lo), order in (nothing, up)
                     @test verdict ==
-                        (resolve(data, prob; by, order) !== nothing)
+                        (resolve(data, prob; by, order, diagnose = false) !== nothing)
                 end
             end
         end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -30,8 +30,10 @@ function test_resolver(
     data :: AbstractDict{P,<:PkgData{P,V}},
     reqs :: AbstractVector{P},
 ) where {P,V}
-    # resolve: a single optimal solution, or nothing when unsatisfiable
-    sol = resolve(data, reqs)
+    # resolve: a single optimal solution, or nothing when unsatisfiable. what
+    # this checks is the answer, so it asks for the verdict rather than the
+    # report an unsatisfiable resolve otherwise returns (see test/diagnostics.jl)
+    sol = resolve(data, reqs; diagnose = false)
 
     # the cheap feasibility check must reach the same verdict as the descent:
     # this is `issatisfiable`'s whole contract, so every sweep checks it


### PR DESCRIPTION
**Stacked on #72** (`relaxation-substrate`); GitHub retargets to `main` when that merges.

A failed resolve stops saying `nothing` and starts saying why. `resolve` returns a `Diagnosis`: the independent conflicts, each with a short chain of facts, and a menu of fixes that have each been checked by actually re-resolving the fixed problem. `diagnose = false` restores the bare `nothing` for callers that only want the verdict.

```
Unsatisfiable — 1 conflict, 3 fixes:

Conflict 1: DataFrames cannot be satisfied.
  • you require DataFrames
  • DataFrames: 0.11.7–0.22.7 are excluded by your compat
  • no version of PrettyTables is available: 0.1.0–3.4.5 are excluded by your compat

Verified fixes:
  1. relax your compat on PrettyTables
     → allows: DataFrames 1.8.2, PrettyTables 3.4.5
  2. relax your compat on DataFrames
     → allows: DataFrames 0.21.8
  3. drop requirement DataFrames
```

## How it works

Two things are assumable — "package p is installed" and "class c of p is forbidden" — and everything else about the problem is a clause the diagnosis never touches. On that footing the whole thing is four calls into `Resolver.UnsatCores` and one re-resolve:

- **Independent conflicts** are the disjoint minimal unsatisfiable subsets of the requirements.
- **A conflict's story** is a minimal unsatisfiable subset of that conflict's requirements plus the packages this query left with nothing installable, shrunk with the requirements attempted first so the surviving chain prefers the facts a user can act on.
- **The fix menu** is the minimal correction sets over the same candidates, enumerated with requirements *kept* first so the menu prefers relaxing a constraint over dropping a dependency.
- **A correction set becomes user actions** through #72's attribution: reactivating a class is not something a user does, so for each one we name the constraints that emptied it — cheapest member first.
- **Every fix is verified by re-resolving the modified problem from the artifact**, and the solution that resolve returns is the witness printed in the report. That is what "what you would get" means, and it is also what keeps #70's query-order caveat out of user-visible output: no version in a report is ever read off an instance filtered under constraints the fix relaxes.

Facts are per *package*, not per class. Per-class facts read as ten near-identical clauses for one package at registry scale, and they cannot be merged at render time without lying — a real case (`PrettyTables` pinned at 0.9.1) has an admitted version sitting between two excluded blocks. So a package's story is minimized over one literal standing for all of its emptied classes, introduced as a definitional extension in a scoped frame: the new variable occurs only negatively, so every model extends with it false and none is removed. The same granularity fixes the fix menu, where per-class enumeration produced *k* identical singleton corrections for one package and exhausted the limit on duplicates.

## Scope

Conflicts caused by registry compatibility between classes that are *not* empty are reported at requirement level — "A and B cannot be satisfied together" — without yet naming the bound responsible. Naming it, and suggesting the upstream release that would fix it, is the next PR. Goals, holdbacks and the presentation toolkit follow after that.

## Testing

`check_diagnosis` re-derives everything independently rather than trusting the implementation: each conflict's facts are asserted jointly unsatisfiable *and* individually load-bearing, each emptiness fact is checked against `class_exclusions` class by class, and — the central property — each fix's actions are applied to the `Problem` and re-resolved from the artifact, asserting the result equals the recorded witness. Swept over the tiny grids × constraint draws × admission kinds × two priority orders and two version orderings, with counters asserting the sweep actually produced multi-fix diagnoses and fixes that relax constraints rather than only dropping requirements. Plus: the instance is left exactly as it was found (verdict battery before and after, four shapes, each diagnosed twice), and a registry-scale case end to end through `bin/resolve.jl`.

## Co-author

Implemented with [Claude Code](https://claude.com/claude-code): implementation and review by Claude, directed and reviewed by @StefanKarpinski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p2sckwc5Gjjg5LG6gdEk7