### PR TITLE
Answer a relaxation on the universe already filtered for the query

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,6 +18,10 @@ Resolver.Universe
 Resolver.prepare_pkg_info
 Resolver.version_permutations
 Resolver.class_ranking
+Resolver.sources
+Resolver.relax
+Resolver.RelaxedProblem
+Resolver.SparsePerm
 Resolver.find_reachable
 Resolver.exclusion_masks
 ```

--- a/docs/src/theory/relaxation.md
+++ b/docs/src/theory/relaxation.md
@@ -340,6 +340,8 @@ keeping the union would add nothing.
     A diagnosis may answer any relaxation of a failed query on the universe
     filtered for that query. Re-filtering per candidate fix is unnecessary.
 
+[`relax`](@ref Resolver.relax) builds that question and `resolve` answers it.
+
 Because ``\le`` is a lattice with the empty query at the bottom, the same
 argument run at ``Q = \emptyset`` says a universe filtered for no constraints
 at all serves every query over the same requirements — which is what makes a

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -134,6 +134,34 @@ function version_permutations(
 end
 
 """
+    SparsePerm <: AbstractVector{Int}
+
+A permutation of `1:n` stored as the positions it moves: the pairs
+`(i, p[i])` for every `i` with `p[i] != i`, ascending in `i`. A permutation
+close to the identity costs what it displaces rather than what it spans, and
+the identity costs nothing at all.
+
+Indexing is a search over those pairs — short, since there are few — and
+`invperm` is the pairs swapped and re-sorted, so neither direction ever touches
+the positions that did not move.
+"""
+struct SparsePerm <: AbstractVector{Int}
+    n     :: Int
+    moved :: Vector{Tuple{Int,Int}}
+end
+
+Base.size(p::SparsePerm) = (p.n,)
+
+Base.@propagate_inbounds function Base.getindex(p::SparsePerm, i::Int)
+    @boundscheck checkbounds(p, i)
+    k = searchsortedfirst(p.moved, i; by = first)
+    return @inbounds k ≤ length(p.moved) && p.moved[k][1] == i ? p.moved[k][2] : i
+end
+
+Base.invperm(p::SparsePerm) =
+    SparsePerm(p.n, sort!(Tuple{Int,Int}[(j, i) for (i, j) in p.moved]))
+
+"""
     class_ranking(info, prob, perms) :: (reps, perms′)
 
 What a query makes of an artifact's classes, before anything is materialized:
@@ -180,9 +208,10 @@ function class_ranking_keys(
 ) where {P,V}
     excl = exclusion_masks(info, prob)
     reps = Dict{P, Vector{Int}}()
-    perms′ = Dict{P, Vector{Int}}()
+    perms′ = Dict{P, SparsePerm}()
     keys_q = want_keys ? Dict{P, Vector{Int}}() : nothing
     keys_0 = want_keys ? Dict{P, Vector{Int}}() : nothing
+    ord = Int[] # scratch: the class order, read out into a `SparsePerm`
     key = Int[] # scratch: per class, the rank of the member it competes at
     key0 = Int[] # scratch: per class, the rank of its best member, period
     for (p, info_p) in info
@@ -214,8 +243,20 @@ function class_ranking_keys(
             end
         end
         reps[p] = reps_p
-        cperm = issorted(key) ? nothing : sortperm(key)
-        cperm === nothing || (perms′[p] = cperm)
+        # the class order this query puts the package in, as what it displaces:
+        # sorted into scratch, then walked, so a package that moves nothing
+        # allocates nothing and one that moves two classes carries two pairs
+        cperm = nothing
+        if !issorted(key)
+            resize!(ord, m)
+            sortperm!(ord, key)
+            moved = Tuple{Int,Int}[]
+            for r = 1:m
+                @inbounds ord[r] == r || push!(moved, (r, ord[r]))
+            end
+            cperm = SparsePerm(m, moved)
+            perms′[p] = cperm
+        end
         if want_keys
             # key_∅: the rank of each class's best member, exclusions ignored
             resize!(key0, m)
@@ -301,7 +342,7 @@ function copy_ranked!(
     univ  :: Universe{P,V},
     info  :: AbstractDict{P, PkgInfo{P,V}},
     reps  :: Dict{P, Vector{Int}},
-    perms :: Union{Nothing, AbstractDict{P, Vector{Int}}} = nothing,
+    perms :: Union{Nothing, AbstractDict{P, SparsePerm}} = nothing,
 ) where {P,V}
     info′ = univ.info
     reps′ = univ.reps
@@ -371,7 +412,7 @@ function relaid_conflicts(
     X    :: BitMatrix,
     m    :: Int,
     n    :: Int,
-    perm :: Union{Nothing, Vector{Int}},
+    perm :: Union{Nothing, AbstractVector{Int}},
     cols :: Union{Nothing, Vector{Int}},
 )
     X′ = falses(size(X, 1), n + 1)

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -5,8 +5,9 @@ function resolve_core(
     sat  :: SAT{P},
     reqs :: SetOrVec{P} = keys(sat.info);
     by   :: Function = identity, # priority ordering
+    ord  :: O = nothing, # class ranking (the universe's own layout by default)
     restore :: Bool = true, # restore the SAT instance's state before returning
-) where {P}
+) where {P, O}
     # a requirement the instance doesn't know has no installable version —
     # the filter drops such packages — so it cannot be satisfied
     all(p -> haskey(sat.info, p), reqs) || return nothing
@@ -31,15 +32,17 @@ function resolve_core(
         # below, so the layered answer is unchanged. a failed probe
         # tells us nothing and the sequential path proceeds as usual
         # (skipped for a single package, whose own probe covers it)
-        todo = [p for p in layer if sol[p] > 1]
+        todo = [p for p in layer
+                if sol[p] != @inbounds ranking(ord, p, nclasses(sat.info[p]))[1]]
         if length(todo) > 1
             for p in todo
-                sat_assume(sat, p, 1)
+                sat_assume(sat, p,
+                    @inbounds ranking(ord, p, nclasses(sat.info[p]))[1])
             end
             is_satisfiable(sat) && extract_solution!(sat, sol)
         end
         for p in layer
-            optimize_version!(sat, sol, p)
+            optimize_version!(sat, sol, p, ord)
             # fix optimized class
             sat_add(sat, p, sol[p])
             sat_add(sat)
@@ -157,6 +160,148 @@ function resolve_prepared(
     sat = SAT(univ)
     # the instance is single-use, so don't bother restoring its state
     try resolve(sat, prob.reqs; by, restore=false)
+    finally
+        finalize(sat)
+    end
+end
+
+"""
+    sources(prob) :: Vector{Pair{Symbol,Any}}
+
+Every constraint source `prob` carries, as something a relaxation can release:
+`:compat => p` and `:pin => p` for the entries naming a package, and
+`:kind => k` for each admission kind. This is the vocabulary
+[`relax`](@ref Resolver.relax) takes, so `relax(univ, prob, prob.reqs,
+sources(prob))` is the bottom of the relaxation lattice — the empty query — and
+any subset of it is a point in between.
+"""
+function sources(prob::Problem{P}) where {P}
+    srcs = Pair{Symbol,Any}[]
+    for p in keys(prob.compat);  push!(srcs, :compat => p); end
+    for p in keys(prob.pins);    push!(srcs, :pin => p);    end
+    for (k, _) in prob.excludes; push!(srcs, :kind => k);   end
+    return srcs
+end
+
+"""
+    RelaxedProblem
+
+A relaxation of a query, together with what answering it on the universe that
+query was filtered for takes: `resolve(sat, rp)` returns what
+`resolve(info, rp.prob)` returns, without preparing again.
+
+Built by [`relax`](@ref Resolver.relax), which *derives* the relaxed problem by
+withdrawing demands rather than accepting one — so that `rp.prob` being a
+relaxation of `rp.base` is a consequence of how the value was made rather than a
+claim about an argument — and settles there what every solve would otherwise
+recompute: the member each class stands for under the relaxed problem, and the
+order those members rank the classes in.
+
+Those two are indexed by the class layout of the universe `relax` was given, so
+a `RelaxedProblem` is stale if that universe is filtered again afterwards.
+Nothing does that: `drop_unmarked!` is reachable only from `prepare_pkg_info`,
+which builds a universe rather than shrinking one already in use.
+"""
+struct RelaxedProblem{P, O}
+    base :: Problem{P} # the query this relaxes — what it is a relaxation *of*
+    prob :: Problem{P} # the relaxed query, derived from `base`
+    reps :: Dict{P, Vector{Int}} # per class, its member under `prob`
+    # per package, the ranking `prob` puts its classes in, for the ones it moved
+    # — or `nothing`, the universe's own layout, when it moved none
+    ord  :: O
+end
+
+"""
+    relax(univ, Q, drop_reqs = P[], drop_sources = Pair{Symbol,Any}[]; order = nothing)
+
+The relaxation of `Q` that withdraws the requirements `drop_reqs` and releases
+the constraint sources `drop_sources`, ready to resolve against `univ` — the
+universe `prepare_pkg_info(info, Q; order)` produced. Withdrawing nothing gives
+`Q` itself, which is a relaxation of `Q`; withdrawing everything gives the empty
+query. Names that `Q` does not carry are ignored, a source that is not there
+being already released.
+
+`drop_sources` names sources the way [`sources`](@ref Resolver.sources) lists
+them: `:compat => p`, `:pin => p`, `:kind => k`.
+
+`order` is the version preference ordering, as `resolve` takes it, and has to be
+the one `univ` was ranked in: it is what "better" means, and the universe and the
+relaxation have to mean the same thing by it. It is consumed here, so the
+permutations it induces are computed once however often the result is resolved.
+"""
+function relax(
+    univ :: Universe{P,V},
+    Q    :: Problem{P},
+    drop_reqs    :: SetOrVec{P} = P[],
+    drop_sources :: SetOrVec{Pair{Symbol,Any}} = Pair{Symbol,Any}[];
+    order = nothing, # version ordering
+) where {P,V}
+    nocomp, nopin = Set{P}(), Set{P}()
+    nokind = Set{Symbol}()
+    for (what, key) in drop_sources
+        what === :compat ? push!(nocomp, key) :
+        what === :pin    ? push!(nopin,  key) :
+        what === :kind   ? push!(nokind, key) :
+            throw(ArgumentError("no such constraint source: $(repr(what))"))
+    end
+    withdrawn = Set{P}(drop_reqs)
+    # a relaxation is `Q` with entries removed, so it is built by removing them
+    R = Problem(P[p for p in Q.reqs if p ∉ withdrawn];
+        compat = isempty(nocomp) ? Q.compat :
+            filter(kv -> first(kv) ∉ nocomp, Dict(Q.compat)),
+        pins = isempty(nopin) ? Q.pins :
+            filter(kv -> first(kv) ∉ nopin, Dict(Q.pins)),
+        excludes = isempty(nokind) ? Q.excludes :
+            Pair{Symbol,Any}[kv for kv in Q.excludes if first(kv) ∉ nokind])
+    # what `R` makes of the classes `Q` laid out, in one pass: the member each
+    # class stands for under `R` and the order those members rank the classes
+    # in. The universe is not relaid out — the clauses say which classes exist,
+    # depend and conflict, and `R` changes none of that — so the ranking is
+    # threaded through the descent instead, and the representatives name the
+    # answer at the end.
+    info = univ.info
+    reps, cperms = class_ranking(info, R, version_permutations(info, order))
+    return RelaxedProblem(Q, R, reps, cperms)
+end
+
+# Answer a relaxation on the instance built for the query it relaxes: the
+# descent again, in the order `rp` ranks the classes, with `rp`'s deactivations
+# in place of the query's for the duration and the query's put back after. The
+# instance is left exactly as it was found — same clauses, same forbidden
+# classes, same decision phases — so one universe answers as many relaxations as
+# it is asked, in any order.
+function resolve(
+    sat :: SAT{P,V},
+    rp  :: RelaxedProblem{P};
+    by  :: Function = identity, # package ordering
+) where {P,V}
+    info = sat.info
+    reps, ord = rp.reps, rp.ord
+    sol = with_deactivations(sat, deactivated_lits(sat, reps)) do
+        rehint_classes!(sat, sat.reps, nothing, reps, ord)
+        try
+            resolve_core(sat, rp.prob.reqs; by, ord)
+        finally
+            rehint_classes!(sat, reps, ord, sat.reps, nothing)
+        end
+    end
+    sol === nothing && return nothing
+    # a solution names classes, and it is the relaxation's representatives that
+    # name the versions: a class whose best member the query forbade stands at a
+    # better one here, so `sat.reps` would name the wrong version — and is not
+    # ours to move
+    return Dict{P,V}(p => info[p].versions[reps[p][i]] for (p, i) in sol)
+end
+
+# ... building the instance for it, which is the shape to reach for when there
+# is a single relaxation to answer; a second one wants the instance kept
+function resolve(
+    univ :: Universe{P,V},
+    rp   :: RelaxedProblem{P};
+    by   :: Function = identity, # package ordering
+) where {P,V}
+    sat = SAT(univ)
+    try resolve(sat, rp; by)
     finally
         finalize(sat)
     end

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -10,11 +10,11 @@ mutable struct SAT{P,V}
     # reactivates every class at once — after which any subset of them can be
     # deactivated again by assumption, no clause rewriting involved
     deact :: Vector{Int}
-    # how many push frames are open. `sat_pop` retracts whatever was pushed
-    # last, so every helper that opens a frame is relying on the frames below
-    # being the ones it thinks they are; this is what lets it say so. picosat
-    # reports the current context as a literal rather than a level, and recycles
-    # those literals, so counting is the way to know
+    # how many push frames are open. picosat reports the current context as a
+    # literal rather than a level, and recycles those literals, so counting is
+    # the way to know: `with_deactivations` has to reach the deactivation frame
+    # with `sat_pop`, which retracts whatever was pushed last, and getting that
+    # wrong retracts someone else's clauses instead of the query's
     depth :: Int
 end
 
@@ -318,52 +318,83 @@ SAT(info :: Dict{P,PkgInfo{P,V}}) where {P,V} = SAT(Universe(info))
 # once — after which any subset can be deactivated again by assuming its
 # literal, with no clause rewritten. Nothing pops the frame in production; the
 # frame exists so that what is built on top of this can, which is
-# `with_classes_relaxed`.
+# `with_classes_relaxed` and `with_deactivations`.
 function deactivate_classes!(sat::SAT{P,V}) where {P,V}
     pico = sat.pico
+    append!(sat.deact, deactivated_lits(sat, sat.reps))
     for (p, reps_p) in sat.reps
         v_p = sat.vars[p]
-        best = 0
-        for (i, r) in enumerate(reps_p)
-            if iszero(r)
-                push!(sat.deact, forbidden_lit(sat, p, i))
-            elseif best == 0
-                best = i
-            end
-        end
         # the structural instance defaults every package's best class to true,
         # so that a package that must be chosen is tried at its best class
         # first. when this query has emptied that class, point the phase at the
         # best class it does admit instead — otherwise the solver's first guess
         # is infeasible for every such package at once
+        best = hinted_class(reps_p, ranking(nothing, p, length(reps_p)))
         if best != 1
             PicoSAT.set_default_phase_lit(pico, v_p + 1, 0)
             best == 0 || PicoSAT.set_default_phase_lit(pico, v_p + best, 1)
         end
     end
-    isempty(sat.deact) && return sat
-    sort!(sat.deact; by = abs) # dict order must not reach the solver
-    return push_deactivations!(sat)
+    return push_forbidden!(sat, sat.deact)
 end
 
-# Assert `sat.deact` as unit clauses in a push frame of its own: one `sat_pop`
+# The literals forbidding the classes `reps` gives no representative to, sorted
+# — what `sat.deact` is for the query the instance was built for, and what a
+# relaxation of that query needs in its place.
+function deactivated_lits(sat::SAT{P}, reps::Dict{P,Vector{Int}}) where {P}
+    lits = Int[]
+    for (p, reps_p) in reps, (i, r) in enumerate(reps_p)
+        iszero(r) && push!(lits, forbidden_lit(sat, p, i))
+    end
+    sort!(lits; by = abs) # dict order must not reach the solver
+    return lits
+end
+
+# Assert `lits` as unit clauses in a push frame of their own: one `sat_pop`
 # retracts all of them at once, and asserting them again is what puts the frame
-# back (`with_classes_relaxed`). Which classes are forbidden and where each
-# package's phase hint points are properties of the query, true whether or not
-# the frame is in force, so `deactivate_classes!` settles them once, around this.
-function push_deactivations!(sat::SAT)
-    isempty(sat.deact) && return sat
+# back. Nothing to assert means no frame, so a caller that pushed nothing must
+# not pop.
+function push_forbidden!(sat::SAT, lits::Vector{Int})
+    isempty(lits) && return sat
     sat_push(sat)
-    for l in sat.deact
+    for l in lits
         PicoSAT.add(sat.pico, l)
         PicoSAT.add(sat.pico, 0)
     end
     return sat
 end
 
+# Run `body` with `deact` forbidden in place of the query's own deactivations,
+# and put the query's frame back afterwards, whatever `body` does, so the
+# instance is as reusable as it was. Returns `body`'s value.
+#
+# The deactivation frame has to be the innermost one, since `sat_pop` retracts
+# whatever was pushed last: this cannot run inside `with_temp_clauses`, though
+# `body` may open one. That is checked rather than trusted — running it one
+# frame too deep pops someone else's clauses and never says so — and so is the
+# balance on the way out, which is what catches a `body` that pushed and did not
+# pop, at the call that did it rather than wherever the damage surfaces.
+function with_deactivations(body::Function, sat::SAT, deact::Vector{Int})
+    depth = sat.depth
+    @assert depth == (isempty(sat.deact) ? 0 : 1) """
+        the deactivation frame is not the innermost one — $depth frames are \
+        open where $(isempty(sat.deact) ? 0 : 1) is expected"""
+    isempty(sat.deact) || sat_pop(sat)
+    try
+        push_forbidden!(sat, deact)
+        try body()
+        finally
+            isempty(deact) || sat_pop(sat)
+        end
+    finally
+        push_forbidden!(sat, sat.deact)
+        @assert sat.depth == depth balance_error(sat, depth)
+    end
+end
+
 # Run `body` with every class of the universe choosable — the deactivating
-# clauses retracted — and put the frame back afterwards, whatever `body` does,
-# so the instance is as reusable as it was. Returns `body`'s value.
+# clauses retracted — and put the frame back afterwards. The empty end of
+# `with_deactivations`: forbidding nothing is the weakest thing to forbid.
 #
 # Inside, activation is entirely a matter of assumption: assuming
 # `forbidden_lit(sat, p, c)` forbids class `c` of `p` for one solve, and
@@ -371,25 +402,8 @@ end
 # subset of the query's deactivations can be imposed one solve at a time with no
 # clause added and none rewritten. Restoring re-asserts the same unit clauses,
 # because popping a frame discards the clauses asserted in it.
-#
-# The deactivation frame has to be the innermost one, since `sat_pop` retracts
-# whatever was pushed last: this cannot run inside `with_temp_clauses`, though
-# `body` may open one. Both halves of that are checked rather than trusted —
-# lifting one frame too deep retracts someone else's clauses, and a `body` that
-# pushes without popping leaves the instance a frame deeper than it found it,
-# and neither says so on its own.
-function with_classes_relaxed(body::Function, sat::SAT)
-    depth = sat.depth
-    @assert depth == (isempty(sat.deact) ? 0 : 1) """
-        the deactivation frame is not the innermost one — $depth frames are \
-        open where $(isempty(sat.deact) ? 0 : 1) is expected"""
-    isempty(sat.deact) || sat_pop(sat) # nothing forbidden: no frame to lift
-    try body()
-    finally
-        push_deactivations!(sat)
-        @assert sat.depth == depth balance_error(sat, depth)
-    end
-end
+with_classes_relaxed(body::Function, sat::SAT) =
+    with_deactivations(body, sat, Int[])
 
 function finalize(sat::SAT)
     pico = sat.pico
@@ -496,6 +510,60 @@ function with_temp_clauses(body::Function, sat::SAT)
     end
 end
 
+# How a relaxation ranks a package's classes, and the whole of what the descent
+# asks of it: `ord_p[r]` is the class ranked `r`-th. `nothing` is the universe's
+# own layout, where a class's rank *is* its index, so the ranking is the range
+# of its class indices and costs nothing to say.
+#
+# Re-ranking invalidates no clause — every clause says which classes exist,
+# depend and conflict, and a relaxation changes none of that — so the universe
+# is not relaid out and the order is threaded through the descent instead. The
+# improvement disjunction has the same size the layout order's would, so the
+# descent adds the clauses it always added.
+#
+# A relaxation moves few packages, and few of the classes of the ones it moves.
+# Both sparsities are one fact, and `SparsePerm` is both: the map holds an entry
+# only for a package that moved, and that entry holds only the classes that did.
+ranking(::Nothing, p, m::Int) = Base.OneTo(m)
+ranking(ord::Dict{P,SparsePerm}, p::P, m::Int) where {P} =
+    get(ord, p, Base.OneTo(m))
+
+# the class a package's decision phase points at when its classes are
+# represented by `reps_p` and ranked by `ord_p`: the best class the query admits,
+# or 0 when it admits none
+function hinted_class(reps_p::Vector{Int}, ord_p)
+    for r in eachindex(ord_p)
+        c = @inbounds ord_p[r]
+        iszero(reps_p[c]) || return c
+    end
+    return 0
+end
+
+# Move every package's phase hint from where `(from, from_ord)` puts it to where
+# `(to, to_ord)` does. A phase is a solver knob rather than a clause, so no
+# `sat_pop` takes one back down: an instance that answers one relaxation after
+# another has to have each one's hints taken down explicitly before the next
+# one's go up, or the first relaxation's guesses leak into the second's solves.
+# Settled once per relaxation and not touched again — once the descent pins a
+# package it adds a unit clause, and the hint stops mattering.
+function rehint_classes!(
+    sat      :: SAT{P},
+    from     :: Dict{P,Vector{Int}},
+    from_ord :: Union{Nothing, Dict{P,SparsePerm}},
+    to       :: Dict{P,Vector{Int}},
+    to_ord   :: Union{Nothing, Dict{P,SparsePerm}},
+) where {P}
+    for (p, v_p) in sat.vars
+        from_p, to_p = from[p], to[p]
+        a = hinted_class(from_p, ranking(from_ord, p, length(from_p)))
+        b = hinted_class(to_p, ranking(to_ord, p, length(to_p)))
+        a == b && continue
+        a == 0 || PicoSAT.set_default_phase_lit(sat.pico, v_p + a, 0)
+        b == 0 || PicoSAT.set_default_phase_lit(sat.pico, v_p + b, 1)
+    end
+    return sat
+end
+
 # improve package p to its best feasible class: repeatedly demand some
 # strictly better class until that becomes unsatisfiable, keeping the last
 # good model in sol
@@ -503,24 +571,30 @@ function optimize_version!(
     sat :: SAT{P},
     sol :: Dict{P,Int},
     p   :: P,
-) where {P}
+    ord :: O = nothing,
+) where {P, O}
+    ord_p = ranking(ord, p, nclasses(sat.info[p]))
+    best = @inbounds ord_p[1]
     # cheap first try: after filtering, the best class is feasible more
     # often than not, and probing it by assumption needs no temp clauses
     # at all — one solve replaces the whole improvement loop
-    if sol[p] > 1
-        sat_assume(sat, p, 1)
+    if sol[p] != best
+        sat_assume(sat, p, best)
         if is_satisfiable(sat)
             extract_solution!(sat, sol)
-            @assert sol[p] == 1
+            @assert sol[p] == best
         end
     end
-    # sol[p] == 1 is already optimal: the improvement clause below would be
-    # empty, forcing a guaranteed-UNSAT solve
-    while sol[p] > 1
+    # a package already at its best class is optimal: the improvement clause
+    # below would be empty, forcing a guaranteed-UNSAT solve
+    while sol[p] != best
         improved = with_temp_clauses(sat) do
-            # some strictly better class of p
-            for i = 1:sol[p]-1
-                sat_add(sat, p, i)
+            # some class ranking strictly above the one it has — the ranks the
+            # scan passes on its way to the one it has, which is where it stops
+            for r in eachindex(ord_p)
+                c = @inbounds ord_p[r]
+                c == sol[p] && break
+                sat_add(sat, p, c)
             end
             sat_add(sat)
             is_satisfiable(sat) || return false

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -10,6 +10,12 @@ mutable struct SAT{P,V}
     # reactivates every class at once — after which any subset of them can be
     # deactivated again by assumption, no clause rewriting involved
     deact :: Vector{Int}
+    # how many push frames are open. `sat_pop` retracts whatever was pushed
+    # last, so every helper that opens a frame is relying on the frames below
+    # being the ones it thinks they are; this is what lets it say so. picosat
+    # reports the current context as a literal rather than a level, and recycles
+    # those literals, so counting is the way to know
+    depth :: Int
 end
 
 function Base.show(io::IO, sat::SAT)
@@ -285,7 +291,7 @@ function SAT(
         PicoSAT.reset(pico)
         rethrow()
     end
-    sat = finalizer(finalize, SAT(info, univ.reps, pico, vars, Int[]))
+    sat = finalizer(finalize, SAT(info, univ.reps, pico, vars, Int[], 0))
     try deactivate_classes!(sat)
     catch
         finalize(sat)
@@ -367,13 +373,21 @@ end
 # because popping a frame discards the clauses asserted in it.
 #
 # The deactivation frame has to be the innermost one, since `sat_pop` retracts
-# whatever was pushed last: this cannot run inside `with_temp_clauses`.
+# whatever was pushed last: this cannot run inside `with_temp_clauses`, though
+# `body` may open one. Both halves of that are checked rather than trusted —
+# lifting one frame too deep retracts someone else's clauses, and a `body` that
+# pushes without popping leaves the instance a frame deeper than it found it,
+# and neither says so on its own.
 function with_classes_relaxed(body::Function, sat::SAT)
-    isempty(sat.deact) && return body() # no frame to lift: nothing is forbidden
-    sat_pop(sat)
+    depth = sat.depth
+    @assert depth == (isempty(sat.deact) ? 0 : 1) """
+        the deactivation frame is not the innermost one — $depth frames are \
+        open where $(isempty(sat.deact) ? 0 : 1) is expected"""
+    isempty(sat.deact) || sat_pop(sat) # nothing forbidden: no frame to lift
     try body()
     finally
         push_deactivations!(sat)
+        @assert sat.depth == depth balance_error(sat, depth)
     end
 end
 
@@ -463,14 +477,22 @@ function solution(sat::SAT{P,V}) where {P,V}
     return sol
 end
 
-sat_push(sat::SAT) = PicoSAT.push(sat.pico)
-sat_pop(sat::SAT) = PicoSAT.pop(sat.pico)
+sat_push(sat::SAT) = (sat.depth += 1; PicoSAT.push(sat.pico))
+sat_pop(sat::SAT) = (sat.depth -= 1; PicoSAT.pop(sat.pico))
+
+# What an unbalanced body did, said the same way wherever it is caught. An
+# exception thrown from a `finally` while another is in flight does not lose it:
+# Julia carries both and reports the original as the cause.
+balance_error(sat::SAT, depth::Int) =
+    "the body left $(sat.depth - depth) push frame(s) open"
 
 function with_temp_clauses(body::Function, sat::SAT)
+    depth = sat.depth
     sat_push(sat)
     try body()
     finally
         sat_pop(sat)
+        @assert sat.depth == depth balance_error(sat, depth)
     end
 end
 

--- a/test/relaxation.jl
+++ b/test/relaxation.jl
@@ -409,7 +409,7 @@ end
 @testset "the substrate stays internal" begin
     # substrate, reached by qualified name: `Resolver` exports none of it
     for name in (:installed_lit, :forbidden_lit, :with_classes_relaxed,
-                 :push_deactivations!, :exclusion_sources, :class_exclusions)
+                 :push_forbidden!, :exclusion_sources, :class_exclusions)
         @test isdefined(Resolver, name)
         @test name ∉ names(Resolver)
     end

--- a/test/relaxation.jl
+++ b/test/relaxation.jl
@@ -17,7 +17,7 @@
 using Resolver: PkgData, Problem, SAT, PicoSAT, pkg_info, nclasses, NoKinds,
     rank_pkg_info, finalize, is_satisfiable, is_excluded,
     exclusion_sources, class_exclusions, installed_lit, forbidden_lit,
-    with_classes_relaxed, sat_assume_var
+    with_classes_relaxed, with_temp_clauses, sat_assume_var, sat_push
 
 const NO_DEPS = Dict{Symbol,Vector{Symbol}}()
 const NO_COMP = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
@@ -345,6 +345,62 @@ end
         before = verdicts(sat)
         @test with_classes_relaxed(() -> verdicts(sat), sat) == before
         @test verdicts(sat) == before
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "push frames have to balance" begin
+    # A helper that opens a frame is relying on the frames below it being the
+    # ones it thinks they are, since `sat_pop` retracts whatever was pushed
+    # last. `sat.depth` is what lets it say so, and what these check is that it
+    # does: a body that pushes without popping leaves the instance a frame
+    # deeper than the helper found it, which is a wrong `sat_pop` somewhere
+    # later and nothing at all at the call that caused it.
+    data = Dict(
+        :P => PkgData([:v2, :v1], NO_DEPS, Dict(:v2 => Dict(:Q => [:w1]))),
+        :Q => PkgData([:w2, :w1], NO_DEPS, NO_COMP),
+    )
+    prob = Problem([:P, :Q]; compat = Dict(:P => [:v1]))
+    info = pkg_info(data, prob; filter = false)
+
+    for (name, prob) in ((:constrained, prob), (:plain, Problem([:P, :Q])))
+        sat = SAT(rank_pkg_info(info, prob))
+        try
+            # the frame the query's deactivations sit in, and nothing else
+            @test sat.depth == (isempty(sat.deact) ? 0 : 1)
+            before = verdicts(sat)
+            # a balanced body is what both helpers are for, and leaves no trace
+            @test with_temp_clauses(() -> :ok, sat) === :ok
+            @test with_classes_relaxed(() -> :ok, sat) === :ok
+            @test sat.depth == (isempty(sat.deact) ? 0 : 1)
+            @test verdicts(sat) == before
+        finally
+            finalize(sat)
+        end
+        # an unbalanced one is caught by each of them, at the call that did it
+        sat = SAT(rank_pkg_info(info, prob))
+        try
+            @test_throws AssertionError with_temp_clauses(() -> sat_push(sat), sat)
+        finally
+            finalize(sat)
+        end
+        sat = SAT(rank_pkg_info(info, prob))
+        try
+            @test_throws AssertionError with_classes_relaxed(() -> sat_push(sat), sat)
+        finally
+            finalize(sat)
+        end
+    end
+
+    # ... and lifting the deactivations from inside a temp-clause frame would
+    # pop that frame instead of theirs, which is caught on the way in
+    sat = SAT(rank_pkg_info(info, prob))
+    try
+        @test !isempty(sat.deact) # there is a frame to get wrong
+        @test_throws AssertionError with_temp_clauses(sat) do
+            with_classes_relaxed(() -> nothing, sat)
+        end
     finally
         finalize(sat)
     end

--- a/test/relaxation_stable.jl
+++ b/test/relaxation_stable.jl
@@ -10,67 +10,99 @@
 #     resolving R from the unfiltered artifact gives
 #
 # for random universes crossed with random queries and random relaxations of
-# them. Two sharper statements are checked alongside, because a failure in
-# either localizes the cause: that the Q-filtered universe contains everything
+# them. The left-hand side is `relax` and `resolve`, run the way a diagnosis
+# runs them: one SAT instance per query, answering the whole sample.
+#
+# Two sharper statements are checked alongside, because a failure in either
+# localizes the cause: that the Q-filtered universe contains everything
 # a fresh filter for R would keep (Theorem B), and that the reachability walk's
 # kept set is downward closed in `key_∅` (the Remark), which is the invariant
 # that lets it carry an integer frontier instead of a set.
 
-using Resolver: PkgData, PkgInfo, Problem, Universe, NoKinds, pkg_info, nclasses,
-    prepare_pkg_info, rank_pkg_info, resolve, resolve_prepared, class_ranking,
-    copy_ranked!, version_permutations, deactivations, mark_installable!,
-    mark_reachable!
+using Resolver: PkgData, Problem, SAT, NoKinds, SparsePerm, RelaxedProblem,
+    pkg_info, nclasses, prepare_pkg_info, rank_pkg_info, resolve, relax, sources,
+    class_ranking, deactivations, is_excluded, with_classes_relaxed,
+    with_temp_clauses, mark_installable!, mark_reachable!, finalize
 
 using .tiny_data
 
 # --- relaxations, at the Problem level: exactly what a diagnosis would ask ---
 
-# every constraint source Q carries, as something removable
-function sources(Q::Problem{P}) where {P}
-    s = Any[]
-    for p in keys(Q.compat); push!(s, (:compat, p)); end
-    for p in keys(Q.pins);   push!(s, (:pin, p));    end
-    for (k, _) in Q.excludes; push!(s, (:kind, k));  end
-    return s
+# What being a relaxation *is*, asserted of every one `relax` builds here.
+# `R ≤ Q` means `reqs_R ⊆ reqs_Q` and `adm_Q ⊆ adm_R` — every version `Q`
+# admitted, `R` admits — which is the hypothesis (Lemma 1) that every theorem on
+# the relaxation-stability page rests on. Resolving a relaxation takes it as a
+# precondition and answers wrongly rather than erroring when it fails, so what
+# has to be right is `relax`, and this is what says it is.
+function is_relaxation(info, Q::Problem{P}, R::Problem{P}) where {P}
+    Set(R.reqs) ⊆ Set(Q.reqs) || return false
+    for (p, info_p) in info, v in info_p.versions
+        is_excluded(R, p, v) && !is_excluded(Q, p, v) && return false
+    end
+    return true
 end
 
-function relax(Q::Problem{P}, drop_reqs, drop_srcs) where {P}
-    reqs = P[p for p in Q.reqs if p ∉ drop_reqs]
-    nocomp = Set(p for (k, p) in drop_srcs if k === :compat)
-    nopin  = Set(p for (k, p) in drop_srcs if k === :pin)
-    nokind = Set(k for (t, k) in drop_srcs if t === :kind)
-    compat = filter(kv -> first(kv) ∉ nocomp, Dict(Q.compat))
-    pins   = filter(kv -> first(kv) ∉ nopin,  Dict(Q.pins))
-    excludes = Pair{Symbol,Any}[kv for kv in Q.excludes if first(kv) ∉ nokind]
-    return Problem(reqs; compat, pins, excludes)
+function relaxed(info, univ, Q, drop_reqs, drop_sources)
+    rp = relax(univ, Q, drop_reqs, drop_sources)
+    @test is_relaxation(info, Q, rp.prob)
+    return rp
 end
 
-# a sample: the bottom of the lattice (everything dropped) first, since it is
+# a sample: the bottom of the lattice (everything withdrawn) first, since it is
 # the hardest case and the one caching depends on, then random points
-function relaxations(Q::Problem{P}, k::Int) where {P}
+function relaxations(info, univ, Q::Problem{P}, k::Int) where {P}
     srcs = sources(Q)
-    out = [relax(Q, P[], srcs)]
+    # the element type is abstract on purpose: a relaxation that reorders
+    # carries a different `ord` from one that does not
+    out = RelaxedProblem[relaxed(info, univ, Q, P[], srcs)]
     for _ = 1:k
         dr = P[p for p in unique(Q.reqs) if rand() < 0.35]
-        ds = Any[s for s in srcs if rand() < 0.5]
+        ds = [s for s in srcs if rand() < 0.5]
         isempty(dr) && isempty(ds) && continue
-        push!(out, relax(Q, dr, ds))
+        push!(out, relaxed(info, univ, Q, dr, ds))
     end
     return out
 end
 
-# What reuse means: keep the filtered universe, re-rank its classes for `R`
-# — new representatives and, where `R` moves them, a new layout — and solve.
-# No pass of the filter is run again.
-function resolve_reuse(univ::Universe{P,V}, R::Problem{P}) where {P,V}
-    info = univ.info
-    reps, cperms = class_ranking(info, R, version_permutations(info, nothing))
-    u = cperms === nothing ?
-        Universe{P,V}(info, reps, nothing) :
-        copy_ranked!(
-            Universe{P,V}(Dict{P,PkgInfo{P,V}}(), Dict{P,Vector{Int}}(), nothing),
-            info, reps, cperms)
-    return resolve_prepared(u, R)
+# Constraints that demote every class that can be demoted: forbid the best
+# member of each multi-member class, so the class competes at a worse member and
+# can fall behind one it used to outrank — and nothing is emptied, so this
+# reorders without deactivating. Dropping the bound puts the classes back, which
+# is a relaxation whose whole content is the class order moving.
+function demoting_constraints(info::AbstractDict{P}) where {P}
+    compat = Dict{P,Vector{Int}}()
+    for (p, info_p) in info
+        banned = Set(info_p.versions[first(mem)]
+                     for mem in info_p.members if length(mem) ≥ 2)
+        isempty(banned) && continue
+        compat[p] = [v for v in info_p.versions if v ∉ banned]
+    end
+    return compat
+end
+
+# One round's data and constraints, in one of two regimes. `:random` is the
+# ordinary case. `:demoting` builds the constraints above, and needs classes of
+# several members for them to have anything to demote — which sparse dependency
+# and compat patterns produce (the same trick `test/classes.jl` uses, for the
+# same reason), so it draws sparsely and redraws until the data has one.
+#
+# Only a class with two members can move: a singleton competes at its only
+# member whatever the query says, so its key is the same under every relaxation.
+# That is why reordering is rare under random constraints, and why testing it
+# takes a regime of its own rather than a bigger sample.
+function draw_query!(mode::Symbol, m, n, make_deps, make_comp, d, c, data)
+    for _ = 1:25
+        sparse = mode === :demoting
+        fill_data!(m, n,
+            make_deps(sparse ? randbits(d) & randbits(d) : randbits(d)),
+            make_comp(sparse ? randbits(c) & randbits(c) & randbits(c) :
+                               randbits(c)), data)
+        info = pkg_info(data, keys(data); filter = false)
+        sparse || return info, random_constraints(m, n)...
+        compat = demoting_constraints(info)
+        isempty(compat) || return info, compat, Dict{Int,Int}()
+    end
+    return nothing # no data with a class of several members: nothing to demote
 end
 
 # the (package, version-tuple) identity of every class left in a universe, so
@@ -79,32 +111,260 @@ classkeys(univ) = Set(
     (p, Tuple(ip.versions[j] for j in mem))
     for (p, ip) in univ.info for mem in ip.members)
 
+# does the relaxation move any of the universe's classes, or only re-represent
+# them? the first is what makes the descent optimize in an order that is not the
+# layout, and `relax` has already settled it
+reranks(rp) = rp.ord !== nothing
+
+# classes the query emptied that the relaxation gives a representative back to
+revivals(univ, rp) = count(
+    iszero(univ.reps[p][c]) && !iszero(rs[c])
+    for (p, rs) in rp.reps for c in eachindex(rs))
+
 @testset "a Q-filtered universe answers every relaxation of Q" begin
-    reused = 0
+    reused = revived = reranked = demoting = 0
     for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2), (2, 5))
         make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
-        for _ = 1:30
-            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+        # both regimes: constraints drawn at random, and constraints built to
+        # demote every class that can be demoted
+        for mode in (:random, :demoting), _ = 1:15
+            drawn = draw_query!(mode, m, n, make_deps, make_comp, d, c, data)
+            drawn === nothing && continue
+            info, compat, pins = drawn
             reqs = collect(make_reqs(rand(1:2^m-1)))
-            info = pkg_info(data, keys(data); filter = false)
-            compat, pins = random_constraints(m, n)
             bad = rand(1:n)
-            excludes = rand(Bool) ?
+            # a second source, independently droppable, so that dropping the
+            # compat bound is one point of the lattice rather than all of it
+            excludes = mode === :demoting || rand(Bool) ?
                 Pair{Symbol,Any}[:test => (p, v) -> v == bad] : NoKinds
             Q = Problem(reqs; compat, pins, excludes)
             univ = prepare_pkg_info(info, Q)
             have = classkeys(univ)
-            for R in relaxations(Q, 4)
-                # Theorem C: reuse answers R exactly as a fresh resolve does
-                @test resolve_reuse(univ, R) == resolve(info, R)
-                # Theorem B, the sharper statement: nothing a fresh filter for
-                # R keeps is missing from the universe filtered for Q
-                @test isempty(setdiff(classkeys(prepare_pkg_info(info, R)), have))
-                reused += 1
+            # one instance for the whole lattice sample, which is the point:
+            # a diagnosis tests its candidate fixes on the instance the failed
+            # resolve already built
+            sat = SAT(univ)
+            try
+                for rp in relaxations(info, univ, Q, 4)
+                    R = rp.prob
+                    # Theorem C: reuse answers R exactly as a fresh resolve does
+                    @test resolve(sat, rp) == resolve(info, R)
+                    # Theorem B, the sharper statement: nothing a fresh filter
+                    # for R keeps is missing from the universe filtered for Q
+                    @test isempty(setdiff(classkeys(prepare_pkg_info(info, R)), have))
+                    reused += 1
+                    revived += revivals(univ, rp) > 0
+                    reranked += reranks(rp)
+                    demoting += mode === :demoting
+                end
+            finally
+                finalize(sat)
             end
         end
     end
-    @test reused > 900
+    @test reused > 800
+    # the sweep really did exercise both things a relaxation moves: the classes
+    # the descent can select at all, and the order it optimizes them in
+    @test revived > 0
+    # the second is what the demoting regime is for. It reorders 11-15% of the
+    # relaxations it sweeps, against 0.5-1% under random constraints alone —
+    # dozens of times a run rather than a handful, so this is a floor with room
+    # under it rather than a coin flip. It is not higher because reordering also
+    # needs the demoted class to be non-contiguous in version order, so that
+    # something it outranked sits between two of its members
+    @test reranked > demoting ÷ 15
+end
+
+@testset "a relaxation the descent optimizes in a new order" begin
+    # :A's :v4 and :v1 are one class (both depend on :B alone), :v3 and :v2 are
+    # another (both on :C). Q forbids :v4, which leaves the first class standing
+    # at :v1 — behind the second, which stands at :v3 — so the universe is laid
+    # out with the :C class first. R lifts the bound and the order flips back:
+    # "some better class" then means a class *later* in the layout
+    data = Dict(
+        :A => PkgData([:v4, :v3, :v2, :v1],
+            Dict(:v4 => [:B], :v3 => [:C], :v2 => [:C], :v1 => [:B]), NO_COMP),
+        :B => PkgData([:w1], NO_DEPS, NO_COMP),
+        :C => PkgData([:x1], NO_DEPS, NO_COMP),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+    Q = Problem([:A]; compat = Dict(:A => [:v3, :v2, :v1]))
+    univ = prepare_pkg_info(info, Q)
+    @test univ.info[:A].members == [[2, 3], [1, 4]] # the :C class laid out first
+    @test univ.reps[:A] == [2, 4]
+    @test resolve(info, Q) == Dict(:A => :v3, :C => :x1)
+
+    rp = relaxed(info, univ, Q, Symbol[], sources(Q))
+    @test rp.prob.reqs == [:A] && isempty(rp.prob.compat)
+    @test reranks(rp) # the class order really did move
+    @test resolve(info, rp.prob) == Dict(:A => :v4, :B => :w1)
+    @test resolve(univ, rp) == Dict(:A => :v4, :B => :w1)
+end
+
+@testset "a relaxation names the version R admits, not the one Q did" begin
+    # :A's :v3 and :v2 are indistinguishable to the registry — one class of two
+    # members — and :v1 is a class of its own because it alone depends on :B.
+    # Q's bound empties the first class outright; R lifts it, which both revives
+    # the class and gives it a representative :A had none of under Q
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1],
+            Dict(:v3 => Symbol[], :v2 => Symbol[], :v1 => [:B]), NO_COMP),
+        :B => PkgData([:w1], NO_DEPS, NO_COMP),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+    Q = Problem([:A]; compat = Dict(:A => [:v1]))
+    univ = prepare_pkg_info(info, Q)
+    # the emptied class is still there, and still has no representative
+    @test nclasses(univ.info[:A]) == 2
+    @test univ.reps[:A] == [0, 3]
+    @test resolve(info, Q) == Dict(:A => :v1, :B => :w1)
+
+    rp = relaxed(info, univ, Q, Symbol[], sources(Q))
+    @test revivals(univ, rp) == 1
+    @test resolve(info, rp.prob) == Dict(:A => :v3)
+    # naming through Q's representatives would index version 0 of :A; naming
+    # through the relaxation's gives the version its best class stands at
+    @test resolve(univ, rp) == Dict(:A => :v3)
+
+    sat = SAT(univ)
+    try
+        @test resolve(sat, rp) == Dict(:A => :v3)
+        # the bottom of the lattice requires nothing, so it installs nothing
+        @test resolve(sat, relaxed(info, univ, Q, Q.reqs, sources(Q))) ==
+            Dict{Symbol,Symbol}()
+        # Q itself is a relaxation of Q, and answers as Q answers
+        @test resolve(sat, relaxed(info, univ, Q, Symbol[], Pair{Symbol,Any}[])) == resolve(info, Q)
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "a relaxation cannot be answered one frame too deep" begin
+    data = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), NO_COMP),
+        :B => PkgData([:w2, :w1], NO_DEPS, NO_COMP),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+    Q = Problem([:A]; compat = Dict(:A => [:v1]))
+    univ = prepare_pkg_info(info, Q)
+    rp = relaxed(info, univ, Q, Symbol[], sources(Q))
+    sat = SAT(univ)
+    try
+        want = resolve(sat, rp)
+        depth = sat.depth
+        # asking from inside a temp-clause frame would have the swap pop that
+        # frame instead of the query's, and nothing downstream could tell
+        @test_throws AssertionError with_temp_clauses(() -> resolve(sat, rp), sat)
+        # the failed call left the instance alone, so it still answers
+        @test sat.depth == depth
+        @test resolve(sat, rp) == want
+    finally
+        finalize(sat)
+    end
+end
+
+@testset "a permutation stored as what it displaces" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # the identity displaces nothing, which is every package a relaxation left
+    # alone and every package at all when it moved none
+    @test collect(SparsePerm(5, Tuple{Int,Int}[])) == 1:5
+    moved = 0
+    for n = 1:6, _ = 1:20
+        perm = randperm(n)
+        sp = SparsePerm(n, Tuple{Int,Int}[(i, perm[i]) for i = 1:n if perm[i] != i])
+        # it is the permutation, through the AbstractVector interface everything
+        # from the descent's scan to `copy_ranked!`'s `members[perm]` uses
+        @test collect(sp) == perm
+        @test all(sp[i] == perm[i] for i = 1:n)
+        @test [10i for i = 1:n][sp] == [10i for i in perm]
+        @test collect(invperm(sp)) == invperm(perm)
+        # and it stores only what it displaces, in position order
+        @test length(sp.moved) == count(i -> perm[i] != i, 1:n)
+        @test issorted(sp.moved)
+        moved += length(sp.moved) > 0
+    end
+    @test moved > 0
+end
+
+@testset "a relaxation's ranking is what the descent indexes" begin
+    # A package a relaxation moved ranks its classes by the permutation
+    # `class_ranking` built while ranking them; every other package ranks them
+    # the way the layout does. Both are vectors the descent indexes.
+    make_deps, make_comp, data, d, c = tiny_data_makers(3, 3)
+    moved = layout = 0
+    for _ = 1:200
+        drawn = draw_query!(:demoting, 3, 3, make_deps, make_comp, d, c, data)
+        drawn === nothing && continue
+        info, compat, pins = drawn
+        reqs = collect(make_reqs(rand(1:2^3-1)))
+        Q = Problem(reqs; compat, pins)
+        univ = prepare_pkg_info(info, Q)
+        rp = relax(univ, Q, Int[], sources(Q))
+        for (p, ip) in univ.info
+            m = nclasses(ip)
+            ord = Resolver.ranking(rp.ord, p, m)
+            @test sort(collect(ord)) == 1:m   # a permutation of the classes
+            if ord isa Base.OneTo
+                layout += 1
+            else
+                moved += 1
+                @test ord === rp.ord[p]       # kept as `class_ranking` built it
+            end
+        end
+    end
+    @test moved > 0
+    @test layout > moved
+end
+
+@testset "one instance, many relaxations, no residue" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    for (m, n) in ((2, 3), (3, 2), (3, 3), (2, 4))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+        reqs = collect(make_reqs(rand(1:2^m-1)))
+        info = pkg_info(data, keys(data); filter = false)
+        compat, pins = random_constraints(m, n)
+        bad = rand(1:n)
+        Q = Problem(reqs; compat, pins,
+            excludes = Pair{Symbol,Any}[:test => (p, v) -> v == bad])
+        univ = prepare_pkg_info(info, Q)
+        rels = relaxations(info, univ, Q, 8)
+        want = Dict(i => resolve(info, rp.prob) for (i, rp) in enumerate(rels))
+        sat = SAT(univ)
+        try
+            # `verdicts` (relaxation.jl) is the instance's answers to every
+            # satisfiability question that can be put to it in terms of
+            # packages and classes: two states that agree on it are
+            # indistinguishable to anything above. The lifted reading is what
+            # says the *frames* balance from the outside, `sat.depth` saying it
+            # from the inside: `with_classes_relaxed` pops exactly one frame, so
+            # one left open would have it lift that instead of the
+            # deactivations, and the relaxed reading would come out wrong
+            before = verdicts(sat)
+            lifted = with_classes_relaxed(() -> verdicts(sat), sat)
+            deact = copy(sat.deact)
+            depth = sat.depth
+            self = resolve(sat, Q.reqs)
+            # each round asks the same relaxations in a fresh random order, so
+            # a leak from one relaxation into the next would show up as an
+            # answer that depends on what was asked before it
+            for round = 1:4, i in randperm(length(rels))
+                @test resolve(sat, rels[i]) == want[i]
+            end
+            # the instance itself is as it was found: the same forbidden
+            # classes, the same open frames, the same answers, and the same
+            # answer to its own query — the last of which is the phase hints
+            # too, since nothing but a solver knob distinguishes two descents
+            # that add the same clauses
+            @test sat.deact == deact
+            @test sat.depth == depth
+            @test verdicts(sat) == before
+            @test with_classes_relaxed(() -> verdicts(sat), sat) == lifted
+            @test resolve(sat, Q.reqs) == self
+        finally
+            finalize(sat)
+        end
+    end
 end
 
 @testset "the reachable set is downward closed in key_∅" begin

--- a/test/relaxation_stable.jl
+++ b/test/relaxation_stable.jl
@@ -104,7 +104,7 @@ classkeys(univ) = Set(
             end
         end
     end
-    @test reused > 1000
+    @test reused > 900
 end
 
 @testset "the reachable set is downward closed in key_∅" begin


### PR DESCRIPTION
Follows #75, and is what makes its theorem usable.

#75 proved that a universe filtered for query `Q` contains everything an answer
to any relaxation `R ≤ Q` needs (Theorem C). Nothing in `src/` could act on
that: every public `resolve` routes through `prepare_pkg_info`, which ranks
*and* filters, so there was no way to say "take this universe and answer a
relaxation of the query it was filtered for". The only implementation was a
ten-line helper in `test/relaxation_stable.jl`, written to check the theorem
rather than to be used.

`resolve(sat, rp::RelaxedProblem)` is that call. It returns what
`resolve(info, rp.prob)` returns, running no pass of the filter and building no
second instance, and leaves the instance as it found it so one universe answers
as many relaxations as it is asked. The consumer is diagnostics: verifying a
candidate fix becomes a re-rank and a descent instead of a re-prepare.

Three commits: a one-line fix to a flaky coverage guard this PR's tests would
otherwise inherit, then the frame-depth mechanism, then the relaxation work
that uses it.

## The value, not the arguments

```julia
sources(prob)                                            # the query's constraint sources
relax(univ, Q, drop_reqs, drop_sources; order = nothing) # -> RelaxedProblem
resolve(sat,  rp::RelaxedProblem; by = identity)
resolve(univ, rp::RelaxedProblem; by = identity)
```

An earlier revision took `(sat, Q, R; order)`, which made two things the
caller had to get right and could not be helped with: that `R` was a relaxation
of `Q`, and that `order` matched what the universe was ranked in. Both are gone
rather than documented or checked. `relax` *derives* the relaxed problem by
withdrawing demands instead of accepting one, so being a relaxation is a
consequence of how the value was made rather than a claim about an argument;
and it settles there what every solve would otherwise recompute — the
representatives and the class ranking — so `order` is consumed at construction
and never reaches a solve.

`relax(univ, Q, Q.reqs, sources(Q))` is the bottom of the lattice;
`relax(univ, Q)` is `Q` itself; a diagnostics fix is a subset of `sources(Q)`
plus a list of requirements, which is the shape a fix already has.

That also stops repeated work: `version_permutations` was recomputed on every
solve. For the canonical ordering it returns immediately, but for a
non-canonical one it walks every package and sorts the ones out of order —
0.17–0.82 ms per solve on these roots, up to a quarter of the cheapest solves.
It is now paid once per relaxation.

## Re-ranking invalidates no clause

Every clause states which classes exist, depend and conflict — including the
prefix-ladder ones, whose "some class at layout position ≤ k" is a structural
fact used for at-most-one and the interval conflict encoding. A relaxation
changes which class we *prefer*, not which classes there are.

So the universe is not relaid out. The new ranking is threaded through the
descent instead, as the two questions the five "better than the current class"
sites actually ask: which class to probe first, and which classes an
improvement step may demand. `LayoutOrder` answers them with `1` and `1:i-1`,
so the ordinary descent is the code it was — **descent allocations are
byte-identical before and after** (12,976 / 20,056 / 62,464 / 84,928 for JSON,
DataFrames, DifferentialEquations, Makie), and the timing differences are
inside the run-to-run noise.

A package's ranking is just a vector the descent indexes: `ord_p[1]` is the
best class, and the classes ranking above the one it holds are the ranks the
scan passes on the way to it. For a relaxation that reorders nothing — which is
every relaxation of these four registry roots, and ~93% even under a generator
built to force reordering — that vector is `Base.OneTo(n)`.

Where something did move it is a `SparsePerm <: AbstractVector{Int}`: a
permutation stored as the pairs `(i, p[i])` for the positions it actually
displaces. `class_ranking` builds it while it ranks — sorting into a scratch
buffer reused across the whole pass, then walking it and pushing what moved — so
a package that reorders nothing allocates nothing and one that swaps two classes
carries two pairs. Nothing dense is retained. Being an `AbstractVector` is what
lets it flow unchanged through `copy_ranked!`'s `members[perm]`, `reps[p][perm]`,
`invperm` and `relaid_conflicts`, and `relax` keeps exactly what `class_ranking`
built, with no conversion.

That is the whole abstraction:

```julia
ranking(::Nothing, p, m::Int) = Base.OneTo(m)
ranking(ord::Dict{P,SparsePerm}, p::P, m::Int) where {P} = get(ord, p, Base.OneTo(m))
```

There is no inverse of it in the descent. "Is `p` at its best" is
`sol[p] == ord_p[1]`, and the better-set is a forward scan that stops at the
class `p` holds — which is guaranteed to be in `ord_p`, and which emits exactly
the literals the caller was going to emit anyway. `RelaxedProblem` is
parameterized on the ordering's type, so the one dynamic dispatch lands at
`resolve(sat, rp)` and everything behind that barrier is specialized.

## `reps` moves under a relaxation

`sat.reps[p][c]` is the member class `c` stands for *under `Q`* — a class whose
best member `Q` forbade stands at a better one under `R`. So `resolve_core`
hands back classes and the caller names them with `R`'s own representatives;
`sat.reps` is never mutated. `class_ranking` returns the new naming map and the
new ordering in one call, because they are one computation.

Deactivation is the other half of what `reps` means, and that is structural:
the reuse path swaps `Q`'s forbidding frame for `R`'s using #72's substrate,
scoped so an exception cannot strand the instance in `R`'s state.
`with_classes_relaxed` is now literally the empty end of that operation.

Frame depth is a field on `SAT` maintained by `sat_push`/`sat_pop`, and the
`with_*` helpers assert balance on entry *and* exit, so an unbalanced push
inside a body is caught at the call that did it. (`picosat_context` cannot
serve: it returns the context literal, not a level, and picosat recycles them.)

## The one precondition left

`reps` and the class ranking are indexed by the layout of the universe `relax`
was given, so a `RelaxedProblem` is stale if that universe is filtered again
afterwards. Nothing does that — `drop_unmarked!` is reachable only from
`prepare_pkg_info`, which builds a universe rather than shrinking one already
in use — so it gets one sentence in the docstring and no runtime machinery. A
`frozen` flag on `Universe` was considered and declined: it would prevent a
sequence nobody performs.

An earlier revision checked at runtime that `R` was a relaxation of `Q`. That
was 24% of the change and a parameter existing for no other purpose, to guard
an internal calling convention — where `resolve_prepared(univ, prob)`,
immediately above, carries the same class of precondition and documents it in a
one-line comment. What verifies it now is a test asserting that *`relax` itself*
produces relaxations: `reqs_R ⊆ reqs_Q` and `adm_Q ⊆ adm_R` pointwise, Lemma 1's
hypothesis, once per relaxation built.

## Numbers

Reuse against `resolve(info, R)`, min of 7, five relaxations each:

| root | per relaxation | batch of five |
|---|---|---|
| JSON | 2.3× – 17.4× | 34.8 → 4.8 ms (7.3×) |
| DataFrames | 2.1× – 7.1× | 49.5 → 14.3 ms (3.5×) |
| DifferentialEquations | 3.6× – 13.4× | 754.7 → 103.7 ms (7.3×) |
| Makie | 2.3× – 9.2× | 439.1 → 96.7 ms (4.5×) |

The batch figure includes `relax` itself (0.01–1.30 ms); the per-relaxation
range is the solve alone.

Every reuse answer is asserted equal to the re-prepared one before timing.

## Tests

The Theorem-C sweep drives `resolve_relaxed` itself, so what proved the theorem
exercises the production path rather than a parallel implementation of it. Its
primary assertion — that reuse answers `R` exactly as a fresh resolve does — is
what catches this whole class of bug, but only on queries that actually
*reorder* classes, and it was barely reaching those: 0.5–1.3% of relaxations.

The reason turned out to be structural. A class of one member competes at that
member whatever the query says, so its key is identical under every relaxation
— it cannot be reordered even in principle. The sweep's data was producing 19
multi-member classes out of 746. Sparse dependency and compat patterns (the
trick `test/classes.jl` already uses, for the same reason) take that to 105 of
637, and a second query regime forbids the best member of every multi-member
class on purpose. Reordering now fires on **5.6–7.4% of relaxations overall and
11.4–15.2% within the demoting regime**; the assertion's threshold sits ~4σ
below the observed band rather than inside it, so it does not flake.

Alongside: a relaxation that revives a class `Q` emptied and must name the
version `R` admits; a hand-built reordering case; one instance answering many
relaxations in fresh orders with no residue; frame-balance assertions catching
both a wrongly-nested call and an unbalanced body; and `ClassRanking` against
dense `randperm` permutations.

Full suite green, docs build clean, and the package precompiles — that last
one is checked explicitly now, because an earlier revision of this branch had
an outer constructor silently overwriting the one Julia generates, which the
full suite tolerated and only the docs build surfaced.

## Disclosure

While reviewing this branch I saw `bin/ tooling regression tests` fail once, on
an early commit, in a way that has not reproduced: every subsequent full-suite
run passes, on both sides of a rebase, and a full-suite control on `main`
passes. The branch touches no `bin/` file. I believe it is a flake — those
tests hit the live registry — but I did not explain it, and would rather say so
than let "suite green" imply it was never seen. #77 is why the next occurrence
will come with the child's output attached.
