### PR TITLE
Relaxation-stable filtering: a filtered universe serves every relaxation of its query

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(
             "Setting" => "theory/setting.md",
             "The layered solution & filtering" => "theory/layered.md",
             "Pareto front optimality" => "theory/front.md",
+            "Relaxation-stable filtering" => "theory/relaxation.md",
         ],
     ],
 )

--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -74,6 +74,21 @@ Real problems are shrunk before solving by two passes
 its constraints — every dependency and every (surviving) conflict of
 ``q@i`` is also one of ``q@j`` — iterated to a fixpoint.
 
+!!! note "What the code runs is weaker than this"
+    Both rules as stated are what the theorems below are proved against, and
+    both are *stronger* than what `find_reachable` and `mark_necessary!`
+    actually apply. The implemented rules replace "the first version" with
+    "every version some relaxation of this query could put first", and
+    "``i < j``" with a comparison that no relaxation can reverse, so that the
+    filtered universe serves every relaxation of the query and not only the
+    query — see [Relaxation-stable filtering](relaxation.md).
+
+    Nothing below needs restating for that. The implemented reachability keeps
+    a superset of the prefix above (Theorem D there) and the implemented
+    redundancy deletes a subset of what the ``i < j`` rule deletes (its Rule A
+    implies ``i < j``), so every deletion the implementation makes is one this
+    page already licenses, and Theorem 4 carries the answer through.
+
 The intuition behind reachability is: *an optimal solution only settles for
 a worse version for a reason, and the reason is a conflict.* That intuition
 is exactly right for the layered (pointwise) semantics, and the theorems

--- a/docs/src/theory/relaxation.md
+++ b/docs/src/theory/relaxation.md
@@ -1,0 +1,371 @@
+# Relaxation-stable filtering
+
+The previous page proves that filtering preserves the answer to *the query
+it was run for*. This page proves something stronger, which is what lets a
+failed resolve be explained rather than merely reported: the filtered
+universe answers every **relaxation** of that query too.
+
+A relaxation is the same query with some of its demands withdrawn — a
+requirement dropped, a compat entry ignored, a pin released. Those are
+exactly the repairs a user can make to an unsatisfiable problem, so
+"filtered for ``Q``, valid for every ``R \le Q``" is precisely the property
+under which a diagnosis may test candidate fixes on the universe the failed
+resolve already built, instead of re-filtering per fix.
+
+The cost of the stronger property is that the filter deletes slightly less.
+Nothing else changes: the passes, their order, and the fixpoint they iterate
+to are the ones the previous page describes.
+
+## What a relaxation is
+
+Fix an artifact ``D``. A **query** ``Q`` is a requirement set together with a
+set of constraint sources — the compat entries, pins, and admission kinds
+(prereleases, yanked versions) the user's problem carries.
+
+!!! note "Definition (the relaxation order)"
+    ``R \le Q`` — "``R`` is a relaxation of ``Q``" — iff
+    ``\mathrm{reqs}_R \subseteq \mathrm{reqs}_Q`` and ``R``'s constraint
+    sources are a subset of ``Q``'s.
+
+This is a lattice with ``2^{|\mathrm{reqs}_Q| + |\mathrm{sources}_Q|}``
+points, ``Q`` at the top and the empty query at the bottom. Note ``Q \le Q``:
+every statement below about "every relaxation" includes the query itself,
+which is what makes the results here strengthen rather than replace the
+previous page's.
+
+Write ``\mathrm{Lay}(D, R)`` for the layered answer to ``R`` on ``D``.
+
+## Two keys per class, and a third
+
+A class competes at the rank of the best member the query admits. This is
+the whole source of the difficulty: a compat bound that forbids a class's
+best member does not remove the class, it *moves* it, possibly behind a class
+it would otherwise outrank. Relaxing the bound moves it back.
+
+Three quantities per class ``c``, all of them version ranks in the query's
+version order:
+
+- ``\mathrm{adm}_Q(c)`` — the members of ``c`` that ``Q`` admits. ``c`` is
+  **deactivated** under ``Q`` when this is empty.
+- ``\mathrm{key}_Q(c) = \min \mathrm{adm}_Q(c)``, and ``\infty`` when ``c`` is
+  deactivated. This is what the walk minimises over.
+- ``\mathrm{key}_\emptyset(c)`` — the rank of ``c``'s first member, ignoring
+  every constraint. Its key under the empty query.
+- ``\kappa_Q(c) = \mathrm{key}_Q(c)`` for an active class, and
+  ``\mathrm{key}_\emptyset(c)`` for a deactivated one. This is the **layout
+  key**: classes are laid out in ascending ``\kappa_Q``.
+
+The distinction between ``\mathrm{key}_Q`` and ``\kappa_Q`` matters and is
+easy to lose. A deactivated class has no admissible member, so
+``\mathrm{key}_Q`` is ``\infty`` — but it is not laid out last. It is laid
+out where its best member would put it, because that is where a relaxation
+reviving it would put it. `class_ranking_keys` computes exactly this: the
+first loop fills each class's key from its best admissible member, and the
+second fills the classes that got none from their best member, period.
+
+!!! note "Fact 0 (the keys are ordered)"
+    ``\mathrm{key}_\emptyset(c) \le \kappa_Q(c) \le \mathrm{key}_Q(c)`` for
+    every class ``c``.
+
+    *Proof.* If ``c`` is active, ``\mathrm{adm}_Q(c)`` is a subset of ``c``'s
+    members, so its minimum is no smaller:
+    ``\mathrm{key}_\emptyset(c) \le \mathrm{key}_Q(c)``, and
+    ``\kappa_Q(c) = \mathrm{key}_Q(c)``. If ``c`` is deactivated,
+    ``\mathrm{key}_\emptyset(c) = \kappa_Q(c)`` by definition and
+    ``\mathrm{key}_Q(c) = \infty``. ∎
+
+## The one order fact a relaxation cannot reverse
+
+!!! note "Lemma 1 (monotonicity)"
+    For every class ``c`` and every ``R \le Q``:
+    ``\mathrm{key}_\emptyset(c) \le \mathrm{key}_R(c) \le \mathrm{key}_Q(c)``.
+
+    *Proof.* Adding constraint sources only removes admissible members, so
+    ``\mathrm{adm}_Q(c) \subseteq \mathrm{adm}_R(c) \subseteq
+    \mathrm{adm}_\emptyset(c)``. A minimum over a superset is no larger
+    (with ``\min \emptyset = \infty``). ∎
+
+!!! note "Lemma 2 (definite dominance)"
+    If ``\mathrm{key}_Q(c') < \mathrm{key}_\emptyset(c)`` then
+    ``\mathrm{key}_R(c') < \mathrm{key}_R(c)`` for every ``R \le Q``.
+
+    *Proof.* ``\mathrm{key}_R(c') \le \mathrm{key}_Q(c') <
+    \mathrm{key}_\emptyset(c) \le \mathrm{key}_R(c)`` by Lemma 1. ∎
+
+Two consequences the rules below lean on. The hypothesis forces
+``\mathrm{key}_Q(c') < \infty``, so ``c'`` is admissible under ``Q`` and
+hence under every ``R \le Q`` — **a deactivated class can never license
+anything**. And this is the *only* order fact stable under relaxation:
+"``c'`` precedes ``c`` in ``Q``'s layout" is not enough, because ``R`` can
+reverse it.
+
+!!! note "Definition (possibly-best)"
+    For a set ``S`` of classes of one package, ``c \in S`` is
+    **possibly-best in ``S``** iff no ``c' \in S`` has
+    ``\mathrm{key}_Q(c') < \mathrm{key}_\emptyset(c)``. Write ``PB(S)``.
+
+Since ``\mathrm{key}_\emptyset(c) \le \mathrm{key}_Q(c)``, no class
+disqualifies itself, and the test collapses to one scalar: with
+``t = \min \{\mathrm{key}_Q(c') : c' \in S\}``,
+
+```math
+PB(S) = \{\, c \in S : \mathrm{key}_\emptyset(c) \le t \,\}.
+```
+
+!!! note "Lemma 3 (``PB`` covers every relaxation's choice)"
+    For every ``R \le Q`` and every non-empty ``S``:
+    ``\arg\min_{c \in S} \mathrm{key}_R(c) \in PB(S)``.
+
+    *Proof.* Let ``c^*`` minimise ``\mathrm{key}_R`` over ``S`` and suppose
+    ``c^* \notin PB(S)``: some ``c' \in S`` has
+    ``\mathrm{key}_Q(c') < \mathrm{key}_\emptyset(c^*)``, so
+    ``\mathrm{key}_R(c') < \mathrm{key}_R(c^*)`` by Lemma 2, contradicting
+    minimality. ∎
+
+Both filtering rules are the same substitution: wherever the prefix filter
+said "the first class", the relaxation-stable filter says "``PB`` of what
+remains", and Lemma 3 says that covers whatever any relaxation would pick.
+
+## Rule A — redundancy
+
+!!! note "Rule A"
+    Strike class ``c_2`` of package ``p`` only if some class ``c_1`` of ``p``
+    has registry rows ``\subseteq`` ``c_2``'s **and**
+    ``\mathrm{key}_Q(c_1) < \mathrm{key}_\emptyset(c_2)``.
+
+The prefix rule asked only that ``c_1`` precede ``c_2`` in ``Q``'s layout —
+the fact Lemma 2's discussion shows a relaxation can reverse.
+
+!!! note "Theorem A (a struck class is needed by no relaxation)"
+    If ``c_2`` is struck by Rule A then ``\mathrm{Lay}(D, R)`` does not use
+    ``c_2``, for every ``R \le Q``.
+
+    *Proof.* Suppose the layered trace for ``R`` pins ``p`` at ``c_2``,
+    witnessed by a model ``M`` extending the pins so far. Build ``M'`` from
+    ``M`` by putting ``p`` at ``c_1`` instead, at ``c_1``'s best
+    ``R``-admissible member — which exists, since
+    ``\mathrm{key}_R(c_1) \le \mathrm{key}_Q(c_1) < \infty``.
+
+    ``M'`` is a model: ``c_1``'s dependencies are a subset of ``c_2``'s and
+    are already satisfied in ``M``; ``c_1``'s conflicts are a subset of
+    ``c_2``'s, so a conflict of ``c_1`` with a member of ``M`` would be one
+    of ``c_2`` too, contradicting ``M``'s validity. ``M'`` agrees with ``M``
+    everywhere else, hence with the pins.
+
+    By Lemma 2, ``\mathrm{key}_R(c_1) < \mathrm{key}_R(c_2)``, so ``M'``
+    gives ``p`` a strictly better rank under ``R``. The trace pins the best
+    *feasible* class, so it would have pinned ``c_1`` or better, not
+    ``c_2``. Contradiction. ∎
+
+!!! warning "Side condition"
+    The domination test ignores conflicts whose partner class is absent from
+    the universe. That exemption is sound only when evaluated against the
+    *conservatively* kept classes — Rule B's output, or all classes — never
+    against a single query's reach prefix. A partner absent under Rule B is,
+    by Theorem B, needed by no relaxation, so conflicts with it constrain no
+    relevant model; a partner that ``Q``'s prefix alone would drop may well
+    matter under ``R``. This is why the two rules are adopted together.
+
+## Rule B — reachability
+
+!!! note "Rule B"
+    Least fixpoint of sets ``S(p)`` with ``\mathrm{push}(p) \subseteq S(p)``
+    recording the classes the walk has been forced past. Writing
+    ``t(p) = \min\{\mathrm{key}_Q(c) : c \notin \mathrm{push}(p)\}``, an
+    unseeded package has ``S(p) = \emptyset`` and a seeded one has
+    ``S(p) = \{c : \mathrm{key}_\emptyset(c) \le t(p)\}``, subject to:
+
+    1. ``p \in \mathrm{reqs}_Q`` ⇒ ``p`` is seeded.
+    2. ``c \in S(p)`` and ``c`` depends on ``q`` ⇒ ``q`` is seeded.
+    3. ``c \in S(p)`` deactivated ⇒ ``c \in \mathrm{push}(p)``.
+    4. ``c \in S(p)``, ``c' \in S(q)``, ``c`` conflicts with ``c'`` ⇒
+       ``c \in \mathrm{push}(p)`` and ``c' \in \mathrm{push}(q)``.
+    5. ``c \in S(p)`` depends on ``q`` with
+       ``\mathrm{push}(q) = \mathrm{classes}(q)`` ⇒
+       ``c \in \mathrm{push}(p)``.
+
+!!! note "Theorem B (every relaxation's reachable set is kept)"
+    For every ``R \le Q`` and every package ``p``, every class the prefix
+    filter would keep for ``R`` lies in ``S(p)``.
+
+    *Proof.* By induction over the derivation of ``R``'s reach fixpoint,
+    maintaining the invariant
+
+    > (∗) ``\mathrm{passed}_R(p) \subseteq \mathrm{push}(p)`` — the walk has
+    > been forced past everything ``R``'s walk was.
+
+    *Invariant.* ``R`` passes ``c`` for one of three reasons, each firing the
+    matching rule: (a) ``c`` conflicts with a class reachable under ``R``,
+    both in ``S`` by the induction hypothesis, and conflicts are
+    query-independent, so rule 4 fires; (b) ``c`` is not selectable under
+    ``R`` — and since ``\mathrm{adm}_Q(c) \subseteq \mathrm{adm}_R(c)``, not
+    under ``Q`` either, so rule 3 fires; (c) ``c`` depends on a package
+    saturated under ``R``, which by (∗) is saturated here too, so rule 5
+    fires.
+
+    *Seeds.* ``p \in \mathrm{reqs}_R \subseteq \mathrm{reqs}_Q``, so rule 1
+    seeds ``p``, and ``R``'s first class of ``p`` minimises
+    ``\mathrm{key}_R`` over all of ``p``'s classes, which Lemma 3 places in
+    ``S(p)``. Dependencies are the same argument via rule 2.
+
+    *Frontier.* Let ``c^*`` be ``R``'s next class after its passed set:
+    ``c^* = \arg\min \mathrm{key}_R`` over
+    ``\mathrm{classes}(p) \setminus \mathrm{passed}_R(p)``. If
+    ``c^* \in \mathrm{push}(p)`` then ``c^* \in S(p)``, since pushed classes
+    are kept. Otherwise ``c^*`` lies in
+    ``\mathrm{classes}(p) \setminus \mathrm{push}(p)``, which by (∗) is a
+    subset of ``\mathrm{classes}(p) \setminus \mathrm{passed}_R(p)``;
+    ``c^*`` minimises ``\mathrm{key}_R`` over the larger set and belongs to
+    the smaller, so it minimises over the smaller too, and Lemma 3 puts it in
+    ``S(p)``. ∎
+
+## The query's own answer, without a second walk
+
+Theorem B with ``R = Q`` already says ``S(p)`` contains what ``Q``'s own
+prefix walk would keep. That is worth stating concretely, because it is what
+licenses the implementation to run *one* walk: the possibly-best walk is not
+unioned with a prefix walk, and no prefix walk is run at all.
+
+Number each package's classes ``1, \dots, m_p`` in layout order, so
+``\kappa_Q(p, \cdot)`` is non-decreasing. The prefix walk ``W`` is the least
+fixpoint of ``r(p) \in \{0, \dots, m_p+1\}`` under
+
+1. ``p \in \mathrm{reqs}`` ⇒ ``r(p) \ge 1``;
+2. ``j \le r(p)`` and ``p@j`` depends on ``q`` ⇒ ``r(q) \ge 1``;
+3. ``j \le r(p)`` and ``p@j`` deactivated ⇒ ``r(p) \ge j+1``;
+4. ``j \le r(p)``, ``k \le r(q)``, ``p@j`` conflicts with ``q@k`` ⇒
+   ``r(p) \ge j+1`` and ``r(q) \ge k+1``;
+5. ``j \le r(p)``, ``p@j`` depends on ``q``, ``r(q) \ge m_q + 1`` ⇒
+   ``r(p) \ge j+1``.
+
+with saturation written ``r(p) = m_p + 1``. This is `find_reachable` as the
+previous page states it, under the precondition that every class of the
+universe is active on entry — which `drop_unmarked!` establishes, since it
+ends by setting every surviving class's flag.
+
+!!! note "Lemma D1 (a pushed prefix keeps a prefix)"
+    If ``p`` is seeded and ``\{1, \dots, j-1\} \subseteq \mathrm{push}(p)``
+    for some ``1 \le j \le m_p + 1``, then
+    ``\{1, \dots, \min(j, m_p)\} \subseteq S(p)``.
+
+    *Proof.* If ``j = m_p + 1`` then every class is pushed, so
+    ``t(p) = \min \emptyset = \infty`` and ``S(p)`` is all of ``p``'s
+    classes.
+
+    Otherwise ``j \le m_p``. Every ``c < j`` is pushed, so ``t(p)`` is a
+    minimum of ``\mathrm{key}_Q`` over a subset of ``\{c : c \ge j\}``, hence
+
+    ```math
+    t(p) \;\ge\; \min_{c \ge j} \mathrm{key}_Q(c)
+          \;\ge\; \min_{c \ge j} \kappa_Q(c)
+          \;=\; \kappa_Q(j),
+    ```
+
+    using Fact 0 for the middle step and monotonicity of ``\kappa_Q`` in the
+    layout position for the last. Then for every ``i \le j``,
+    ``\mathrm{key}_\emptyset(i) \le \kappa_Q(i) \le \kappa_Q(j) \le t(p)``,
+    again by Fact 0 and monotonicity, so ``i \in S(p)``. ∎
+
+!!! note "Lemma D2 (the prefix walk's pushes are matched)"
+    Every fact ``r(p) \ge j`` derivable by ``W`` implies, at Rule B's
+    fixpoint, that ``p`` is seeded and
+    ``\{1, \dots, j-1\} \subseteq \mathrm{push}(p)``.
+
+    *Proof.* Induction on the derivation of ``r(p) \ge j``.
+
+    *(1)* ``j = 1``: rule 1 seeds ``p``, and the claimed inclusion is empty.
+
+    *(2)* The premise ``j \le r(p)`` is a derived fact, so by the induction
+    hypothesis ``p`` is seeded with ``\{1, \dots, j-1\} \subseteq
+    \mathrm{push}(p)``, whence ``j \in S(p)`` by Lemma D1. ``p@j`` depends on
+    ``q``, so rule 2 seeds ``q``; the inclusion for ``q`` at ``j = 1`` is
+    empty.
+
+    *(3)* As in (2), ``j \in S(p)``. ``p@j`` is deactivated, so rule 3 puts
+    ``j \in \mathrm{push}(p)``; with the induction hypothesis this gives
+    ``\{1, \dots, j\} \subseteq \mathrm{push}(p)``.
+
+    *(4)* As in (2), ``j \in S(p)`` and ``k \in S(q)``. Conflicts are
+    query-independent, so rule 4 pushes both, giving
+    ``\{1, \dots, j\} \subseteq \mathrm{push}(p)`` and
+    ``\{1, \dots, k\} \subseteq \mathrm{push}(q)``.
+
+    *(5)* By the induction hypothesis applied to ``r(q) \ge m_q + 1``,
+    ``\{1, \dots, m_q\} \subseteq \mathrm{push}(q)``, i.e. ``q`` is saturated
+    in Rule B's sense. As in (2), ``j \in S(p)``, so rule 5 pushes it. ∎
+
+!!! note "Theorem D (containment: the union is never necessary)"
+    At the two fixpoints, for every package ``p``:
+
+    ```math
+    \{1, \dots, \min(r(p),\, m_p)\} \;\subseteq\; S(p).
+    ```
+
+    *Proof.* If ``r(p) = 0`` the claim is empty. Otherwise ``r(p) \ge r(p)``
+    is derivable, so Lemma D2 gives ``p`` seeded with
+    ``\{1, \dots, r(p)-1\} \subseteq \mathrm{push}(p)``, and Lemma D1 with
+    ``j = r(p)`` gives the conclusion. ∎
+
+So Theorems 5 and 6 of the previous page transfer unchanged: whatever the
+prefix walk kept for ``Q`` is still kept, and the layered answer to ``Q``
+survives filtering exactly as before. Running a prefix walk alongside and
+keeping the union would add nothing.
+
+!!! note "Remark (why one integer suffices)"
+    ``\mathrm{push}(p)`` only grows, so ``t(p)`` — a minimum over its
+    complement — only rises, so ``S(p) = \{c : \mathrm{key}_\emptyset(c) \le
+    t(p)\}`` only grows and is **downward closed in ``\mathrm{key}_\emptyset``
+    order**. Every rule that pushes a class has that class already in
+    ``S(p)`` as a premise, so ``\mathrm{push}(p) \subseteq S(p)`` needs no
+    separate enforcement and the kept set is exactly the final ``PB``.
+
+    A set-valued frontier is therefore not required: the kept set is a
+    prefix, in ``\mathrm{key}_\emptyset`` order rather than layout order, and
+    one monotone pointer along each of the two orders represents it. That is
+    what `find_reachable` implements.
+
+## Composition
+
+!!! note "Theorem C (relaxation-stable filtering)"
+    Let ``F_Q`` be the filter under ``Q`` using Rules A and B, iterated to a
+    fixpoint. Then for every ``R \le Q``:
+    ``\mathrm{Lay}(F_Q(D), R) = \mathrm{Lay}(D, R)``.
+
+    *Proof.* By Theorems A and B no pass ever deletes a class that
+    ``\mathrm{Lay}(D, R)`` uses, for any ``R \le Q``; deletions compose, so
+    ``\mathrm{Lay}(D, R)`` survives in ``F_Q(D)``. Theorem 4 of the previous
+    page (reduction invariance) then gives equality. ∎
+
+!!! note "Corollary C1 (the point)"
+    A diagnosis may answer any relaxation of a failed query on the universe
+    filtered for that query. Re-filtering per candidate fix is unnecessary.
+
+Because ``\le`` is a lattice with the empty query at the bottom, the same
+argument run at ``Q = \emptyset`` says a universe filtered for no constraints
+at all serves every query over the same requirements — which is what makes a
+filtered artifact worth caching.
+
+## What this does not give
+
+The guarantee is over relaxations of one query, not over arbitrary queries.
+A *different* query — one that adds a requirement, or tightens a bound —
+is not below ``Q`` in the order and is not covered; it needs its own filter
+run. In particular this says nothing about upstream fixes, which change the
+registry rather than the query, and therefore change ``D``.
+
+Nor does it make the class *order* stable. Relaxing genuinely reorders
+classes, and the layered answer depends on that order. What Theorem C says
+is that the surviving universe still contains everything the reordered
+answer needs — so a relaxation is answered by re-ranking and re-solving the
+filtered universe, not by re-filtering it.
+
+!!! warning "Formalization boundary"
+    As on the previous page, the rule sets above are a faithful but
+    hand-made reading of `class_ranking_keys`, `mark_necessary!` and
+    `find_reachable`; the correspondence is checked by review and by the
+    test suite rather than mechanically. `test/relaxation_stable.jl` checks the
+    conclusions directly: for random universes and random queries it
+    enumerates relaxations, re-ranks and re-solves the filtered universe
+    under each, and compares against resolving that relaxation from the
+    unfiltered artifact — an empirical check of Theorem C, and through it
+    of the rules it rests on.

--- a/src/BitKernels.jl
+++ b/src/BitKernels.jl
@@ -36,11 +36,12 @@
 #
 # The passes read the two facts differently, and deliberately so:
 #
-#   * `find_reachable` keeps a prefix of each package's classes and stops at
-#     the first one it can install. A deactivated class cannot be selected, so
-#     the prefix has to continue past it — while its dependencies are followed
-#     anyway, which is what keeps the packages behind it in the universe. Its
-#     own drops clear the in-universe flag.
+#   * `find_reachable` keeps, per package, every class some relaxation of the
+#     query could put first, and stops at the first one it can install. A
+#     deactivated class cannot be selected, so the walk has to continue past
+#     it — while its dependencies are followed anyway, which is what keeps the
+#     packages behind it in the universe. Its own drops clear the in-universe
+#     flag.
 #   * `mark_necessary!` takes deactivated classes off *both* sides of the
 #     domination test: they may not be deleted (a relaxation would want them
 #     back) and they may not dominate (domination says a better class will be

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -52,7 +52,18 @@ be reachable from the thing that gets cached and shared.
 struct Universe{P,V}
     info :: Dict{P, PkgInfo{P,V}}
     reps :: Dict{P, Vector{Int}}
+    # per package, `(key_Q, key_∅)` per class: the version rank the class
+    # competes at under this query, and the rank of its best member with
+    # nothing forbidden. The filter's licence to delete is a comparison of the
+    # two (see the relaxation-stability page). Carried alongside `reps` and
+    # renumbered with it.
+    ranks :: Union{Nothing, Tuple{Dict{P,Vector{Int}}, Dict{P,Vector{Int}}}}
 end
+
+Universe{P,V}(
+    info :: Dict{P, PkgInfo{P,V}},
+    reps :: Dict{P, Vector{Int}},
+) where {P,V} = Universe{P,V}(info, reps, nothing)
 
 # the universe an unconstrained query makes of an artifact: every class stands
 # for its first member (the canonical order's best), nothing is deactivated
@@ -150,15 +161,30 @@ Both outputs are per-resolve state: the partition they index is the registry's,
 but which member stands for a class, and hence how the classes are ordered,
 belongs to the query.
 """
-function class_ranking(
+class_ranking(
     info  :: AbstractDict{P, PkgInfo{P,V}},
     prob  :: Problem{P} = Problem(P[]),
     perms :: Union{Nothing, AbstractDict{P, Vector{Int}}} = nothing,
+) where {P,V} = class_ranking_keys(info, prob, perms, false)[1:2]
+
+# `class_ranking` plus, when `want_keys`, the two per-class rank keys the
+# filter's deletion rules compare: `key_Q` (what `key` below already is) and
+# `key_∅`, the rank of the class's best member ignoring the query's
+# exclusions. Both are returned in the *post-permutation* class layout, like
+# `reps` after `copy_ranked!` — i.e. permuted by `perms′` where there is one.
+function class_ranking_keys(
+    info  :: AbstractDict{P, PkgInfo{P,V}},
+    prob  :: Problem{P},
+    perms :: Union{Nothing, AbstractDict{P, Vector{Int}}},
+    want_keys :: Bool,
 ) where {P,V}
     excl = exclusion_masks(info, prob)
     reps = Dict{P, Vector{Int}}()
     perms′ = Dict{P, Vector{Int}}()
+    keys_q = want_keys ? Dict{P, Vector{Int}}() : nothing
+    keys_0 = want_keys ? Dict{P, Vector{Int}}() : nothing
     key = Int[] # scratch: per class, the rank of the member it competes at
+    key0 = Int[] # scratch: per class, the rank of its best member, period
     for (p, info_p) in info
         m = nclasses(info_p)          # one entry of `reps` and `key` per class
         nv = length(info_p.versions)  # ... walking this many versions to fill them
@@ -188,9 +214,23 @@ function class_ranking(
             end
         end
         reps[p] = reps_p
-        issorted(key) || (perms′[p] = sortperm(key))
+        cperm = issorted(key) ? nothing : sortperm(key)
+        cperm === nothing || (perms′[p] = cperm)
+        if want_keys
+            # key_∅: the rank of each class's best member, exclusions ignored
+            resize!(key0, m)
+            fill!(key0, 0)
+            for r = 1:nv
+                j = cls[perm === nothing ? r : perm[r]]
+                key0[j] == 0 || continue
+                key0[j] = r
+            end
+            keys_q[p] = cperm === nothing ? copy(key) : key[cperm]
+            keys_0[p] = cperm === nothing ? copy(key0) : key0[cperm]
+        end
     end
-    return reps, isempty(perms′) ? nothing : perms′
+    return reps, isempty(perms′) ? nothing : perms′,
+        want_keys ? (keys_q, keys_0) : nothing
 end
 
 """
@@ -241,12 +281,13 @@ function rank_pkg_info(
     order = nothing,
 ) where {P,V}
     perms = version_permutations(info, order)
-    reps, cperms = class_ranking(info, prob, perms)
+    reps, cperms, keys = class_ranking_keys(
+        info, prob, perms, true)
     # reordering reads every matrix while writing a differently laid out one,
     # so the in-place shortcut is only available when nothing moves
     cperms === nothing || info′ !== info ||
         (info′ = Dict{P, PkgInfo{P,V}}())
-    univ = Universe{P,V}(info′, Dict{P, Vector{Int}}())
+    univ = Universe{P,V}(info′, Dict{P, Vector{Int}}(), keys)
     return copy_ranked!(univ, info, reps, cperms)
 end
 
@@ -356,10 +397,17 @@ function relaid_conflicts(
     return X′
 end
 
-filter_pkg_info!(
+# the unconstrained case, filtered in place: ranking an unconstrained query
+# moves no class, so this is `Universe(info)` plus the rank keys the passes
+# compare — which even here are not both the same, since two members of one
+# class still give it one `key_∅`
+function filter_pkg_info!(
     info :: Dict{P, PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info),
-) where {P,V} = filter_pkg_info!(Universe(info), Problem(reqs))
+) where {P,V}
+    prob = Problem(collect(reqs))
+    return filter_pkg_info!(rank_pkg_info(info, prob, info), prob)
+end
 
 function filter_pkg_info!(
     univ :: Universe{P,V},
@@ -386,13 +434,19 @@ function filter_pkg_info!(
     # can satisfy those — so the requirements remain valid across rounds.
     # rounds strictly shrink the total class count, so the loop terminates
     mark_installable!(info)
-    mark_necessary!(info, deactivations(univ))
+    mark_necessary!(info, deactivations(univ), univ.ranks)
     drop_unmarked!(univ)
     while true
         total = sum(nclasses(i) for i in values(info); init = 0)
         deact = deactivations(univ)
-        mark_reachable!(info, reqs, deact)
-        mark_necessary!(info, deact)
+        mark_reachable!(info, reqs, deact, univ.ranks)
+        # a prefix walk is arc-consistent by construction — it steps past any
+        # class that depends on a package with no installable class — but the
+        # possibly-best set keeps classes from outside any one prefix, which
+        # carries no such guarantee and can leave `depends` naming a package
+        # this round empties. Restore the invariant explicitly.
+        mark_installable!(info)
+        mark_necessary!(info, deact, univ.ranks)
         drop_unmarked!(univ)
         sum(nclasses(i) for i in values(info); init = 0) < total ||
             break
@@ -400,193 +454,313 @@ function filter_pkg_info!(
     return univ
 end
 
-"""
-    find_reachable(info, reqs) :: Dict{P, Int}
-
-This function finds a minimal "reachable" subset of packages and classes that
-could appear in pareto-optimal solutions to version resolution for the given set
-of required "root" packages, using the following recursive logic:
-
-- P in reqs => P[1] reachable
-- P[i] reachable & P[i] depends on D => D[1] reachable
-- P[i] reachable & P[i] conflicts w. reachable => P[i+1] reachable
-- D[end] conflicts w. reachable & P[i] depends on D => P[i+1] reachable
-
-The optional `deact` argument gives, per package, a mask of its deactivated
-classes — the ones this query admits no member of. Such a class cannot be
-selected, so the package cannot be installed at it and the prefix has to
-continue past it, exactly as it continues past a class conflicting with
-something present:
-
-- P[i] reachable & P[i] deactivated => P[i+1] reachable
-
-A deactivated class's dependencies are followed all the same, which is what
-keeps the cone behind it in the universe: it is precisely the cone a relaxation
-of whatever emptied the class would need to find still there.
-
-The function returns a dictionary mapping packages to the maximum class index
-of that package that could be reached in an optimal solution. If a package
-cannot appear in an optimal solution, it will not appear in this dictionary.
-"""
-function find_reachable(
-    info  :: Dict{P, PkgInfo{P,V}},
-    reqs  :: SetOrVec{P} = keys(info),
-    deact :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
-) where {P,V}
-    # intern packages as integer indices so that the fixpoint loop below
-    # hashes no package names; all derived tables are indexed by pkg id
+# the interned tables the reachability walk reads: packages as integer indices,
+# so the fixpoint below hashes no package names.
+function reach_tables(info::Dict{P, PkgInfo{P,V}}) where {P,V}
     pkgs = sort!(collect(keys(info)))
     N = length(pkgs)
     ix = Dict{P,Int}(p => i for (i, p) in enumerate(pkgs))
     infos = Vector{PkgInfo{P,V}}(undef, N)
     ncls = Vector{Int}(undef, N)
-    # interned depends, same order (id 0: dependency absent from info,
-    # i.e. a package with no installable class — see below)
     deps = Vector{Vector{Int}}(undef, N)
-    partners = Vector{Vector{Tuple{Int,Int}}}(undef, N)
-    # interned deactivation masks (nothing: nothing empty here, the norm)
-    deacts = Vector{Union{Nothing,BitVector}}(nothing, N)
+    # (partner id, partner's class block offset in p's matrix,
+    #  p's class block offset in the partner's matrix)
+    partners = Vector{Vector{NTuple{3,Int}}}(undef, N)
     for p = 1:N
         info_p = info[pkgs[p]]
         infos[p] = info_p
         ncls[p] = nclasses(info_p)
-        deacts[p] = get(deact, pkgs[p], nothing)
         deps[p] = Int[get(ix, q, 0) for q in info_p.depends]
-        # (partner id, offset of p's class block in the partner's matrix)
-        prt = Tuple{Int,Int}[
-            (ix[q], info[q].interacts[pkgs[p]])
-            for q in keys(info_p.interacts)
-        ]
-        partners[p] = sort!(prt)
+        partners[p] = sort!(NTuple{3,Int}[
+            (ix[q], b, info[q].interacts[pkgs[p]]) for (q, b) in info_p.interacts])
     end
-
-    # meaning (both map packages to class indices):
-    #   - reach tracks fully processed reachable classes
-    #   - queue tracks newly reachable classes not yet processed
-    reach = zeros(Int, N)
-    queue = zeros(Int, N)
-    stack = Int[] # packages with queued work
-    instack = falses(N)
-
-    function enqueue(p::Int, j::Int)
-        queue[p] = j
-        if !instack[p]
-            instack[p] = true
-            push!(stack, p)
-        end
-    end
-
-    # add next active class of p *after* i to the queue
-    # do nothing if there's already class > i in reach/queue
-    function next(p::Int, i::Int)
-        reach[p] > i && return false
-        queue[p] > i && return false
-        m = ncls[p]
-        X = infos[p].conflicts
-        # first active class after i (the flag column is the active set)
-        j = col_min_from(X, size(X, 2), i + 1, m)
-        # j == 0: we're out of classes (i.e. saturated; see below)
-        enqueue(p, j == 0 ? m + 1 : j)
-        return true
-    end
-
-    rdeps = [Dict{Int,Int}() for _ = 1:N] # reverse dependency map
-    # rdeps[p][q] == k means
-    #   "k is latest reachable class of q that depends on p"
-
-    for p in reqs
-        # a requirement with no installable class reaches nothing
-        i = get(ix, p, 0)
-        i == 0 || enqueue(i, 1)
-    end
-
-    # notation:
-    #   - p, q: packages
-    #   - info_p = infos[p]
-    #   - indices of classes of package p: i, j
-    #   - indices of classes of package q: k
-    while !isempty(stack)
-        # get unprocessed package + class
-        p = pop!(stack)
-        instack[p] = false
-        i = queue[p]
-        queue[p] = 0
-        info_p = infos[p]
-        m = ncls[p]
-        # check for saturation
-        #   p saturated means: conflicts can force p to be uninstallable
-        #   saturation represented by i > ncls[p]
-        if i > m
-            # p has become saturated
-            for (q, k) in rdeps[p]
-                # q@k depends on p, therefore
-                # q@k conflicts with p being uninstallable
-                # p being saturated means that can happen
-                next(q, k)
-            end
-        end
-        # process each newly reachable class of p
-        deact_p = deacts[p]
-        for j = reach[p]+1:min(i, m)
-            # p@j is deactivated: it cannot be selected, so it cannot be
-            # what p is installed at — the prefix has to continue past it.
-            # its dependencies below are followed anyway, which is what keeps
-            # the packages behind it in the universe
-            deact_p === nothing || !deact_p[j] || next(p, j)
-            # dependencies
-            for (k, q) in enumerate(deps[p])
-                info_p.conflicts[j, k] || continue
-                # p@j depends on q
-                if q == 0
-                    # q has no installable class at all, so neither has
-                    # p@j: p can only be installed past it
-                    next(p, j)
-                    continue
-                end
-                rdeps_q = rdeps[q]
-                rdeps_q[p] = max(get(rdeps_q, p, 0), j)
-                next(q, 0) # q can be required
-                # check if q is saturated:
-                if reach[q] > ncls[q]
-                    # p@j depends on q, therefore
-                    # p@j conflicts with q being uninstallable
-                    # q being saturated means that can happen
-                    next(p, j)
-                end
-            end
-            # find p@j's conflicts with reached classes of each partner:
-            # conflicts are stored symmetrically, so scan the partner-side
-            # column Y[k, c+j] == X[j, b+k], which is contiguous
-            for (q, c) in partners[p]
-                r = min(reach[q], ncls[q])
-                r > 0 || continue
-                k = col_max_upto(infos[q].conflicts, c + j, r)
-                k == 0 && continue
-                # p@j conflicts with q@k (the highest such k; pushing past
-                # it subsumes pushing past any lower conflicting class)
-                next(p, j)
-                next(q, k)
-            end
-        end
-        # update the reach map
-        reach[p] = i
-    end
-
-    return Dict{P,Int}(pkgs[p] => reach[p] for p = 1:N if reach[p] > 0)
+    return (; pkgs, N, ix, infos, ncls, deps, partners)
 end
 
 function mark_reachable!(
     info  :: Dict{P, PkgInfo{P,V}},
-    reqs  :: SetOrVec{P} = keys(info),
-    deact :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
+    reqs  :: SetOrVec{P},
+    deact :: AbstractDict{P, BitVector},
+    # the per-package `(key_Q, key_∅)` vectors the walk compares
+    ranks :: Tuple{Dict{P,Vector{Int}}, Dict{P,Vector{Int}}},
 ) where {P,V}
-    reach = find_reachable(info, reqs, deact)
-    for (p, info_p) in info
-        r = min(get(reach, p, 0), nclasses(info_p))
-        info_p.conflicts[1:r, end] .= true
-        info_p.conflicts[r+1:end, end] .= false
+    for (_, info_p) in info
+        info_p.conflicts[1:nclasses(info_p), end] .= false
     end
-    return reach
+    return find_reachable(info, reqs, deact, ranks[1], ranks[2])
+end
+
+"""
+    find_reachable(info, reqs, deact, kq, k0)
+
+Flag, in each package's matrix, the classes that some relaxation of this query
+could reach — where a relaxation is the same query with any of its requirements
+or constraint sources dropped. `kq` gives per class the rank of the best member
+this query admits (`typemax` if it admits none) and `k0` the rank of its best
+member, period.
+
+Relaxing a constraint only moves a class earlier, so `k0(c) ≤ key_R(c) ≤ kq(c)`
+for every relaxation `R`. A class `c` can therefore be the best of a candidate
+set `C` under some relaxation exactly when no `c′ ∈ C` has `kq(c′) < k0(c)`:
+otherwise `c′` at its worst still precedes `c` at its best. Writing
+`t = min{kq(c′) : c′ ∈ C}`, those classes are `{c ∈ C : k0(c) ≤ t}`.
+
+A package's flagged classes are the possibly-best classes of whatever it has
+not been forced past, and being forced past one — a conflict with a flagged
+class, nothing selectable in it, a dependency on a package with nothing
+selectable — recomputes that set, to a fixpoint. The result already contains
+the classes this query alone would reach, so there is nothing to union it with —
+Theorem D of the manual's relaxation-stability page proves that.
+"""
+function find_reachable(
+    info  :: Dict{P, PkgInfo{P,V}},
+    reqs  :: SetOrVec{P},
+    deact :: AbstractDict{P, BitVector},
+    kq    :: Dict{P, Vector{Int}},
+    k0    :: Dict{P, Vector{Int}},
+    tb    = reach_tables(info),
+) where {P,V}
+    pkgs, N, ix, infos, ncls, deps, partners =
+        tb.pkgs, tb.N, tb.ix, tb.infos, tb.ncls, tb.deps, tb.partners
+
+    # ---------------------------------------------------------------- layout
+    # Everything per-class is flat: `coff[p]` offsets the key arrays, `soff[p]`
+    # the bitset words. One allocation each instead of one per package.
+    coff = Vector{Int}(undef, N + 1); coff[1] = 0
+    soff = Vector{Int}(undef, N + 1); soff[1] = 0
+    cw   = Vector{Int}(undef, N)  # words per column of p's matrix
+    # the matrices' backing words, hoisted: the walk reads them by package id
+    # thousands of times and has no other use for the wrappers
+    chunks = Vector{Vector{UInt64}}(undef, N)
+    for p = 1:N
+        coff[p+1] = coff[p] + ncls[p]
+        soff[p+1] = soff[p] + cld(ncls[p], 64)
+        X = infos[p].conflicts
+        cw[p] = col_words(X)
+        chunks[p] = X.chunks
+    end
+    M = coff[N+1]
+    KQ = Vector{Int}(undef, M) # key_Q, typemax where the query empties the class
+    K0 = Vector{Int}(undef, M) # key_∅
+    # The classes in key_∅ order, per package — `nothing` when that is the
+    # layout order already, which is exactly when nothing here is demoted.
+    ord0 = Vector{Union{Nothing,Vector{Int}}}(nothing, N)
+    for p = 1:N
+        m = ncls[p]
+        o = coff[p]
+        d = get(deact, pkgs[p], nothing)
+        a, b = kq[pkgs[p]], k0[pkgs[p]]
+        @inbounds for c = 1:m
+            KQ[o+c] = d !== nothing && d[c] ? typemax(Int) : a[c]
+            K0[o+c] = b[c]
+        end
+        issorted(b) || (ord0[p] = sortperm(b))
+    end
+
+    # ------------------------------------------------------------ reverse deps
+    # `p` saturating pushes every class of every package that depends on `p`.
+    # Which classes those are is already in the dependee's matrix — its
+    # dependency column for `p` — so the walk needs only the static edge list,
+    # not the incremental (package => classes) map it used to accumulate.
+    nrd = zeros(Int, N + 1)
+    for p = 1:N, q in deps[p]
+        q == 0 || (nrd[q+1] += 1)
+    end
+    rdoff = cumsum!(nrd, nrd)
+    rdpkg = Vector{Int}(undef, rdoff[N+1])
+    rdcol = Vector{Int}(undef, rdoff[N+1])
+    fill = copy(rdoff)
+    for p = 1:N, (k, q) in enumerate(deps[p])
+        q == 0 && continue
+        fill[q] += 1
+        rdpkg[fill[q]] = p
+        rdcol[fill[q]] = k
+    end
+
+    # ----------------------------------------------------------------- state
+    # S(p), the kept set, is a prefix in key_∅ order — `iK0[p]` is how far along
+    # that order it reaches. It is stored as a bitset anyway because the
+    # conflict scan wants to AND it against a partner's column, but no scan of
+    # it ever runs past `smax[p]`, its highest layout index.
+    Sw = zeros(UInt64, soff[N+1]) # kept
+    Pw = zeros(UInt64, soff[N+1]) # forced past
+    npushed = zeros(Int, N)       # count, so saturation is O(1)
+    smax = zeros(Int, N)          # highest layout index in S(p)
+    iKQ = ones(Int, N)            # into layout order: min key_Q still unpushed
+    iK0 = ones(Int, N)            # into key_∅ order: how far S(p) reaches
+    seeded = falses(N)
+    indirty = falses(N)
+    addq  = Tuple{Int,Int}[]  # classes newly in S, to be processed
+    dirty = Int[]             # packages whose candidate set shrank
+
+    @inline getbit(A, b, c) =
+        @inbounds (A[b + ((c - 1) >> 6) + 1] >> ((c - 1) & 63)) & 1 != 0
+    @inline setbit!(A, b, c) =
+        @inbounds A[b + ((c - 1) >> 6) + 1] |= UInt64(1) << ((c - 1) & 63)
+
+    function add!(p::Int, c::Int)
+        b = soff[p]
+        getbit(Sw, b, c) && return
+        setbit!(Sw, b, c)
+        c > smax[p] && (smax[p] = c)
+        push!(addq, (p, c))
+        return
+    end
+
+    function mark_pushed!(p::Int, c::Int)
+        b = soff[p]
+        getbit(Pw, b, c) && return
+        setbit!(Pw, b, c)
+        npushed[p] += 1
+        # a class something had to step past is still one the universe keeps —
+        # that is what "keep the first class, then the next" means
+        add!(p, c)
+        if !indirty[p]
+            indirty[p] = true
+            push!(dirty, p)
+        end
+        return
+    end
+
+    # every class of every dependee that depends on a saturated `p`
+    function saturate!(p::Int)
+        @inbounds for t = rdoff[p]+1:rdoff[p+1]
+            q, k = rdpkg[t], rdcol[t]
+            smax[q] == 0 && continue
+            Yc = chunks[q]
+            base = (k - 1) * cw[q]
+            b = soff[q]
+            for w = 1:cld(smax[q], 64)
+                z = Yc[base + w] & Sw[b + w] & ~Pw[b + w]
+                while !iszero(z)
+                    c = ((w - 1) << 6) + trailing_zeros(z) + 1
+                    z &= z - 1
+                    mark_pushed!(q, c)
+                end
+            end
+        end
+        return
+    end
+
+    # S(p) ⊇ possibly-best of (all classes − pushed).
+    #
+    # `mkq`, the smallest key_Q among the classes not yet pushed, only rises,
+    # and the possibly-best set `{c : key_∅(c) ≤ mkq}` only grows: both pointers
+    # advance monotonically and neither order is ever rescanned. The layout
+    # order already sorts the *active* classes by key_Q — it was built as
+    # `sortperm(key_Q)` — so finding `mkq` is a walk along it skipping the
+    # deactivated and the pushed, with no second permutation to maintain.
+    function refresh!(p::Int)
+        m = ncls[p]
+        o, b = coff[p], soff[p]
+        i = iKQ[p]
+        @inbounds while i ≤ m && (KQ[o+i] == typemax(Int) || getbit(Pw, b, i))
+            i += 1
+        end
+        iKQ[p] = i
+        # no active class left to rest on: every class is possibly-best, since
+        # a relaxation that revives one of them revives it at its own key_∅
+        mkq = i > m ? typemax(Int) : @inbounds KQ[o+i]
+        j = iK0[p]
+        ord = ord0[p]
+        if ord === nothing
+            @inbounds while j ≤ m && K0[o+j] ≤ mkq
+                add!(p, j)
+                j += 1
+            end
+        else
+            @inbounds while j ≤ m && K0[o+ord[j]] ≤ mkq
+                add!(p, ord[j])
+                j += 1
+            end
+        end
+        iK0[p] = j
+        # saturated: conflicts can force p to be uninstallable, so every class
+        # that depends on p has to be stepped past too
+        npushed[p] == m && saturate!(p)
+        return
+    end
+
+    function seed!(p::Int)
+        seeded[p] && return
+        seeded[p] = true
+        if !indirty[p]
+            indirty[p] = true
+            push!(dirty, p)
+        end
+        return
+    end
+
+    for p in reqs
+        i = get(ix, p, 0)
+        i == 0 || seed!(i)
+    end
+
+    while !isempty(dirty) || !isempty(addq)
+        while !isempty(dirty)
+            r = pop!(dirty)
+            indirty[r] = false
+            refresh!(r)
+        end
+        isempty(addq) && continue
+        p, c = pop!(addq)
+        info_p = infos[p]
+        o = coff[p]
+        # a class this query admits nothing of cannot be rested on
+        @inbounds KQ[o+c] == typemax(Int) && mark_pushed!(p, c)
+        # dependencies
+        @inbounds for (k, q) in enumerate(deps[p])
+            info_p.conflicts[c, k] || continue
+            if q == 0
+                mark_pushed!(p, c) # nothing installable to depend on
+                continue
+            end
+            seed!(q)
+            npushed[q] == ncls[q] && mark_pushed!(p, c)
+        end
+        # conflicts against the partner's kept classes. the partner-side column
+        # of p@c is contiguous, so this is a mask AND — bounded by the partner's
+        # highest kept class, which is what keeps it off the tail of the column
+        @inbounds for (q, _b, cq) in partners[p]
+            # nothing of q is kept yet, so nothing of q can be conflicted with
+            smax[q] == 0 && continue
+            Yc = chunks[q]
+            base = (cq + c - 1) * cw[q]
+            bq = soff[q]
+            hit = false
+            for w = 1:cld(smax[q], 64)
+                x = Yc[base + w] & Sw[bq + w]
+                iszero(x) && continue
+                hit = true
+                # only the conflicting classes that have not already been
+                # stepped past need visiting; without this mask every class
+                # added to S(p) re-walks every conflict q had already absorbed
+                z = x & ~Pw[bq + w]
+                while !iszero(z)
+                    k = ((w - 1) << 6) + trailing_zeros(z) + 1
+                    z &= z - 1
+                    mark_pushed!(q, k)
+                end
+            end
+            hit && mark_pushed!(p, c)
+        end
+    end
+
+    # the kept set goes straight into each matrix's flag column, OR-ed over
+    # whatever the query's own prefix already marked there: `Sw`'s words are
+    # laid out exactly like the column's, and its bits stop below the flag row
+    for p = 1:N
+        m = ncls[p]
+        m == 0 && continue
+        W = cw[p]
+        base = (size(infos[p].conflicts, 2) - 1) * W
+        Xc = chunks[p]
+        b = soff[p]
+        @inbounds for w = 1:cld(m, 64)
+            Xc[base + w] |= Sw[b + w]
+        end
+    end
+    return nothing
 end
 
 function mark_installable!(
@@ -639,6 +813,8 @@ end
 function mark_necessary!(
     info  :: Dict{P, PkgInfo{P,V}},
     deact :: AbstractDict{P, BitVector} = EmptyDict{P,BitVector}(),
+    # the per-package `(key_Q, key_∅)` vectors the domination rule compares
+    ranks :: Union{Nothing, Tuple{Dict{P,Vector{Int}}, Dict{P,Vector{Int}}}} = nothing,
 ) where {P,V}
     # intern packages as integer indices so that the work loop below
     # hashes no package names (sorted so the processing order — and with
@@ -651,11 +827,18 @@ function mark_necessary!(
     partners = Vector{Vector{NTuple{3,Int}}}(undef, N)
     # interned deactivation masks (nothing: nothing empty here, the norm)
     deacts = Vector{Union{Nothing,BitVector}}(nothing, N)
+    # interned rank keys
+    kqv = Vector{Union{Nothing,Vector{Int}}}(nothing, N)
+    k0v = Vector{Union{Nothing,Vector{Int}}}(nothing, N)
     for p = 1:N
         info_p = info[pkgs[p]]
         infos[p] = info_p
         ncls[p] = nclasses(info_p)
         deacts[p] = get(deact, pkgs[p], nothing)
+        if ranks !== nothing
+            kqv[p] = ranks[1][pkgs[p]]
+            k0v[p] = ranks[2][pkgs[p]]
+        end
         # (partner id, partner's class block offset in p's matrix,
         #  p's class block offset in the partner's matrix)
         prt = NTuple{3,Int}[
@@ -669,6 +852,11 @@ function mark_necessary!(
     D = UInt64[]        # per-class domination candidate masks
     T = UInt64[]        # mask of classes still tracked by the sweep
     R = Int[]           # redundant indices vector
+    # scratch: suffix masks of the classes
+    # ordered by key_∅, so "the classes whose best possible rank is worse than
+    # t" is one mask lookup
+    S = UInt64[]
+    k0s = Int[]
 
     # the classes redundancy may reason about: the in-universe ones, less the
     # deactivated ones — the pass is the one place that reads *both* per-class
@@ -762,6 +950,33 @@ function mark_necessary!(
         resize!(D, m * W)
         resize!(T, W)
         copyto!(T, A)
+        # the candidate set of `i` is not "the classes worse than i" but "the
+        # classes whose *best possible* rank is worse than i's current one" —
+        # key_∅(j) > key_Q(i), the one order fact a relaxation cannot reverse
+        # (see the relaxation-stability page).'
+        # Build the suffix masks of the classes sorted by key_∅ once per
+        # package; `S[(k-1)*W+1 : k*W]` is the mask of the classes at position
+        # k and later, and the block at k = m+1 is empty.
+        kq_p = kqv[p]
+        k0_p = k0v[p]
+        if kq_p !== nothing
+            ord = sortperm(k0_p)
+            resize!(k0s, m)
+            for k = 1:m
+                k0s[k] = k0_p[ord[k]]
+            end
+            resize!(S, (m + 1) * W)
+            fill!(S, UInt64(0))
+            @inbounds for k = m:-1:1
+                base = (k - 1) * W
+                nb = k * W
+                for w = 1:W
+                    S[base + w] = S[nb + w]
+                end
+                j = ord[k]
+                S[base + ((j - 1) >> 6) + 1] |= UInt64(1) << ((j - 1) & 63)
+            end
+        end
         @inbounds for w = 1:W
             c = A[w]
             while !iszero(c)
@@ -769,16 +984,27 @@ function mark_necessary!(
                 c &= c - 1
                 # candidates of i: candidate classes worse than i
                 o = (i - 1) * W
-                for w′ = 1:W
-                    D[o + w′] = A[w′]
-                end
-                wt = i >> 6
-                for w′ = 1:min(wt, W)
-                    D[o + w′] = 0
-                end
-                r = i & 63
-                if r != 0 && wt < W
-                    D[o + wt + 1] &= ~((UInt64(1) << r) - 1)
+                if kq_p === nothing
+                    for w′ = 1:W
+                        D[o + w′] = A[w′]
+                    end
+                    wt = i >> 6
+                    for w′ = 1:min(wt, W)
+                        D[o + w′] = 0
+                    end
+                    r = i & 63
+                    if r != 0 && wt < W
+                        D[o + wt + 1] &= ~((UInt64(1) << r) - 1)
+                    end
+                else
+                    # key_∅(j) > key_Q(i) implies j > i (key_∅(j) ≤ key_Q(j)
+                    # and key_Q is ascending), so this is a subset of the
+                    # candidate set "every class worse than i"
+                    kk = searchsortedlast(k0s, kq_p[i]) + 1
+                    sb = (kk - 1) * W
+                    for w′ = 1:W
+                        D[o + w′] = A[w′] & S[sb + w′]
+                    end
                 end
                 live = UInt64(0)
                 for w′ = 1:W
@@ -852,11 +1078,15 @@ function mark_necessary!(
     end
 end
 
-drop_unmarked!(univ::Universe) = drop_unmarked!(univ.info, univ.reps)
+drop_unmarked!(univ::Universe) = drop_unmarked!(univ.info, univ.reps, univ.ranks)
 
 function drop_unmarked!(
     info :: Dict{P, <: PkgInfo{P}},
     reps :: Union{Nothing, Dict{P, Vector{Int}}} = nothing,
+    # renumbered with `reps`; the *values* are ranks in the
+    # artifact's version order and are never rewritten, only subset, so the
+    # comparisons they support survive deletion
+    ranks :: Union{Nothing, Tuple{Dict{P,Vector{Int}}, Dict{P,Vector{Int}}}} = nothing,
 ) where {P}
     # This pass reads the *in-universe* bit and nothing else: it knows about
     # the deleting passes' verdicts and knows nothing about deactivation, which
@@ -914,6 +1144,10 @@ function drop_unmarked!(
         if m′ == 0
             delete!(info, p)
             reps === nothing || delete!(reps, p)
+            if ranks !== nothing
+                delete!(ranks[1], p)
+                delete!(ranks[2], p)
+            end
             continue
         end
         # keep as is if everything is active (with the column flags
@@ -951,6 +1185,12 @@ function drop_unmarked!(
         if reps !== nothing
             r = reps[p]
             reps[p] = Int[iszero(r[i]) ? 0 : index[r[i]] for i = 1:m if I[i]]
+        end
+        if ranks !== nothing
+            kq, k0 = ranks
+            kq_p, k0_p = kq[p], k0[p]
+            kq[p] = Int[kq_p[i] for i = 1:m if I[i]]
+            k0[p] = Int[k0_p[i] for i = 1:m if I[i]]
         end
         # compute shrunken components
         D′ = D[K[1:length(D)]]

--- a/test/relaxation_stable.jl
+++ b/test/relaxation_stable.jl
@@ -1,0 +1,142 @@
+# The property the filter buys with the two rank keys: a universe filtered for
+# query `Q` still answers every *relaxation* of `Q` — the same query with some
+# requirements or constraint sources dropped, which is exactly the shape of a
+# repair a user can make to an unsatisfiable problem.
+#
+# The theory page states this as Theorem C. What is checked here is its
+# conclusion, end to end and without reference to how it is proved:
+#
+#     re-rank the Q-filtered universe under R, solve it, and you get what
+#     resolving R from the unfiltered artifact gives
+#
+# for random universes crossed with random queries and random relaxations of
+# them. Two sharper statements are checked alongside, because a failure in
+# either localizes the cause: that the Q-filtered universe contains everything
+# a fresh filter for R would keep (Theorem B), and that the reachability walk's
+# kept set is downward closed in `key_∅` (the Remark), which is the invariant
+# that lets it carry an integer frontier instead of a set.
+
+using Resolver: PkgData, PkgInfo, Problem, Universe, NoKinds, pkg_info, nclasses,
+    prepare_pkg_info, rank_pkg_info, resolve, resolve_prepared, class_ranking,
+    copy_ranked!, version_permutations, deactivations, mark_installable!,
+    mark_reachable!
+
+using .tiny_data
+
+# --- relaxations, at the Problem level: exactly what a diagnosis would ask ---
+
+# every constraint source Q carries, as something removable
+function sources(Q::Problem{P}) where {P}
+    s = Any[]
+    for p in keys(Q.compat); push!(s, (:compat, p)); end
+    for p in keys(Q.pins);   push!(s, (:pin, p));    end
+    for (k, _) in Q.excludes; push!(s, (:kind, k));  end
+    return s
+end
+
+function relax(Q::Problem{P}, drop_reqs, drop_srcs) where {P}
+    reqs = P[p for p in Q.reqs if p ∉ drop_reqs]
+    nocomp = Set(p for (k, p) in drop_srcs if k === :compat)
+    nopin  = Set(p for (k, p) in drop_srcs if k === :pin)
+    nokind = Set(k for (t, k) in drop_srcs if t === :kind)
+    compat = filter(kv -> first(kv) ∉ nocomp, Dict(Q.compat))
+    pins   = filter(kv -> first(kv) ∉ nopin,  Dict(Q.pins))
+    excludes = Pair{Symbol,Any}[kv for kv in Q.excludes if first(kv) ∉ nokind]
+    return Problem(reqs; compat, pins, excludes)
+end
+
+# a sample: the bottom of the lattice (everything dropped) first, since it is
+# the hardest case and the one caching depends on, then random points
+function relaxations(Q::Problem{P}, k::Int) where {P}
+    srcs = sources(Q)
+    out = [relax(Q, P[], srcs)]
+    for _ = 1:k
+        dr = P[p for p in unique(Q.reqs) if rand() < 0.35]
+        ds = Any[s for s in srcs if rand() < 0.5]
+        isempty(dr) && isempty(ds) && continue
+        push!(out, relax(Q, dr, ds))
+    end
+    return out
+end
+
+# What reuse means: keep the filtered universe, re-rank its classes for `R`
+# — new representatives and, where `R` moves them, a new layout — and solve.
+# No pass of the filter is run again.
+function resolve_reuse(univ::Universe{P,V}, R::Problem{P}) where {P,V}
+    info = univ.info
+    reps, cperms = class_ranking(info, R, version_permutations(info, nothing))
+    u = cperms === nothing ?
+        Universe{P,V}(info, reps, nothing) :
+        copy_ranked!(
+            Universe{P,V}(Dict{P,PkgInfo{P,V}}(), Dict{P,Vector{Int}}(), nothing),
+            info, reps, cperms)
+    return resolve_prepared(u, R)
+end
+
+# the (package, version-tuple) identity of every class left in a universe, so
+# that two independently built universes can be compared by content
+classkeys(univ) = Set(
+    (p, Tuple(ip.versions[j] for j in mem))
+    for (p, ip) in univ.info for mem in ip.members)
+
+@testset "a Q-filtered universe answers every relaxation of Q" begin
+    reused = 0
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2), (2, 5))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:30
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            info = pkg_info(data, keys(data); filter = false)
+            compat, pins = random_constraints(m, n)
+            bad = rand(1:n)
+            excludes = rand(Bool) ?
+                Pair{Symbol,Any}[:test => (p, v) -> v == bad] : NoKinds
+            Q = Problem(reqs; compat, pins, excludes)
+            univ = prepare_pkg_info(info, Q)
+            have = classkeys(univ)
+            for R in relaxations(Q, 4)
+                # Theorem C: reuse answers R exactly as a fresh resolve does
+                @test resolve_reuse(univ, R) == resolve(info, R)
+                # Theorem B, the sharper statement: nothing a fresh filter for
+                # R keeps is missing from the universe filtered for Q
+                @test isempty(setdiff(classkeys(prepare_pkg_info(info, R)), have))
+                reused += 1
+            end
+        end
+    end
+    @test reused > 1000
+end
+
+@testset "the reachable set is downward closed in key_∅" begin
+    # The walk keeps `{c : key_∅(c) ≤ t}` for a threshold that only rises. That
+    # is what makes the kept set a prefix — in key_∅ order, not layout order —
+    # and so representable by a pointer rather than a set. If it ever failed,
+    # the walk would be keeping something its own rule does not license.
+    checked = nontrivial = 0
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2), (2, 5))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:25
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            info = pkg_info(data, keys(data); filter = false)
+            compat, pins = random_constraints(m, n)
+            prob = Problem(reqs; compat, pins)
+            univ = rank_pkg_info(info, prob)
+            mark_installable!(univ.info)
+            mark_reachable!(univ.info, prob.reqs, deactivations(univ), univ.ranks)
+            for (p, ip) in univ.info
+                k0 = univ.ranks[2][p]
+                mc = nclasses(ip)
+                kept = [j for j = 1:mc if ip.conflicts[j, end]]
+                isempty(kept) && continue
+                t = maximum(k0[j] for j in kept)
+                @test all((k0[j] ≤ t) == ip.conflicts[j, end] for j = 1:mc)
+                checked += 1
+                length(kept) < mc && (nontrivial += 1)
+            end
+        end
+    end
+    # the sweep really did exercise packages that are not kept whole
+    @test checked > 100
+    @test nontrivial > 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,6 +297,7 @@ include("satisfiable.jl")
 include("classes.jl")
 include("class_space.jl")
 include("relaxation.jl")
+include("relaxation_stable.jl")
 include("ordering.jl")
 
 @testset "registry resolve" begin


### PR DESCRIPTION
Closes #70.

A filtering deletion is licensed by a comparison of class ranks, and a user
constraint moves ranks: a compat bound that forbids a class's best member does
not remove the class, it *moves* it, possibly behind a class it would otherwise
outrank. So every deletion the filter made was licensed only for the query it
was computed for. Sound for resolving — which is what the filter existed for —
but not enough to explain a failure, because a diagnosis asks what would happen
if a requirement were dropped or a bound relaxed, and those are *different*
queries whose answers the filtered universe was under no obligation to contain.

This makes both passes stable under relaxation, so the universe a failed
resolve already built answers every repair of that query, with no re-filtering
per candidate fix.

## The rule

Write `key_Q(c)` for the rank of the best member the query admits and
`key_∅(c)` for the rank of its best member, period. Relaxing only ever moves a
class earlier, so `key_∅(c) ≤ key_R(c) ≤ key_Q(c)` for every relaxation `R`.
Hence `key_Q(c′) < key_∅(c)` — the dominator at its worst still preceding the
dominated at its best — survives every relaxation, and nothing weaker does.

- **Redundancy** strikes a dominated class only under that comparison, instead
  of under "earlier in this query's order".
- **Reachability** keeps, per package, the classes some relaxation could put
  first — `{c : key_∅(c) ≤ min key_Q over what the walk has not been forced
  past}` — instead of a prefix of one query's order.

## Theory

A new page, `docs/src/theory/relaxation.md`, proves a struck class is needed by
no relaxation (Theorem A), every relaxation's reachable set is kept (Theorem
B), and the two compose to `Lay(F_Q(D), R) = Lay(D, R)` for every `R ≤ Q`
(Theorem C).

**Theorem D** is what makes this *one* walk rather than two. The possibly-best
set already contains the prefix the query's own walk would keep, so that walk
is deleted rather than run alongside and unioned with. The proof turns on
separating two things issue #70's sketch conflated: the walk's key (`key_Q`,
`∞` for a deactivated class) from the **layout key** `κ_Q` (`key_Q` when
active, `key_∅` when deactivated — where a relaxation reviving it would put
it). Only `κ_Q` is monotone in layout position, and the argument needs exactly
that monotonicity. It also states the precondition it relies on — every class
active on entry, which `drop_unmarked!` establishes.

`layered.md` keeps its theorems and gains a note reconciling them with what
runs: both implemented rules are *weakenings* (reachability keeps a superset by
Theorem D; Rule A implies `i < j`), so every deletion the code makes is one
that page already licenses, and Theorem 4 carries the answer through.

## Verification

| | check | result |
|---|---|---|
| resolver answers | vs `main`, 6 roots × 4 julia bounds | **3091 version pins, byte-identical**; filtered universes the same size |
| relaxed problems | re-rank the `Q`-filtered universe under `R`, solve, compare against resolving `R` fresh | **2007 assertions pass**, incl. the bottom of the relaxation lattice |
| prefix invariant | kept set downward closed in `key_∅` | 418 assertions |
| speed | same registry scenarios, 11 reps, min-of | prepare **1.010×**, resolve total **1.005×**, worst single 1.028× |
| suite | `test/runtests.jl` | green |
| docs | `docs/make.jl` | builds clean |

`test/relaxation_stable.jl` checks the conclusion rather than the argument:
over random universes crossed with random queries and random relaxations, it
re-ranks the `Q`-filtered universe under each relaxation, solves, and compares
against resolving that relaxation from the unfiltered artifact.

The cost is that the filter deletes slightly less. On real registry queries it
deletes exactly as much, because those queries demote nothing; the difference
shows up only where a constraint actually reorders classes.

## Two scope calls worth flagging on review

- **The relaxation-stable rules replace the previous ones outright** rather
  than sitting behind a switch. There is no second filter and no chooser:
  `find_reachable` *is* the possibly-best walk now, and the prefix walk is
  deleted. Theorem D is what makes that legitimate rather than merely
  convenient.
- **The measurement harnesses are not included.** They exist to compare two
  rule sets, and after this there is only one. The speed numbers above are
  reproducible from a branch pair rather than from this branch alone; happy to
  add a committed prepare benchmark if that trade is wrong.

## What this does not give

The guarantee is over relaxations of one query, not arbitrary queries. A query
that *adds* a requirement or *tightens* a bound is not below `Q` and needs its
own filter run. Upstream fixes change the registry rather than the query, so
they are outside it too.
