### PR TITLE
@test_success: report the command, exit code and output when a subprocess test fails

### DIFF
--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -137,7 +137,8 @@ function resolve_versions(
         # back so a caller that passed `err` in can read it too
         msg = String(take!(err))
         print(err, msg)
-        occursin("Unsatisfiable", msg) || error("failed: $cmd")
+        # when it broke, say what it said -- the command alone explains nothing
+        occursin("Unsatisfiable", msg) || error("failed: $cmd\n$msg")
         return nothing
     end
     vers = Dict{UUID,VersionNumber}()

--- a/test/TestSuccess.jl
+++ b/test/TestSuccess.jl
@@ -1,0 +1,126 @@
+# A `@test` for subprocesses. Nothing here knows about Resolver: it uses Base
+# and Test only, so it can be lifted out of this repo unchanged. Inside Test
+# itself, `test_success` below would build its Pass/Fail the way the other test
+# macros do; from outside, it sticks to constructor forms that have been stable
+# since Julia 1.9.
+
+"""
+Defines [`@test_success`](@ref), a `@test` for commands whose failures report
+the command, how it exited and what it printed.
+"""
+module TestSuccess
+
+using Test
+
+export @test_success
+
+# how many bytes of a failed command's output to report, by default
+const OUTPUT_LIMIT = 8 * 1024
+
+# Test aligns the labels of a failure report in a 14-column gutter
+# ("  Expression: "); the lines we add line up with them.
+label(name::AbstractString) = lpad(name * ":", 13) * " "
+const INDENT = " "^14
+
+"""
+    @test_success cmd
+    @test_success cmd limit = 8192
+
+Test that `cmd` runs and exits with status 0 — the same contract as
+`@test success(cmd)`, but a failure says why: it reports the command as it was
+actually run, how it exited, and what it printed.
+
+Output is captured rather than shown, so a command that succeeds is silent.
+Standard output and standard error are captured together, interleaved in the
+order the command wrote them. A failure reports the last `limit` bytes of that
+— the end being where an explanation usually is — and says how many bytes it
+dropped to fit. A stream `cmd` redirects for itself goes where `cmd` sends it,
+and only the other one is captured.
+
+A command that cannot be started at all — a misspelled program, say — fails the
+test and reports why, rather than throwing.
+
+The test is recorded in the enclosing testset like any other, counting as one
+`Pass` or `Fail` in its summary.
+"""
+macro test_success(cmd, kws...)
+    limit = OUTPUT_LIMIT
+    for kw in kws
+        Meta.isexpr(kw, :(=), 2) && kw.args[1] === :limit ||
+            throw(ArgumentError("@test_success: expected `limit = n`, got `$kw`"))
+        limit = kw.args[2]
+    end
+    quote
+        test_success($(esc(cmd)), $(string(cmd)), $(esc(limit)),
+                     $(QuoteNode(__source__)))
+    end
+end
+
+# Run `cmd` with its output captured; return `nothing` if it exited 0, and
+# otherwise the report of what happened instead.
+#
+# Both streams are pointed at one file opened in append mode, so the kernel
+# interleaves them in write order exactly as a shared terminal would, and
+# however much the command writes is bounded by disk rather than by memory.
+# Only the part of it that gets reported is ever read back in.
+function capture(cmd, limit::Integer)
+    path, io = mktemp()
+    close(io) # the command opens the file itself; we only wanted the name
+    try
+        redirected = pipeline(cmd; stdout = path, stderr = path, append = true)
+        proc = try
+            run(redirected, wait = false)
+        catch err
+            err isa Base.IOError || rethrow()
+            return string("could not run ", cmd, "\n",
+                          label("Error"), sprint(showerror, err))
+        end
+        wait(proc)
+        success(proc) && return nothing
+        return string(cmd, "\n",
+                      label("Exit code"), status(proc), "\n",
+                      label("Output"), report_output(path, limit))
+    finally
+        rm(path, force = true)
+    end
+end
+
+status(proc) = proc.termsignal != 0 ?
+    string("killed by signal ", proc.termsignal) : string(proc.exitcode)
+
+# The tail of the captured output, each line indented and marked as the
+# command's, headed by a note of how much was dropped to fit in `limit`.
+function report_output(path::AbstractString, limit::Integer)
+    total = filesize(path)
+    total == 0 && return "(none)"
+    dropped = max(total - limit, 0)
+    bytes = open(path) do io
+        seek(io, dropped)
+        read(io)
+    end
+    if dropped > 0
+        # start at a line boundary: the cut lands mid-line, and as easily
+        # mid-character, so the leading partial line is worth less than the
+        # confusion it causes
+        nl = findfirst(==(UInt8('\n')), bytes)
+        if nl !== nothing && nl < length(bytes)
+            dropped += nl
+            bytes = bytes[nl+1:end]
+        end
+    end
+    header = dropped == 0 ? "($total bytes)" :
+        "(last $(total - dropped) of $total bytes, $dropped truncated)"
+    lines = split(chomp(String(bytes)), '\n')
+    return header * join("\n" * INDENT * "| " * rstrip(line, '\r') for line in lines)
+end
+
+function test_success(cmd, expr::AbstractString, limit::Integer,
+                      source::LineNumberNode)
+    report = capture(cmd, limit)
+    result = report === nothing ?
+        Test.Pass(:test, expr, nothing, true, source, false) :
+        Test.Fail(:test, expr, report, "false", nothing, source, false)
+    Test.record(Test.get_testset(), result)
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -291,6 +291,7 @@ end
     @test resolve(info, [:C]) == Dict(:C => :v1, :A => :v1)
 end
 
+include("test_success.jl")
 include("unsat_cores.jl")
 include("problem.jl")
 include("satisfiable.jl")
@@ -369,26 +370,26 @@ Compat = "4"
     end
 
     run(`$julia --project=$project -e 'import Pkg; Pkg.instantiate()'`)
-    # In both cases we assert `success` rather than `@test_nowarn`: resolving
-    # legitimately prints Pkg's "Installed ..." progress to stderr, which
-    # `@test_nowarn` would flag as a warning on a clean depot.
+    # In both cases we assert the exit status rather than `@test_nowarn`:
+    # resolving legitimately prints Pkg's "Installed ..." progress to stderr,
+    # which `@test_nowarn` would flag as a warning on a clean depot.
     if isempty(VERSION.prerelease)
         # Released Julia: exercise the full manifest-generation path, then
         # confirm the yanked Compat v4.0.0 was not selected (the second command
         # exits nonzero if it was).
-        @test success(`$julia --project=$project $script $dir --min=@deps --julia=$julia_version`)
-        @test success(`$julia --project=$dir -e '
+        @test_success `$julia --project=$project $script $dir --min=@deps --julia=$julia_version`
+        @test_success `$julia --project=$dir -e '
             using Pkg, UUIDs
             deps = Pkg.dependencies()
             pkg = deps[UUID("34da2185-b29b-5c13-b0c7-acf172513d20")]
             compat_version = pkg.version
-            exit(compat_version == v"4.0.0" ? 1 : 0)'`)
+            exit(compat_version == v"4.0.0" ? 1 : 0)'`
     else
         # Prerelease (e.g. nightly): writing a manifest needs the host and
         # target Julia to match, which they can't when the host has no matching
         # registered release. Read the resolved version directly instead.
         out = IOBuffer()
-        @test success(pipeline(`$julia --project=$project $script $dir --print-versions --min=@deps --julia=$julia_version`; stdout=out))
+        @test_success pipeline(`$julia --project=$project $script $dir --print-versions --min=@deps --julia=$julia_version`; stdout=out)
         m = match(r"34da2185-b29b-5c13-b0c7-acf172513d20 +\S+ +(\S+)", String(take!(out)))
         @test m !== nothing
         @test VersionNumber(m.captures[1]) != v"4.0.0"
@@ -404,7 +405,9 @@ end
     project = pkgdir(Resolver, "bin")
     tests = joinpath(project, "test", "runtests.jl")
     run(`$julia --project=$project -e 'import Pkg; Pkg.instantiate()'`)
-    @test success(`$julia --project=$project $tests`)
+    # a whole test suite's worth of output is worth keeping on failure: the
+    # first failing child assertion can be a long way above the summary
+    @test_success `$julia --project=$project $tests` limit = 64 * 1024
 end
 
 include("workspaces.jl")

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -5,6 +5,9 @@ using Test
 @isdefined(includet) ? includet("tiny_data.jl") : include("tiny_data.jl")
 @isdefined(includet) ? includet("registry.jl")  : include("registry.jl")
 
+@isdefined(TestSuccess) || include(joinpath(@__DIR__, "TestSuccess.jl"))
+using .TestSuccess
+
 module TestResolver
 
 using Resolver: resolve, issatisfiable, DepsProvider, PkgData, PkgInfo,

--- a/test/test_success.jl
+++ b/test/test_success.jl
@@ -1,0 +1,120 @@
+# Tests for the @test_success macro (test/TestSuccess.jl).
+
+using Test
+
+@isdefined(TestSuccess) || include(joinpath(@__DIR__, "TestSuccess.jl"))
+using .TestSuccess
+
+module TestSuccessTests
+
+using Test
+using ..TestSuccess
+
+export collect_results, only_result, message, child
+
+# A testset that keeps its results instead of reporting them, so that a failing
+# test can be inspected as a value rather than failing the run.
+mutable struct Collector <: Test.AbstractTestSet
+    results :: Vector{Test.Result}
+end
+Collector(::AbstractString; kws...) = Collector(Test.Result[])
+Test.record(ts::Collector, res::Test.Result) = (push!(ts.results, res); res)
+Test.finish(ts::Collector) = ts # deliberately not recorded in the parent
+
+collect_results(body::Function) =
+    (@testset Collector "collected" begin body() end).results
+only_result(body::Function) = only(collect_results(body))
+
+# what a failure looks like in the log
+message(res::Test.Result) = sprint(show, res)
+
+# a child process that runs `code`, portably (no shell)
+child(code::AbstractString) = `$(Base.julia_cmd()[1]) --startup-file=no -e $code`
+
+end # module
+
+using .TestSuccessTests
+
+@testset "@test_success" begin
+    @testset "a command that exits 0 passes, quietly" begin
+        res, echoed = mktemp() do log, io
+            res = redirect_stdout(io) do
+                only_result() do
+                    @test_success child("print(\"loud\"); flush(stdout)")
+                end
+            end
+            close(io)
+            res, read(log, String)
+        end
+        @test res isa Test.Pass
+        @test isempty(echoed) # the child's output is not echoed
+    end
+
+    @testset "a nonzero exit fails, reporting stdout" begin
+        res = only_result() do
+            @test_success child("print(\"spoken on stdout\"); exit(3)")
+        end
+        @test res isa Test.Fail
+        msg = message(res)
+        @test occursin("Exit code: 3", msg)
+        @test occursin("spoken on stdout", msg)
+    end
+
+    @testset "a nonzero exit fails, reporting stderr" begin
+        res = only_result() do
+            @test_success child("print(stderr, \"spoken on stderr\"); exit(4)")
+        end
+        @test res isa Test.Fail
+        msg = message(res)
+        @test occursin("Exit code: 4", msg)
+        @test occursin("spoken on stderr", msg)
+    end
+
+    @testset "the report shows the command as run, not as written" begin
+        code = "exit(5)"
+        res = only_result() do
+            @test_success child(code)
+        end
+        msg = message(res)
+        @test occursin("Expression: child(code)", msg) # the source expression
+        @test occursin("exit(5)", msg)                 # what it expanded to
+    end
+
+    @testset "both streams, in the order the command wrote them" begin
+        res = only_result() do
+            @test_success child("""
+                print(stdout, "first\\n");  flush(stdout)
+                print(stderr, "second\\n"); flush(stderr)
+                print(stdout, "third\\n");  flush(stdout)
+                exit(1)
+                """)
+        end
+        msg = message(res)
+        at(s) = first(something(findfirst(s, msg)))
+        @test at("first") < at("second") < at("third")
+    end
+
+    @testset "output past the limit is truncated, from the front" begin
+        res = only_result() do
+            @test_success child("""
+                for i = 1:2000; println("line \$i"); end
+                exit(1)
+                """) limit = 256
+        end
+        @test res isa Test.Fail
+        msg = message(res)
+        @test occursin(r"\d+ truncated", msg)
+        @test occursin("| line 2000", msg)  # the tail is what is kept
+        @test !occursin("| line 1\n", msg)  # the head is what is dropped
+    end
+
+    @testset "a command that cannot start fails, and does not throw" begin
+        res = only_result() do
+            @test_success `no-such-program-9f3a1c`
+        end
+        @test res isa Test.Fail
+        msg = message(res)
+        @test occursin("could not run", msg)
+        @test occursin("no-such-program-9f3a1c", msg)
+    end
+end

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -15,20 +15,35 @@ using Test
 using Resolver
 import TOML
 
-# Run bin/resolve.jl on a workspace; return (success, stdout, stderr strings).
-function resolve_workspace_manifest(ws::AbstractString; flags::Cmd = `--print-manifest`)
+@isdefined(TestSuccess) || include(joinpath(@__DIR__, "TestSuccess.jl"))
+using .TestSuccess
+
+# The bin/resolve.jl command for a workspace, with the bin/ environment
+# instantiated so that it can run.
+function resolve_workspace_cmd(ws::AbstractString; flags::Cmd = `--print-manifest`)
     julia = Base.julia_cmd()[1]
     project = pkgdir(Resolver, "bin")
     script = joinpath(project, "resolve.jl")
     julia_version = string(Int(VERSION.major), ".", VERSION.minor)
     run(`$julia --project=$project -e 'import Pkg; Pkg.instantiate()'`)
+    return `$julia --project=$project $script $ws $flags --julia=$julia_version`
+end
+
+# Resolve a workspace, asserting that it resolved, and return what the script
+# printed; a failure reports the command, its exit code and its stderr.
+function resolve_workspace(ws::AbstractString; flags::Cmd = `--print-manifest`)
     out = IOBuffer()
+    @test_success pipeline(resolve_workspace_cmd(ws; flags); stdout = out)
+    return String(take!(out))
+end
+
+# Resolve a workspace that must *not* resolve, returning the script's stderr so
+# the caller can check which complaint it made.
+function resolve_workspace_error(ws::AbstractString; flags::Cmd = `--print-manifest`)
     err = IOBuffer()
-    ok = success(pipeline(
-        `$julia --project=$project $script $ws $flags --julia=$julia_version`;
-        stdout = out, stderr = err,
-    ))
-    return ok, String(take!(out)), String(take!(err))
+    cmd = resolve_workspace_cmd(ws; flags)
+    @test !success(pipeline(cmd; stdout = devnull, stderr = err))
+    return String(take!(err))
 end
 
 @testset "workspaces" begin
@@ -74,9 +89,7 @@ end
             WorkspaceRoot = "11111111-1111-1111-1111-111111111111"
             """)
 
-        ok, manifest, err = resolve_workspace_manifest(ws)
-        ok || print(stderr, err)
-        @test ok
+        manifest = resolve_workspace(ws)
         m = TOML.parse(manifest)
 
         # all three workspace packages are path entries relative to the root,
@@ -135,9 +148,7 @@ end
             Example = "7876af07-990d-54b4-ab0e-23690620f79a"
             """)
 
-        ok, manifest, err = resolve_workspace_manifest(ws)
-        ok || print(stderr, err)
-        @test ok
+        manifest = resolve_workspace(ws)
         m = TOML.parse(manifest)
 
         # the local JSON is a path entry fixed at its local version, and the
@@ -173,9 +184,7 @@ end
             WorkspaceRoot = "11111111-1111-1111-1111-111111111111"
             """)
 
-        ok, manifest, err = resolve_workspace_manifest(ws)
-        ok || print(stderr, err)
-        @test ok
+        manifest = resolve_workspace(ws)
         m = TOML.parse(manifest)
         root = only(m["deps"]["WorkspaceRoot"])
         @test root["path"] == "."
@@ -204,9 +213,7 @@ end
             JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
             """)
 
-        ok, manifest, err = resolve_workspace_manifest(ws)
-        ok || print(stderr, err)
-        @test ok
+        manifest = resolve_workspace(ws)
         m = TOML.parse(manifest)
         member = only(m["deps"]["WorkspaceMember"])
         @test member["path"] == "member"
@@ -251,15 +258,11 @@ end
         # (a) local version admitted by Conda's compat: resolves against the
         # fixed local copy; the registry JSON's dependency tree stays out
         ws = make_shadow_ws("1.99.99")
-        ok, out, err = resolve_workspace_manifest(ws; flags = `--print-versions`)
-        ok || print(stderr, err)
-        @test ok
+        out = resolve_workspace(ws; flags = `--print-versions`)
         @test occursin(r"(?m)^682c06a0-de6a-54ab-a142-c8b1cf79cde6 JSON\s+1\.99\.99$", out)
         @test !occursin("Parsers", out)
 
-        ok, manifest, err = resolve_workspace_manifest(ws)
-        ok || print(stderr, err)
-        @test ok
+        manifest = resolve_workspace(ws)
         m = TOML.parse(manifest)
         json = only(m["deps"]["JSON"])
         @test json["path"] == "json"
@@ -273,8 +276,7 @@ end
 
         # (b) local version excluded by Conda's compat: unsatisfiable, as Pkg
         ws = make_shadow_ws("99.0.0")
-        ok, out, err = resolve_workspace_manifest(ws)
-        @test !ok
+        err = resolve_workspace_error(ws)
         @test occursin("Unsatisfiable", err)
     end
 
@@ -303,8 +305,7 @@ end
             version = "99.0.0"
             """)
 
-        ok, out, err = resolve_workspace_manifest(ws)
-        @test !ok
+        err = resolve_workspace_error(ws)
         @test occursin("excludes its local version", err)
     end
 end


### PR DESCRIPTION
`success(cmd)` returns a `Bool` and throws the child's output away, so a
subprocess test that fails says only that it failed:

```
bin/ tooling regression tests: Test Failed at test/runtests.jl:407
  Expression: success(`... runtests.jl`)
```

No exit code, no output, no indication of which child assertion went wrong.
That happened during review of #76 and cost hours that one line of captured
output would have saved. `@test_success` is the general fix.

```
bin/ tooling regression tests: Test Failed at .../runtests.jl:410
  Expression: `$julia --project=$project $tests`
   Evaluated: `/home/.../julia --project=/home/.../bin /home/.../bin/test/runtests.jl`
   Exit code: 1
      Output: (750 bytes)
              | ERROR: Some tests did not pass: 1 passed, 1 failed, 0 errored, 0 broken.
              | bin/resolve.jl: Test Failed at none:1
              |   Expression: occursin("a", "b")
              ...
```

The `Evaluated:` line matters on its own: the source expression is all
interpolations, so which Julia and which project were in play was previously
invisible.

## Contract

Passes iff the command exits 0 — the same contract as `@test success(cmd)`,
with a failure that says why. Output is captured rather than shown, so a
passing command stays silent. A command that cannot be started fails the test
and reports why rather than throwing. It records a normal `Pass`/`Fail` in the
enclosing testset, counting in its summary like any other test.

## Two decisions worth reviewing

**One temp file, both streams, append mode.** The obvious alternatives were
tried and rejected on evidence, not taste: a shared `IOBuffer` is not something
Julia's `setup_stdio` supports for two concurrent writers, and the same *path*
without `append` has each `FileRedirect` truncate the other — one stream's
output is silently destroyed. Append means both opens get `O_APPEND`, so each
write atomically appends and the kernel interleaves in write order exactly as a
shared terminal would. The file also bounds the child's output by disk rather
than memory; only the reported tail is read back, truncated from the front at a
line boundary with an explicit `(last N of M bytes, K truncated)` header.

It composes with redirects the caller sets up — `@test_success pipeline(cmd;
stdout = out)` leaves stdout in `out` and captures only stderr — which is what
`test/workspaces.jl` needs.

**`Test.Pass`/`Test.Fail` arities.** These have changed across versions
(`Fail` has 7 fields on 1.10, 8 on 1.12+; `Pass` gained `source`/`message_only`
in 1.9). The forms used work unchanged on 1.9 → nightly. `Fail`'s 6-arg shim
reaches back further but is marked in Test's own source as deprecated for
removal in Julia 2.0, so it is the *less* future-proof option; building the
constructor by introspecting `fieldnames` was also rejected, since it fails as
a `MethodError` at test time when it guesses wrong.

## Call sites

Four `@test success(...)` in `test/runtests.jl` converted; the `bin/` one gets
`limit = 64 * 1024` since its first failing assertion can be far above the
summary.

`test/workspaces.jl` was worse than the original case: it printed stderr out of
band and *ahead* of the failure it explained, and dropped stdout and the exit
code entirely. Its helper is split into one that builds the command, one that
asserts success and returns stdout, and one that expects failure and returns
stderr — net −18 lines at the call sites, test count unchanged (45/45).

`bin/test/runtests.jl:135` keeps `success(...)` deliberately: there it is
control flow, telling "unsatisfiable" from "the script broke", not an
assertion. Its error message now includes the captured stderr.

## Tests

`test/test_success.jl`, 18 assertions, run as part of the suite: exit 0 with
output suppressed, nonzero with stdout, nonzero with stderr, expanded-vs-source
command, both streams in write order, truncation past the limit (asserting the
marker, that the tail survived and the head did not), and a nonexistent
program. All assert on the rendered failure message content, not merely that a
failure occurred. Verified on Julia 1.10.11, 1.12.6 and 1.14.0-DEV.

Full suite green.

## Windows

The append-interleaving property is traced through libuv's `O_APPEND` →
`FILE_APPEND_DATA` mapping but **verified on Linux only** — this PR's CI run is
its first real test on Windows, via the "both streams, in the order the command
wrote them" testset. If that goes red there, the fallback is capturing the two
streams separately and labelling them: ordering is lost, correctness is not.

That testset is worth keeping permanently rather than removing once it passes.
It guards the single assumption the capture design rests on, and a regression
would show up as scrambled diagnostic output at exactly the moment someone is
relying on it to debug something else.

## Stdlib shape

Written to be liftable: Base and Test only, 126 lines including the docstring,
composes with user redirects rather than fighting them. Inside `Test` the one
awkward part — choosing constructor arities that survive across versions —
disappears. Two known limitations if it ever goes that way: `@test_success`
inside a helper reports the helper's line rather than the call site (the same
limitation any function-wrapped `@test` has, including this repo's
`test_resolver`), which would want `__source__` threading or a `source =`
keyword; and it returns the `Test.Result` to match `@test`, where returning the
captured output would be what pattern-matching on output needs.
