### PR TITLE
A problem's constraints are one namespace, keyed by kind

### DIFF
--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -248,14 +248,15 @@ is_bundled(uuid::UUID, v::VersionNumber) =
 #
 # Whether a query will accept prerelease versions is a *query* fact, not a
 # registry one: the versions exist either way. So the provider offers them all
-# and `--allow-pre` reaches the resolver as one of the `Problem`'s exclusion
-# kinds, forbidding the prereleases of the packages it was not given for -- which
-# is what deleting them used to accomplish, minus the need for a private universe.
+# and `--allow-pre` reaches the resolver as the predicate of a `Problem`
+# constraint kind (`prerelease`), forbidding the prereleases of the packages it
+# was not given for -- which is what deleting them used to accomplish, minus the
+# need for a private universe.
 #
 # `allow_pre` is keyed by package uuid with the zero uuid holding the default,
 # exactly as the flag parses it.
 prerelease_exclusion(allow_pre::Dict{UUID,Bool}) =
-    :prerelease => function (uuid::UUID, v::VersionNumber)
+    function (uuid::UUID, v::VersionNumber)
         isempty(v.prerelease) && return false
         return !get(allow_pre, uuid, get(allow_pre, UUID(0), false))
     end

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -493,9 +493,7 @@ reg = registry_provider(packages;
 # so the struck versions are not in the universe to begin with -- see the provider.)
 const problem = Problem(reqs;
     compat = project_compat,
-    excludes = [
-        prerelease_exclusion(allow_pre),
-    ],
+    prerelease = prerelease_exclusion(allow_pre),
 )
 
 pkg_info = Resolver.pkg_info(reg, problem)

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -72,9 +72,8 @@ function make_problem(
 )
     c = Dict{UUID,Any}(compat)
     c[JULIA_UUID] = julia
-    Resolver.Problem(reqs; compat = c, excludes = [
-        prerelease_exclusion(allow_pre),
-    ])
+    Resolver.Problem(reqs;
+        compat = c, prerelease = prerelease_exclusion(allow_pre))
 end
 
 # The old baked path, for the knobs that used to be applied by deleting versions
@@ -303,8 +302,8 @@ end
 
         for allow_pre in (no_pre, all_pre,
                           Dict(UUID(0) => false, LLVM_FULL_JLL => true))
-            excludes = [prerelease_exclusion(allow_pre)]
-            prob = Resolver.Problem(reqs; excludes)
+            prob = Resolver.Problem(reqs;
+                prerelease = prerelease_exclusion(allow_pre))
             old = bake(data, prob) # the versions deleted, as the provider used to
             @test Resolver.resolve(data, prob) == Resolver.resolve(old, reqs)
             @test Resolver.resolve(info, prob) == Resolver.resolve(old, reqs)
@@ -398,12 +397,10 @@ end
         yanked_of(u::UUID) = get!(() -> yanked_versions(packages, u), struck, u)
         # a kind reaches every package in the universe, not just the required
         # ones, so this has to answer for any uuid it is handed
-        kind = Pair{Symbol,Any}(:yanked,
-            (u::UUID, v::VersionNumber) -> v in yanked_of(u))
-        for pre in (Pair{Symbol,Any}[],
-                    Pair{Symbol,Any}[prerelease_exclusion(no_pre)])
-            old = Resolver.Problem(reqs; excludes = [kind, pre...])
-            new = Resolver.Problem(reqs; excludes = pre)
+        yanked = (u::UUID, v::VersionNumber) -> v in yanked_of(u)
+        for pre in ((;), (; prerelease = prerelease_exclusion(no_pre)))
+            old = Resolver.Problem(reqs; yanked, pre...)
+            new = Resolver.Problem(reqs; pre...)
             @test Resolver.resolve(reg, new) == Resolver.resolve(kept, old)
             @test Resolver.resolve(info, new) == Resolver.resolve(kept, old)
             order = u -> (<)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,7 +18,7 @@ Resolver.Universe
 Resolver.prepare_pkg_info
 Resolver.version_permutations
 Resolver.class_ranking
-Resolver.sources
+Resolver.relaxations
 Resolver.relax
 Resolver.RelaxedProblem
 Resolver.SparsePerm

--- a/docs/src/theory/relaxation.md
+++ b/docs/src/theory/relaxation.md
@@ -5,7 +5,7 @@ it was run for*. This page proves something stronger, which is what lets a
 failed resolve be explained rather than merely reported: the filtered
 universe answers every **relaxation** of that query too.
 
-A relaxation is the same query with some of its demands withdrawn — a
+A relaxation is the same query with some of its demands relaxed — a
 requirement dropped, a compat entry ignored, a pin released. Those are
 exactly the repairs a user can make to an unsatisfiable problem, so
 "filtered for ``Q``, valid for every ``R \le Q``" is precisely the property
@@ -19,15 +19,16 @@ to are the ones the previous page describes.
 ## What a relaxation is
 
 Fix an artifact ``D``. A **query** ``Q`` is a requirement set together with a
-set of constraint sources — the compat entries, pins, and admission kinds
-(prereleases, yanked versions) the user's problem carries.
+set of constraints — one per package a compat entry or a pin of the user's
+problem names, plus one per admission kind (prereleases, yanked versions),
+which names no package in particular.
 
 !!! note "Definition (the relaxation order)"
     ``R \le Q`` — "``R`` is a relaxation of ``Q``" — iff
-    ``\mathrm{reqs}_R \subseteq \mathrm{reqs}_Q`` and ``R``'s constraint
-    sources are a subset of ``Q``'s.
+    ``\mathrm{reqs}_R \subseteq \mathrm{reqs}_Q`` and ``R``'s constraints are
+    a subset of ``Q``'s.
 
-This is a lattice with ``2^{|\mathrm{reqs}_Q| + |\mathrm{sources}_Q|}``
+This is a lattice with ``2^{|\mathrm{reqs}_Q| + |\mathrm{cons}_Q|}``
 points, ``Q`` at the top and the empty query at the bottom. Note ``Q \le Q``:
 every statement below about "every relaxation" includes the query itself,
 which is what makes the results here strengthen rather than replace the
@@ -80,7 +81,7 @@ second fills the classes that got none from their best member, period.
     For every class ``c`` and every ``R \le Q``:
     ``\mathrm{key}_\emptyset(c) \le \mathrm{key}_R(c) \le \mathrm{key}_Q(c)``.
 
-    *Proof.* Adding constraint sources only removes admissible members, so
+    *Proof.* Adding constraints only removes admissible members, so
     ``\mathrm{adm}_Q(c) \subseteq \mathrm{adm}_R(c) \subseteq
     \mathrm{adm}_\emptyset(c)``. A minimum over a superset is no larger
     (with ``\min \emptyset = \infty``). ∎

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -536,7 +536,7 @@ end
 
 Flag, in each package's matrix, the classes that some relaxation of this query
 could reach — where a relaxation is the same query with any of its requirements
-or constraint sources dropped. `kq` gives per class the rank of the best member
+or constraints relaxed. `kq` gives per class the rank of the best member
 this query admits (`typemax` if it admits none) and `k0` the rank of its best
 member, period.
 

--- a/src/Problem.jl
+++ b/src/Problem.jl
@@ -1,8 +1,8 @@
 # An empty dictionary that costs nothing to make: a singleton, since it has no
 # fields. Constructing an unconstrained `Problem` — which every convenience
-# `resolve` entry point does — must not allocate a pair of dictionaries just to
-# say "no constraints", and the filter must not allocate a mask dictionary per
-# round just to say "no masks".
+# `resolve` entry point does — must not allocate a dictionary just to say "no
+# constraints", and the filter must not allocate a mask dictionary per round
+# just to say "no masks".
 struct EmptyDict{K,V} <: AbstractDict{K,V} end
 
 Base.length(::EmptyDict) = 0
@@ -11,27 +11,97 @@ Base.haskey(::EmptyDict, key) = false
 Base.get(::EmptyDict, key, default) = default
 Base.getindex(::EmptyDict, key) = throw(KeyError(key))
 
-# The kinds with no versions to forbid: the shared empty value for a problem's
-# `excludes`, for the same reason `EmptyDict` exists.
-const NoKinds = Pair{Symbol,Any}[]
+## constraints
+#
+# A problem's constraints are one namespace: a map from *kind* — the symbol
+# naming what a constraint is — to the constraint itself. `:compat` and `:pin`
+# are the two well-known kinds; any other kind is a predicate its caller
+# supplied. They are stored alike because every consumer treats them alike: a
+# constraint answers three questions and nothing else.
+#
+#   excludes(c, p, v)   does it forbid version `v` of package `p`?
+#   named(c)            which packages does it speak about, or `nothing` for
+#                       every package — a predicate cannot enumerate them
+#   relax(c, pkgs)      the same constraint, no longer applying to `pkgs`
+#                       (`nothing` again being every package), or `nothing`
+#                       when nothing of it is left
+#
+# The map's value type is a closed union, so `is_excluded` — which
+# `exclusion_masks` calls once per package per version — splits over three
+# branches instead of dispatching dynamically.
+
+# `:compat`: per package, the set of versions it admits, queried with `in`
+struct Compat{P,S}
+    allowed :: Dict{P,S}
+end
+
+# `:pin`: per package, the one version it is held at
+struct Pins{P,V}
+    at :: Dict{P,V}
+end
+
+# any other kind: a rule about versions — "no prereleases", say — so it reaches
+# every package, less the ones it has been relaxed for
+struct Predicate{P}
+    forbids           # (p, v) -> Bool, true for the versions this forbids
+    except :: Set{P}  # the packages it has been relaxed for
+end
+
+const Constraint{P,V,S} = Union{Compat{P,S}, Pins{P,V}, Predicate{P}}
+
+# does this constraint forbid version `v` of package `p`?
+excludes(c::Compat{P}, p::P, v) where {P} =
+    (s = get(c.allowed, p, nothing); s !== nothing && v ∉ s)
+excludes(c::Pins{P}, p::P, v) where {P} =
+    (w = get(c.at, p, nothing); w !== nothing && v != w)
+excludes(c::Predicate{P}, p::P, v) where {P} =
+    p ∉ c.except && c.forbids(p, v)::Bool
+
+# the packages this constraint speaks about, or `nothing` for every package
+named(c::Compat{P}) where {P} = Set{P}(keys(c.allowed))
+named(c::Pins{P}) where {P} = Set{P}(keys(c.at))
+named(::Predicate) = nothing
+
+# this constraint no longer applying to `pkgs` (`nothing` being every package),
+# or `nothing` when nothing of it is left — so `relax(c, named(c))` is always
+# `nothing`, whatever the shape
+relax(::Compat, ::Nothing) = nothing
+relax(c::Compat{P,S}, pkgs) where {P,S} =
+    (d = filter(kv -> first(kv) ∉ pkgs, c.allowed);
+     isempty(d) ? nothing : Compat{P,S}(d))
+relax(::Pins, ::Nothing) = nothing
+relax(c::Pins{P,V}, pkgs) where {P,V} =
+    (d = filter(kv -> first(kv) ∉ pkgs, c.at);
+     isempty(d) ? nothing : Pins{P,V}(d))
+relax(::Predicate, ::Nothing) = nothing
+# a predicate speaks about every package, so no finite set of them is all of it
+relax(c::Predicate{P}, pkgs) where {P} =
+    Predicate{P}(c.forbids, union(c.except, pkgs))
 
 """
-    Problem(reqs; compat = ..., pins = ..., excludes = ...)
+    Problem(reqs; compat = ..., pin = ..., kind = predicate, ...)
 
 A resolution problem: the required packages `reqs`, plus the constraints that say
 which versions are admissible. A `Problem` carries everything that determines
 *satisfiability*; orderings (the `by` priority order, the `order` version rank
 order) are `resolve` parameters instead.
 
-Three kinds of constraint, in two shapes:
+A constraint has a *kind* — a symbol naming it — and the kinds are one
+namespace: every keyword here is a kind, and the keyword's name is the kind's
+name, so no two constraints can share one. Two kinds are well known, and want a
+dictionary keyed by package:
 
   * `compat`: per package, the set of allowed versions (queried with `in`).
-  * `pins`: per package, the one version it is held at.
-  * `excludes`: the *admission* knobs — "no prereleases" is the one the resolver's
-    own tooling uses — which say something about versions rather than about
-    particular packages, and so come as `kind => predicate` pairs, where
-    `predicate(p, v)` is true for the versions that source forbids and `kind` is a
-    symbol naming it.
+  * `pin`: per package, the one version it is held at.
+
+Any other keyword names a kind of its own, and wants a predicate: the
+*admission* knobs — "no prereleases" is the one the resolver's own tooling uses
+— say something about versions rather than about particular packages, so they
+are stated as `predicate(p, v)`, true for the versions that kind forbids.
+
+    Problem(reqs;
+        compat = Dict(:B => [v"1.0", v"1.1"]),
+        pre = (p, v) -> !isempty(v.prerelease))
 
 Constraints for packages that don't exist, and constraints that exclude nothing,
 are allowed and have no effect.
@@ -41,40 +111,107 @@ a deletion from a private one: that is what lets a single T1 artifact (see
 [`pkg_info`](@ref Resolver.pkg_info)) serve queries that admit different things,
 and what lets diagnostics eventually name the kind that ruled a version out.
 """
-struct Problem{P,V,S}
-    reqs   :: Vector{P}
-    # allowed-version sets, queried via `in(v, s)`, and exact-version pins.
-    # abstractly typed so that the unconstrained case can share one immutable
-    # empty dictionary instead of allocating two per problem
-    compat :: AbstractDict{P,S}
-    pins   :: AbstractDict{P,V}
-    # admission knobs: per kind, a predicate `(p, v) -> Bool` that is true for
-    # the versions that kind forbids ("no prereleases", say)
-    excludes :: Vector{Pair{Symbol,Any}}
+struct Problem{P, C<:AbstractDict{Symbol}}
+    reqs :: Vector{P}
+    # the constraints, by kind. The type is a parameter so the unconstrained
+    # case can share one immutable empty dictionary, and so the value type
+    # stays the concrete union `is_excluded` splits on
+    constraints :: C
 end
 
-function Problem(
-    reqs   :: SetOrVec{P};
-    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
-    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
-    excludes = NoKinds,
-) where {P}
-    Problem{P, valtype(pins), valtype(compat)}(
-        P[p for p in reqs], adopt(compat), adopt(pins), adopt_kinds(excludes))
+# A keyword's name is its kind, so nothing tells a typo apart from a kind of
+# its own: `compt = Dict(...)` names a predicate perfectly well, and only the
+# shape catches it. Hence checking before anything is built, and saying both
+# the shape wanted and the shape given.
+function check_shape(::Type{P}, kind::Symbol, value) where {P}
+    if kind === :compat || kind === :pin
+        value isa AbstractDict{P} || wrong_shape(P, kind, value)
+    else
+        # a predicate is anything callable; what is worth catching is a
+        # collection handed to a kind that never wanted one
+        isempty(methods(value)) && wrong_shape(P, kind, value)
+    end
+    return
 end
 
-# a caller's dictionary is copied, so later mutation can't change the problem;
-# the shared empties are immutable and shared on purpose
-adopt(d::AbstractDict) = Dict(d)
-adopt(d::EmptyDict) = d
+# out of line: naming a type allocates enough to show up in `Problem` if the
+# message is built on the success path
+@noinline function wrong_shape(::Type{P}, kind::Symbol, value) where {P}
+    want = kind in (:compat, :pin) ?
+        "a dictionary keyed by package ($P)" :
+        "a predicate, `(p, v) -> Bool`, true for the versions it forbids"
+    got = isempty(methods(value)) ? "a $(typeof(value))" : "a callable"
+    throw(ArgumentError("constraint kind $(repr(kind)) wants $want; got $got"))
+end
 
-adopt_kinds(kinds) = isempty(kinds) ? NoKinds :
-    Pair{Symbol,Any}[Symbol(kind) => forbids for (kind, forbids) in kinds]
+# The constraint a keyword names, or `nothing` when it names none: an empty
+# dictionary excludes nothing, so it makes nothing. A caller's dictionary is
+# copied, so later mutation can't change the problem.
+function constraint(::Type{P}, kind::Symbol, value) where {P}
+    kind === :compat && return isempty(value) ? nothing : Compat(Dict(value))
+    kind === :pin    && return isempty(value) ? nothing : Pins(Dict(value))
+    return Predicate{P}(value, Set{P}())
+end
+
+# Every keyword is a kind, and its name is the kind's name — which is what
+# makes a repeated kind a syntax error rather than something to check for.
+Problem(reqs::SetOrVec{P}; kinds...) where {P} = problem(reqs, values(kinds))
+
+function problem(reqs::SetOrVec{P}, kws::NamedTuple) where {P}
+    for (kind, value) in pairs(kws)
+        check_shape(P, kind, value)
+    end
+    # `:pin` and `:compat` supply the version and version-set types; a problem
+    # without them is typed by neither
+    pin, compat = get(kws, :pin, nothing), get(kws, :compat, nothing)
+    C = Constraint{P,
+        pin    === nothing ? Any : valtype(pin),
+        compat === nothing ? Any : valtype(compat)}
+    r = P[p for p in reqs]
+    # made only once there is something to put in it, so a problem that names
+    # no constraint costs no dictionary — whether it named no kind at all or
+    # only empty ones
+    cons = nothing
+    for (kind, value) in pairs(kws)
+        c = constraint(P, kind, value)
+        c === nothing && continue
+        cons === nothing && (cons = Dict{Symbol,C}())
+        cons[kind] = c
+    end
+    cons === nothing && return Problem(r, EmptyDict{Symbol,C}())
+    return Problem(r, cons)
+end
 
 # does the problem constrain anything at all? the fast paths below lean on this:
 # an unconstrained resolve must not do any per-version work
-is_constrained(prob::Problem) =
-    !isempty(prob.compat) || !isempty(prob.pins) || !isempty(prob.excludes)
+is_constrained(prob::Problem) = !isempty(prob.constraints)
+
+# `prob` with the requirements `drop_reqs` relaxed and each constraint named
+# in `drops` relaxed for the packages `drops` maps it to — `nothing` there
+# being every package, which relaxes that kind outright. Kinds `prob` does not
+# carry are ignored, a constraint that isn't there being already relaxed; and
+# what the map is consulted with is `haskey`, so *absent* and *relaxed
+# outright* cannot collide.
+function relax(
+    prob      :: Problem{P},
+    drop_reqs :: SetOrVec{P},
+    drops     :: AbstractDict{Symbol},
+) where {P}
+    dropped = Set{P}(drop_reqs)
+    reqs = P[p for p in prob.reqs if p ∉ dropped]
+    cons = prob.constraints
+    isempty(drops) && return Problem(reqs, cons)
+    kept = Dict{Symbol, valtype(cons)}()
+    for (kind, c) in cons
+        if haskey(drops, kind)
+            c = relax(c, drops[kind])
+            c === nothing && continue
+        end
+        kept[kind] = c
+    end
+    isempty(kept) && return Problem(reqs, EmptyDict{Symbol, valtype(cons)}())
+    return Problem(reqs, kept)
+end
 
 # What a user constraint does, and the only thing it does, is forbid *members*
 # of interchangeability classes. Members are indistinguishable to everything in
@@ -95,40 +232,30 @@ is_constrained(prob::Problem) =
 
 # does the problem forbid version v of package p?
 function is_excluded(prob::Problem{P}, p::P, v) where {P}
-    s = get(prob.compat, p, nothing)
-    s === nothing || v ∈ s || return true
-    w = get(prob.pins, p, nothing)
-    w === nothing || v == w || return true
-    for (_, forbids) in prob.excludes
-        forbids(p, v)::Bool && return true
+    for (_, c) in prob.constraints
+        excludes(c, p, v) && return true
     end
     return false
 end
 
-# Which of the problem's constraints forbid version `v` of package `p`: one
-# symbol per source that does — `:compat` for an allowed-version set the version
-# is not in, `:pin` for a pin at another version, and its own symbol for each
-# admission kind whose predicate holds — in that order, and empty when the
-# problem admits the version. Every source is named, where `is_excluded` stops
-# at the first: lifting one source leaves the others in force, so what a
-# question about lifting one needs is all of them.
-function exclusion_sources(prob::Problem{P}, p::P, v) where {P}
-    srcs = Symbol[]
-    s = get(prob.compat, p, nothing)
-    s === nothing || v ∈ s || push!(srcs, :compat)
-    w = get(prob.pins, p, nothing)
-    w === nothing || v == w || push!(srcs, :pin)
-    for (kind, forbids) in prob.excludes
-        forbids(p, v)::Bool && push!(srcs, kind)
+# Which of the problem's constraints forbid version `v` of package `p`: the kind
+# of each one that does, in kind order, and empty when the problem admits the
+# version. Every one is named, where `is_excluded` stops at the first: lifting
+# one constraint leaves the others in force, so what a question about lifting one
+# needs is all of them.
+function exclusion_kinds(prob::Problem{P}, p::P, v) where {P}
+    kinds = Symbol[]
+    for (kind, c) in prob.constraints
+        excludes(c, p, v) && push!(kinds, kind)
     end
-    return srcs
+    return sort!(kinds)
 end
 
 # Why class `c` of package `p` holds nothing this problem admits: the class's
-# members in version order, each paired with the sources that exclude it
-# (`exclusion_sources`). A constraint forbids versions, and a class is empty
+# members in version order, each paired with the kinds that exclude it
+# (`exclusion_kinds`). A constraint forbids versions, and a class is empty
 # when every member of it is forbidden — so the class is empty exactly when no
-# pair here has an empty source list, and these pairs are then the whole of what
+# pair here has an empty kind list, and these pairs are then the whole of what
 # emptied it: which versions the class holds, and what rules each one out.
 #
 # Constraints and the partition are all this reads; no solver is involved.
@@ -139,17 +266,25 @@ function class_exclusions(
     c      :: Integer,
 ) where {P}
     vers = info_p.versions
-    return [vers[i] => exclusion_sources(prob, p, vers[i])
+    return [vers[i] => exclusion_kinds(prob, p, vers[i])
             for i in info_p.members[c]]
 end
 
-# the packages a constraint could forbid a version of. Compat bounds and pins
-# name their packages, and only a handful of packages are named, which is what
-# makes constraining cheap; an admission knob is stated about versions instead, so
-# it reaches every package in the universe.
-exclusion_candidates(info::AbstractDict{P}, prob::Problem{P}) where {P} =
-    isempty(prob.excludes) ?
-        union(keys(prob.compat), keys(prob.pins)) : keys(info)
+# the packages a constraint could forbid a version of: what the problem's
+# constraints name between them, or every package in the universe as soon as one
+# of them names none in particular
+function exclusion_candidates(
+    info :: AbstractDict{P},
+    prob :: Problem{P},
+) where {P}
+    pkgs = Set{P}()
+    for (_, c) in prob.constraints
+        names = named(c)
+        names === nothing && return keys(info)
+        union!(pkgs, names)
+    end
+    return pkgs
+end
 
 """
     exclusion_masks(info, prob) :: AbstractDict{P, BitVector}

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -95,7 +95,7 @@ end
 
 """
     resolve(data, prob::Problem; by = identity) -> Union{Dict{P,V}, Nothing}
-    resolve(data, reqs; by = identity, compat = ..., pins = ...)
+    resolve(data, reqs; by = identity)
 
 Resolve the requirements `reqs` against the package universe described by
 `data`, returning the optimal solution as a dict mapping each needed package
@@ -103,11 +103,10 @@ to its chosen version, or `nothing` when the requirements are not jointly
 satisfiable. The solution covers every requirement and is exactly the
 dependency closure of the requirements under its own chosen versions.
 
-A [`Problem`](@ref) additionally constrains the admissible versions with user
-compat bounds and pins; the answer is the one the same universe with those
-versions deleted would give. The requirements-and-keywords form builds one, so
-`resolve(data, reqs; compat, pins)` and `resolve(data, Problem(reqs; compat,
-pins))` are the same call.
+Bare requirements are the unconstrained problem: `resolve(data, reqs)` is
+`resolve(data, Problem(reqs))`. A [`Problem`](@ref) additionally constrains the
+admissible versions — compat bounds, pins, and whatever else it names — and the
+answer is the one the same universe with those versions deleted would give.
 
 The returned solution is the *layered solution*: requirements are optimized
 first, in the priority order induced by `by` (each package maximized to its
@@ -166,22 +165,18 @@ function resolve_prepared(
 end
 
 """
-    sources(prob) :: Vector{Pair{Symbol,Any}}
+    relaxations(prob) :: Dict{Symbol, Union{Nothing, Set{P}}}
 
-Every constraint source `prob` carries, as something a relaxation can release:
-`:compat => p` and `:pin => p` for the entries naming a package, and
-`:kind => k` for each admission kind. This is the vocabulary
-[`relax`](@ref Resolver.relax) takes, so `relax(univ, prob, prob.reqs,
-sources(prob))` is the bottom of the relaxation lattice — the empty query — and
-any subset of it is a point in between.
+Every constraint `prob` carries, in the shape [`relax`](@ref Resolver.relax)
+relaxes them: per kind, the packages that kind speaks about — or `nothing` for
+a kind that speaks about every package, which is every kind but `:compat` and
+`:pin`. So `relax(univ, prob, prob.reqs, relaxations(prob))` is the bottom of
+the relaxation lattice — the empty query — and relaxing less than all of it,
+a kind or a package at a time, is a point in between.
 """
-function sources(prob::Problem{P}) where {P}
-    srcs = Pair{Symbol,Any}[]
-    for p in keys(prob.compat);  push!(srcs, :compat => p); end
-    for p in keys(prob.pins);    push!(srcs, :pin => p);    end
-    for (k, _) in prob.excludes; push!(srcs, :kind => k);   end
-    return srcs
-end
+relaxations(prob::Problem{P}) where {P} =
+    Dict{Symbol, Union{Nothing, Set{P}}}(
+        kind => named(c) for (kind, c) in prob.constraints)
 
 """
     RelaxedProblem
@@ -191,7 +186,7 @@ query was filtered for takes: `resolve(sat, rp)` returns what
 `resolve(info, rp.prob)` returns, without preparing again.
 
 Built by [`relax`](@ref Resolver.relax), which *derives* the relaxed problem by
-withdrawing demands rather than accepting one — so that `rp.prob` being a
+relaxing demands rather than accepting one — so that `rp.prob` being a
 relaxation of `rp.base` is a consequence of how the value was made rather than a
 claim about an argument — and settles there what every solve would otherwise
 recompute: the member each class stands for under the relaxed problem, and the
@@ -212,17 +207,19 @@ struct RelaxedProblem{P, O}
 end
 
 """
-    relax(univ, Q, drop_reqs = P[], drop_sources = Pair{Symbol,Any}[]; order = nothing)
+    relax(univ, Q, drop_reqs = P[], drops = Dict{Symbol,Nothing}(); order = nothing)
 
-The relaxation of `Q` that withdraws the requirements `drop_reqs` and releases
-the constraint sources `drop_sources`, ready to resolve against `univ` — the
-universe `prepare_pkg_info(info, Q; order)` produced. Withdrawing nothing gives
-`Q` itself, which is a relaxation of `Q`; withdrawing everything gives the empty
-query. Names that `Q` does not carry are ignored, a source that is not there
-being already released.
+The relaxation of `Q` that relaxes the requirements `drop_reqs` and relaxes
+each constraint named in `drops` for the packages `drops` maps it to, ready to
+resolve against `univ` — the universe `prepare_pkg_info(info, Q; order)`
+produced. Withdrawing nothing gives `Q` itself, which is a relaxation of `Q`;
+relaxing everything gives the empty query. Names that `Q` does not carry are
+ignored, a constraint that is not there being already relaxed.
 
-`drop_sources` names sources the way [`sources`](@ref Resolver.sources) lists
-them: `:compat => p`, `:pin => p`, `:kind => k`.
+`drops` maps a constraint kind to the packages it is relaxed for, the way
+[`relaxations`](@ref Resolver.relaxations) lists them — `nothing` meaning every
+package, which relaxes that kind outright. A kind absent from `drops` is not
+relaxed at all.
 
 `order` is the version preference ordering, as `resolve` takes it, and has to be
 the one `univ` was ranked in: it is what "better" means, and the universe and the
@@ -232,27 +229,12 @@ permutations it induces are computed once however often the result is resolved.
 function relax(
     univ :: Universe{P,V},
     Q    :: Problem{P},
-    drop_reqs    :: SetOrVec{P} = P[],
-    drop_sources :: SetOrVec{Pair{Symbol,Any}} = Pair{Symbol,Any}[];
+    drop_reqs :: SetOrVec{P} = P[],
+    drops     :: AbstractDict{Symbol} = EmptyDict{Symbol,Nothing}();
     order = nothing, # version ordering
 ) where {P,V}
-    nocomp, nopin = Set{P}(), Set{P}()
-    nokind = Set{Symbol}()
-    for (what, key) in drop_sources
-        what === :compat ? push!(nocomp, key) :
-        what === :pin    ? push!(nopin,  key) :
-        what === :kind   ? push!(nokind, key) :
-            throw(ArgumentError("no such constraint source: $(repr(what))"))
-    end
-    withdrawn = Set{P}(drop_reqs)
-    # a relaxation is `Q` with entries removed, so it is built by removing them
-    R = Problem(P[p for p in Q.reqs if p ∉ withdrawn];
-        compat = isempty(nocomp) ? Q.compat :
-            filter(kv -> first(kv) ∉ nocomp, Dict(Q.compat)),
-        pins = isempty(nopin) ? Q.pins :
-            filter(kv -> first(kv) ∉ nopin, Dict(Q.pins)),
-        excludes = isempty(nokind) ? Q.excludes :
-            Pair{Symbol,Any}[kv for kv in Q.excludes if first(kv) ∉ nokind])
+    # a relaxation is `Q` with demands relaxed, so it is built by relaxing
+    R = relax(Q, drop_reqs, drops)
     # what `R` makes of the classes `Q` laid out, in one pass: the member each
     # class stands for under `R` and the order those members rank the classes
     # in. The universe is not relaid out — the clauses say which classes exist,
@@ -343,48 +325,46 @@ function resolve(
     resolve_prepared(prepare_pkg_info(info, prob; order), prob; by)
 end
 
-# convenience entry points: bare requirements, with the user constraints (if
-# any) given as keywords instead of a `Problem`
+# convenience entry points: bare requirements, which are the unconstrained
+# `Problem`. Constraints come only from a `Problem`, so the keywords here stay a
+# closed set — `order` takes a callable, and a misspelling of it would otherwise
+# be indistinguishable from a caller naming a constraint kind of its own
 
 resolve(
     deps :: DepsProvider{P},
     reqs :: SetOrVec{P} = deps.packages;
-    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
-    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
-    by     :: Function = identity, # package ordering
-    order  = nothing, # version ordering
-) where {P} = resolve(deps, Problem(reqs; compat, pins); by, order)
+    by   :: Function = identity, # package ordering
+    order = nothing, # version ordering
+) where {P} = resolve(deps, Problem(reqs); by, order)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
     reqs :: SetOrVec{P} = keys(data);
-    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
-    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
-    by     :: Function = identity, # package ordering
-    order  = nothing, # version ordering
-) where {P} = resolve(data, Problem(reqs; compat, pins); by, order)
+    by   :: Function = identity, # package ordering
+    order = nothing, # version ordering
+) where {P} = resolve(data, Problem(reqs); by, order)
 
 resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},
     reqs :: SetOrVec{P} = keys(info);
-    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
-    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
-    by     :: Function = identity, # package ordering
-    order  = nothing, # version ordering
-) where {P,V} = resolve(info, Problem(reqs; compat, pins); by, order)
+    by   :: Function = identity, # package ordering
+    order = nothing, # version ordering
+) where {P,V} = resolve(info, Problem(reqs); by, order)
 
 """
-    issatisfiable(data, reqs; compat = ..., pins = ...) -> Bool
+    issatisfiable(data, reqs) -> Bool
+    issatisfiable(data, prob::Problem) -> Bool
 
-Compute `resolve(data, reqs; ...) !== nothing` more efficiently, with a single
+Compute `resolve(data, reqs) !== nothing` more efficiently, with a single
 satisfiability check instead of a full optimizing resolve. Use this when you
 want to know whether the requirements can be satisfied but don't need an
 actual solution.
 
 `data` may be a `DepsProvider`, a dict of `PkgData`, a dict of `PkgInfo`, or a
-`SAT` instance, and a `Problem` may be passed in place of the requirements and
-keywords, as with `resolve`. The `by` and `order` keywords are not accepted
-since they affect which solution `resolve` picks, not whether one exists. The `SAT` method leaves the instance unchanged, so it can be reused.
+`SAT` instance, and a `Problem` may be passed in place of bare requirements, as
+with `resolve`. There are no keywords: `by` and `order` affect which solution
+`resolve` picks, not whether one exists. The `SAT` method leaves the instance
+unchanged, so it can be reused.
 """
 function issatisfiable(
     sat  :: SAT{P},
@@ -436,26 +416,20 @@ issatisfiable(
     prob :: Problem{P},
 ) where {P,V} = issatisfiable_prepared(prepare_pkg_info(info, prob), prob)
 
-# convenience entry points: bare requirements, with the user constraints (if
-# any) given as keywords instead of a `Problem`
+# convenience entry points: bare requirements, which are the unconstrained
+# `Problem`. No keywords at all here — there is nothing left to say
 
 issatisfiable(
     deps :: DepsProvider{P},
-    reqs :: SetOrVec{P} = deps.packages;
-    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
-    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
-) where {P} = issatisfiable(deps, Problem(reqs; compat, pins))
+    reqs :: SetOrVec{P} = deps.packages,
+) where {P} = issatisfiable(deps, Problem(reqs))
 
 issatisfiable(
     data :: AbstractDict{P,<:PkgData{P}},
-    reqs :: SetOrVec{P} = keys(data);
-    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
-    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
-) where {P} = issatisfiable(data, Problem(reqs; compat, pins))
+    reqs :: SetOrVec{P} = keys(data),
+) where {P} = issatisfiable(data, Problem(reqs))
 
 issatisfiable(
     info :: AbstractDict{P,PkgInfo{P,V}},
-    reqs :: SetOrVec{P} = keys(info);
-    compat :: AbstractDict{P} = EmptyDict{P,Any}(),
-    pins   :: AbstractDict{P} = EmptyDict{P,Any}(),
-) where {P,V} = issatisfiable(info, Problem(reqs; compat, pins))
+    reqs :: SetOrVec{P} = keys(info),
+) where {P,V} = issatisfiable(info, Problem(reqs))

--- a/test/class_space.jl
+++ b/test/class_space.jl
@@ -20,7 +20,7 @@
 using Resolver: PkgData, PkgInfo, Problem, SAT, PicoSAT, pkg_info, nclasses,
     rank_pkg_info, prepare_pkg_info, filter_pkg_info!, deactivations,
     mark_installable!, mark_necessary!, class_ranking, finalize,
-    sat_assume, sat_pop, is_satisfiable, NoKinds
+    sat_assume, sat_pop, is_satisfiable
 
 const NODEPS = Dict{Symbol,Vector{Symbol}}()
 const NOCOMP = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
@@ -93,10 +93,9 @@ end
             facts = universe_facts(base)
             @test isempty(emptied(base)) # nothing constrains, nothing is empty
             for cs = 1:4
-                compat, pins = random_constraints(m, n)
-                kinds = [:test => (p, v) -> v == rand(1:n)]
-                prob = Problem(reqs; compat, pins,
-                               excludes = iseven(cs) ? kinds : NoKinds)
+                compat, pin = random_constraints(m, n)
+                test = iseven(cs) ? (; test = (p, v) -> v == rand(1:n)) : (;)
+                prob = Problem(reqs; compat, pin, test...)
                 univ = rank_pkg_info(info, prob)
                 # the partition is not refined: same classes, same members
                 @test all_classes(univ) == all_classes(base)
@@ -134,7 +133,7 @@ end
 @testset "precondition 2c: redundancy never deletes a dead class" begin
     # :P's classes are {:v3, :v1} (no constraints at all) and {:v2} (conflicts
     # with :Q@:w2), so the first dominates the second outright. Two different
-    # sources empty them: the compat bound takes the dominator, an admission
+    # kinds empty them: the compat bound takes the dominator, an admission
     # kind takes the dominated one. Deleting the dominated class for being
     # dominated would make relaxing the kind alone unanswerable, because the
     # class it would return is the one that was deleted.
@@ -145,8 +144,8 @@ end
     info = pkg_info(data, [:P, :Q]; filter = false)
     @test info[:P].members == [[1, 3], [2]]
     prob = Problem([:P, :Q];
-        compat = Dict(:P => [:v2]),                 # empties {:v3, :v1}
-        excludes = [:pre => (p, v) -> v == :v2])    # empties {:v2}
+        compat = Dict(:P => [:v2]),          # empties {:v3, :v1}
+        pre = (p, v) -> v == :v2)            # empties {:v2}
     univ = prepare_pkg_info(pkg_info(data, prob), prob)
     @test nclasses(univ.info[:P]) == 2
     @test univ.reps[:P] == [0, 0]
@@ -196,8 +195,8 @@ end
             info = pkg_info(data, keys(data); filter = false)
             base = struck(redundancy_only(info, Problem(reqs)))
             for _ = 1:4
-                compat, pins = random_constraints(m, n)
-                prob = Problem(reqs; compat, pins)
+                compat, pin = random_constraints(m, n)
+                prob = Problem(reqs; compat, pin)
                 univ = redundancy_only(info, prob)
                 gone = struck(univ)
                 @test isempty(gone ∩ emptied(univ))
@@ -289,7 +288,7 @@ end
 @testset "fitness: the D1′ shape is unrepresentable" begin
     # Proposition D1′'s counterexample shape: a compat bound and a pin that
     # between them forbid both versions of a package, where relaxing one of the
-    # two sources ought to bring one version back. What made a partial
+    # two kinds ought to bring one version back. What made a partial
     # relaxation unsound in version space was that the constraints entered the
     # rows, could make the two versions row-identical, and redundancy
     # elimination could then delete the one the relaxation needed.
@@ -301,21 +300,21 @@ end
         :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), NOCOMP),
         :B => PkgData([:w1], NODEPS, NOCOMP),
     )
-    prob = Problem([:A]; compat = Dict(:A => [:v1]), pins = Dict(:A => :v2))
+    prob = Problem([:A]; compat = Dict(:A => [:v1]), pin = Dict(:A => :v2))
     info = pkg_info(data, prob)
     # nothing in the registry tells :v2 and :v1 apart, so they are one class
     @test info[:A].classes == [1, 1]
     @test info[:A].members == [[1, 2]]
     @test nclasses(info[:A]) == 1
-    # the two sources empty that one class between them
+    # the two kinds empty that one class between them
     univ = rank_pkg_info(info, prob)
     @test univ.reps[:A] == [0]
     @test resolve(data, prob) === nothing
 
-    # relaxing either source reactivates the same single class — there is no
+    # relaxing either kind reactivates the same single class — there is no
     # "half" of this constraint set to be unsound about, and nothing that could
     # have been deleted for being dominated by the other half
-    for (relaxed, want) in ((Problem([:A]; pins = Dict(:A => :v2)), :v2),
+    for (relaxed, want) in ((Problem([:A]; pin = Dict(:A => :v2)), :v2),
                             (Problem([:A]; compat = Dict(:A => [:v1])), :v1))
         u = rank_pkg_info(info, relaxed)
         @test nclasses(u.info[:A]) == 1

--- a/test/classes.jl
+++ b/test/classes.jl
@@ -144,7 +144,7 @@ function class_emptying_problems(data, reqs)
             for v in sort!(collect(cls))
                 push!(probs, Problem(reqs;
                     compat = Dict(p => [w for w in vers if w != v])))
-                push!(probs, Problem(reqs; pins = Dict(p => v)))
+                push!(probs, Problem(reqs; pin = Dict(p => v)))
             end
         end
     end
@@ -199,7 +199,7 @@ end
     # a pin inside a class does not *refine* it — a class is one column, and a
     # user constraint has no way to split one. All it can do is move which
     # member stands for the class, and empty the classes it admits nothing of
-    prob = Problem([:A]; pins = Dict(:A => :v1))
+    prob = Problem([:A]; pin = Dict(:A => :v1))
     reps, cperms = class_ranking(info, prob)
     @test info[:A].members == [[1, 3], [2]] # the partition is untouched
     @test reps[:A] == [3, 0]  # {:v3, :v1} stands at :v1; {:v2} is empty
@@ -252,8 +252,8 @@ end
                         test_class_space(data, Problem(reqs); by)
                     end
                     for _ = 1:4
-                        compat, pins = random_constraints(m, n)
-                        test_class_space(data, Problem(reqs; compat, pins))
+                        compat, pin = random_constraints(m, n)
+                        test_class_space(data, Problem(reqs; compat, pin))
                     end
                 end
             end
@@ -271,8 +271,8 @@ end
             fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
             reqs = collect(make_reqs(rand(1:2^m-1)))
             for _ = 1:4
-                compat, pins = random_constraints(m, n)
-                test_class_space(data, Problem(reqs; compat, pins);
+                compat, pin = random_constraints(m, n)
+                test_class_space(data, Problem(reqs; compat, pin);
                                  by = rand((hi, lo)))
             end
         end
@@ -313,11 +313,11 @@ end
             reqs = collect(make_reqs(rand(1:2^m-1)))
             for shapes in Iterators.product(ntuple(_ -> CONSTRAINT_SHAPES, m)...)
                 compat = Dict{Int,Vector{Int}}()
-                pins   = Dict{Int,Int}()
+                pin    = Dict{Int,Int}()
                 for (p, shape) in enumerate(shapes)
-                    constrain!(compat, pins, p, shape, n)
+                    constrain!(compat, pin, p, shape, n)
                 end
-                prob = Problem(reqs; compat, pins)
+                prob = Problem(reqs; compat, pin)
                 test_class_space(data, prob; by = hi)
                 test_class_space(data, prob; by = lo)
             end
@@ -336,8 +336,8 @@ end
             deps = make_deps(0)
             comp = make_comp(0)
             reqs = collect(make_reqs(rand(1:2^m-1)))
-            compat, pins = random_constraints(m, n; mild = true)
-            prob = Problem(reqs; compat, pins)
+            compat, pin = random_constraints(m, n; mild = true)
+            prob = Problem(reqs; compat, pin)
             while true
                 fill_data!(m, n, deps, comp, data)
                 test_class_space(data, prob)
@@ -387,8 +387,8 @@ permute_versions(data::AbstractDict, perms) = Dict(
                 # and the answer under the permuted ordering is the
                 # universe's answer all the same
                 test_class_space(perm, Problem(reqs))
-                compat, pins = random_constraints(m, n)
-                test_class_space(perm, Problem(reqs; compat, pins))
+                compat, pin = random_constraints(m, n)
+                test_class_space(perm, Problem(reqs; compat, pin))
             end
         end
     end
@@ -409,8 +409,8 @@ end
             for reqs_bits = 0:2^m-1
                 reqs = collect(make_reqs(reqs_bits))
                 specific = pkg_info(deps, reqs) # T1 over the closure of reqs
-                compat, pins = random_constraints(m, n)
-                for prob in (Problem(reqs), Problem(reqs; compat, pins))
+                compat, pin = random_constraints(m, n)
+                for prob in (Problem(reqs), Problem(reqs; compat, pin))
                     @test resolve(all_reqs, prob) == resolve(specific, prob)
                     @test resolve(all_reqs, prob) == resolve(data, prob)
                     # the T1 artifacts are reusable: resolving does not

--- a/test/ordering.jl
+++ b/test/ordering.jl
@@ -117,9 +117,9 @@ end
                     for mk in (reversed, shuffled, partly), by in (hi, lo)
                         order = mk(m, n)
                         test_order_equivalence(data, Problem(reqs), order; by)
-                        compat, pins = random_constraints(m, n)
+                        compat, pin = random_constraints(m, n)
                         test_order_equivalence(
-                            data, Problem(reqs; compat, pins), order; by)
+                            data, Problem(reqs; compat, pin), order; by)
                     end
                 end
             end
@@ -140,12 +140,12 @@ end
                 order = mk(m, n)
                 by = rand((hi, lo))
                 test_order_equivalence(data, Problem(reqs), order; by)
-                compat, pins = random_constraints(m, n)
+                compat, pin = random_constraints(m, n)
                 test_order_equivalence(
-                    data, Problem(reqs; compat, pins), order; by)
+                    data, Problem(reqs; compat, pin), order; by)
                 # ... and the ordering must not disturb the bake-equivalence of
                 # the user constraints either
-                prob = Problem(reqs; compat, pins)
+                prob = Problem(reqs; compat, pin)
                 @test resolve(data, prob; by, order) ==
                       resolve(bake(bake_order(data, order), prob), reqs; by)
             end
@@ -165,11 +165,11 @@ end
             order = shuffled(m, n)
             for shapes in Iterators.product(ntuple(_ -> CONSTRAINT_SHAPES, m)...)
                 compat = Dict{Int,Vector{Int}}()
-                pins   = Dict{Int,Int}()
+                pin    = Dict{Int,Int}()
                 for (p, shape) in enumerate(shapes)
-                    constrain!(compat, pins, p, shape, n)
+                    constrain!(compat, pin, p, shape, n)
                 end
-                prob = Problem(reqs; compat, pins)
+                prob = Problem(reqs; compat, pin)
                 test_order_equivalence(data, prob, order; by = hi)
                 test_order_equivalence(data, prob, order; by = lo)
             end
@@ -192,8 +192,8 @@ end
             before = deepcopy(all_reqs)
             for reqs_bits = 1:2^m-1
                 reqs = collect(make_reqs(reqs_bits))
-                compat, pins = random_constraints(m, n)
-                for prob in (Problem(reqs), Problem(reqs; compat, pins)),
+                compat, pin = random_constraints(m, n)
+                for prob in (Problem(reqs), Problem(reqs; compat, pin)),
                     order in (CANONICAL, reversed(m, n), shuffled(m, n))
                     baked = bake_order(data, order)
                     @test resolve(all_reqs, prob; order) == resolve(baked, prob)

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -9,7 +9,8 @@
 
 using Resolver: Problem, PkgData, PkgInfo, pkg_info, SAT, PicoSAT,
     exclusion_masks, is_excluded, finalize, sat_assume, sat_pop,
-    is_satisfiable, rank_pkg_info, prepare_pkg_info
+    is_satisfiable, rank_pkg_info, prepare_pkg_info, Constraint, Compat, Pins,
+    Predicate, excludes, named, relax
 
 # delete the versions `prob` excludes from each package's data, old-style
 function bake(
@@ -42,7 +43,7 @@ end
 # instance to stay solvable for a while.
 function random_constraints(m::Int, n::Int; mild::Bool = false)
     compat = Dict{Int,Vector{Int}}()
-    pins   = Dict{Int,Int}()
+    pin    = Dict{Int,Int}()
     subset() = mild ? [v for v = 1:n if rand(Bool) || v == rand(1:n)] :
                       [v for v = 1:n if rand(Bool)]
     for p = 1:m+1
@@ -52,16 +53,16 @@ function random_constraints(m::Int, n::Int; mild::Bool = false)
         elseif r == 4
             compat[p] = collect(1:n)  # allows everything
         elseif r == 5
-            pins[p] = rand(1:n)
+            pin[p] = rand(1:n)
         elseif r == 6
-            pins[p] = mild ? rand(1:n) : n + 1 # no such version
+            pin[p] = mild ? rand(1:n) : n + 1 # no such version
         elseif r == 7
             compat[p] = subset()
-            mild || (pins[p] = rand(1:n))
+            mild || (pin[p] = rand(1:n))
         end
         # r == 8: leave p unconstrained
     end
-    return compat, pins
+    return compat, pin
 end
 
 # the constraint shapes worth enumerating exhaustively for one package
@@ -75,22 +76,22 @@ const CONSTRAINT_SHAPES = [
     :pin_best,
     :pin_worst,
     :pin_missing, # pin at a version that doesn't exist
-    :pin_and_compat, # two constraint sources on one package
+    :pin_and_compat, # two constraints on one package
 ]
 
-function constrain!(compat, pins, p::Int, shape::Symbol, n::Int)
+function constrain!(compat, pin, p::Int, shape::Symbol, n::Int)
     shape == :none           ? nothing :
     shape == :allow_all      ? (compat[p] = collect(1:n)) :
     shape == :exclude_all    ? (compat[p] = Int[]) :
     shape == :best           ? (compat[p] = [1]) :
     shape == :worst          ? (compat[p] = [n]) :
     shape == :middle         ? (compat[p] = collect(2:n)) :
-    shape == :pin_best       ? (pins[p] = 1) :
-    shape == :pin_worst      ? (pins[p] = n) :
-    shape == :pin_missing    ? (pins[p] = n + 1) :
-    shape == :pin_and_compat ? (compat[p] = [1]; pins[p] = n) :
+    shape == :pin_best       ? (pin[p] = 1) :
+    shape == :pin_worst      ? (pin[p] = n) :
+    shape == :pin_missing    ? (pin[p] = n + 1) :
+    shape == :pin_and_compat ? (compat[p] = [1]; pin[p] = n) :
     error("unknown constraint shape: $shape")
-    return compat, pins
+    return compat, pin
 end
 
 # `resolve(data, prob)` must agree with the unconstrained resolve of the baked
@@ -105,9 +106,14 @@ end
 @testset "Problem: construction & masks" begin
     prob = Problem([:A, :B])
     @test prob.reqs == [:A, :B]
-    @test isempty(prob.compat) && isempty(prob.pins)
-    prob = Problem(Set([:A]); compat = Dict(:B => [:v1]), pins = Dict(:C => :v2))
-    @test prob isa Problem{Symbol,Symbol,Vector{Symbol}}
+    @test isempty(prob.constraints)
+    prob = Problem(Set([:A]); compat = Dict(:B => [:v1]), pin = Dict(:C => :v2))
+    # one namespace, keyed by kind, whose value type is the closed union
+    @test prob isa Problem{Symbol}
+    @test sort!(collect(keys(prob.constraints))) == [:compat, :pin]
+    @test valtype(prob.constraints) == Constraint{Symbol,Symbol,Vector{Symbol}}
+    @test prob.constraints[:compat] isa Compat{Symbol,Vector{Symbol}}
+    @test prob.constraints[:pin] isa Pins{Symbol,Symbol}
     @test !is_excluded(prob, :B, :v1)
     @test  is_excluded(prob, :B, :v2)
     @test !is_excluded(prob, :C, :v2)
@@ -133,17 +139,63 @@ end
         Problem([:A]; compat = Dict(:A => [:v1, :v2], :Z => Symbol[]))))
 end
 
+@testset "Problem: every keyword is a kind, and its shape is checked" begin
+    # a keyword's name *is* the kind's name, so a misspelling of a well-known
+    # one is a perfectly good name for a kind of its own; what catches it is
+    # that a dictionary is not a predicate. The message has to name the kind,
+    # since that is the word the caller has to change — the rest of its wording
+    # is not the test's business
+    for bad in (:(compt = Dict(:B => [:v1])),      # a dictionary, kind unknown
+                :(compat = (p, v) -> true),        # a callable where one is not
+                :(pin = [:v1, :v2]),               # not a dictionary at all
+                :(compat = Dict("B" => [:v1])))    # keyed by the wrong package
+        kind = String(bad.args[1])
+        e = @test_throws ArgumentError @eval Problem([:A]; $bad)
+        @test occursin(kind, e.value.msg)
+    end
+    # a kind of its own takes any callable, and reaches every package
+    prob = Problem([:A]; pre = (p, v) -> v == :v2)
+    @test prob.constraints[:pre] isa Predicate{Symbol}
+    @test is_excluded(prob, :Z, :v2)
+end
+
+@testset "Problem: a constraint answers three questions" begin
+    # whatever its shape, a constraint says whether it forbids a version, which
+    # packages it speaks about, and what is left of it once some of them are
+    # relaxed — and nothing else. Everything above is a loop over those.
+    prob = Problem([:A]; compat = Dict(:A => [:v1]), pin = Dict(:B => :v2),
+                         pre = (p, v) -> v == :v3)
+    # relaxing a constraint for everything it names leaves nothing of it,
+    # which is what makes "relaxed outright" need no convention of its own
+    for (_, c) in prob.constraints
+        @test relax(c, named(c)) === nothing
+        @test relax(c, Set{Symbol}()) !== nothing
+    end
+    compat = prob.constraints[:compat]
+    @test named(compat) == Set([:A])
+    @test excludes(compat, :A, :v2) && !excludes(compat, :A, :v1)
+    @test !excludes(compat, :Z, :v2) # a package it doesn't name
+    pin = prob.constraints[:pin]
+    @test named(pin) == Set([:B])
+    @test excludes(pin, :B, :v1) && !excludes(pin, :B, :v2)
+    pre = prob.constraints[:pre]
+    @test named(pre) === nothing # a predicate cannot enumerate them
+    @test excludes(pre, :Z, :v3) && excludes(pre, :Y, :v3)
+    # ... but it can still be relaxed for a package, like anything else
+    @test !excludes(relax(pre, [:Z]), :Z, :v3)
+    @test  excludes(relax(pre, [:Z]), :Y, :v3)
+end
+
 @testset "Problem: the unconstrained case is free" begin
     # `Problem(reqs)` is on every convenience `resolve` path, so it must not
-    # allocate a pair of dictionaries just to say "no constraints": the empty
-    # compat and pins are one shared immutable value
+    # allocate a dictionary just to say "no constraints": the empty constraint
+    # map is one shared immutable value
     reqs = [:A, :B]
     a, b = Problem(reqs), Problem(reverse(reqs))
-    @test a.compat === b.compat
-    @test a.pins === b.pins
-    @test isempty(a.compat) && isempty(a.pins)
-    @test valtype(a.compat) == valtype(a.pins) == Any
-    @test !haskey(a.compat, :A) && get(a.pins, :A, nothing) === nothing
+    @test a.constraints === b.constraints
+    @test isempty(a.constraints)
+    @test !haskey(a.constraints, :compat)
+    @test get(a.constraints, :pin, nothing) === nothing
     # the mask dictionary of an unconstrained problem is shared the same way
     nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
     info = pkg_info(Dict(:A => PkgData([:v1], Dict{Symbol,Vector{Symbol}}(), nocomp)),
@@ -153,33 +205,40 @@ end
     # a caller's dictionary is still copied, so later mutation can't reach in
     d = Dict(:B => [:v1])
     p = Problem(reqs; compat = d)
-    @test p.compat == d && p.compat !== d
+    @test p.constraints[:compat].allowed == d
+    @test p.constraints[:compat].allowed !== d
 
-    # so building one allocates the requirements vector and the struct, and
-    # strictly less than the same call handed an (empty) dictionary to copy
+    # so building one allocates the requirements vector and the struct and
+    # nothing else. An empty dictionary names no constraint to make, so it gets
+    # the same shared map, and what it costs over the no-keyword case is the
+    # keyword itself rather than a dictionary — where an entry costs one
     build(::Nothing) = Problem(reqs)
     build(c::AbstractDict) = Problem(reqs; compat = c)
     empty_dict = Dict{Symbol,Any}()
-    build(nothing); build(empty_dict) # compile both
-    @test @allocated(build(nothing)) < @allocated(build(empty_dict))
+    one_entry = Dict(:B => [:v1])
+    build(nothing); build(empty_dict); build(one_entry) # compile all three
+    @test build(empty_dict).constraints === build(nothing).constraints
+    @test @allocated(build(empty_dict)) - @allocated(build(nothing)) < 64
+    @test @allocated(build(nothing)) < @allocated(build(one_entry))
 end
 
-@testset "Problem: resolve's convenience keywords" begin
-    # the requirements-and-keywords form of `resolve` just builds the Problem
+@testset "Problem: bare requirements are the unconstrained problem" begin
+    # `resolve` takes a `Problem` or bare requirements, and bare requirements
+    # are `Problem(reqs)`. Constraints are the `Problem`'s alone: there is no
+    # keyword here to pass them by, so `by`/`order` stay a closed set and a
+    # misspelled one is a `MethodError` rather than a constraint nobody meant
     nodeps = Dict{Symbol,Vector{Symbol}}()
     nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
     data = Dict(
         :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), nocomp),
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
-    compat = Dict(:B => [:v1])
-    pins = Dict(:A => :v1)
-    prob = Problem([:A]; compat, pins)
-    @test resolve(data, [:A]; compat, pins) == resolve(data, prob)
-    @test resolve(data, [:A]; compat) == resolve(data, Problem([:A]; compat))
+    info = pkg_info(data, keys(data); filter = false)
     @test resolve(data, [:A]) == resolve(data, Problem([:A]))
-    info = pkg_info(data, prob)
-    @test resolve(info, [:A]; compat, pins) == resolve(info, prob)
+    @test resolve(info, [:A]) == resolve(info, Problem([:A]))
+    @test issatisfiable(data, [:A]) == issatisfiable(data, Problem([:A]))
+    @test_throws MethodError resolve(data, [:A]; compat = Dict(:B => [:v1]))
+    @test_throws MethodError issatisfiable(data, [:A]; pin = Dict(:A => :v1))
 end
 
 @testset "Problem: exclusions constrain, they don't delete" begin
@@ -230,7 +289,7 @@ end
                       Dict(:v2 => Dict(:B => [:v2]))),
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
-    prob = Problem([:A, :B]; pins = Dict(:B => :v1))
+    prob = Problem([:A, :B]; pin = Dict(:B => :v1))
     info = pkg_info(data, prob)
     @test info[:B].versions == [:v2, :v1]
     @test resolve(data, prob) == Dict(:A => :v1, :B => :v1)
@@ -280,7 +339,7 @@ end
     # allow-all entries or entries for absent packages
     prob = Problem([:A];
         compat = Dict(:A => [:v1], :B => [:v1, :v2], :Z => Symbol[]),
-        pins   = Dict(:A => :v2))
+        pin    = Dict(:A => :v2))
     univ = rank_pkg_info(info, prob)
     sat = SAT(univ)
     try
@@ -307,7 +366,7 @@ end
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
     prob = Problem([:A, :B];
-        compat = Dict(:A => [:v1]), pins = Dict(:B => :v2))
+        compat = Dict(:A => [:v1]), pin = Dict(:B => :v2))
     info = pkg_info(data, prob; filter = false)
     univ = rank_pkg_info(info, prob)
     sat = SAT(univ)
@@ -329,11 +388,11 @@ end
 end
 
 @testset "Problem: exclusion kinds" begin
-    # `excludes` carries the *admission* knobs — "no prereleases" and the like —
-    # which are stated about versions rather than about packages, so they come as
-    # `kind => predicate` pairs instead of per-package entries.
-    # Semantically a kind is nothing but another constraint source: forbidding
-    # exactly the versions a compat entry forbids must be the same problem.
+    # a keyword of its own carries an *admission* knob — "no prereleases" and
+    # the like — which is stated about versions rather than about packages, so
+    # it comes as a predicate instead of per-package entries. Semantically a
+    # kind is nothing but another constraint: forbidding exactly the versions a
+    # compat entry forbids must be the same problem.
     nodeps = Dict{Symbol,Vector{Symbol}}()
     nocomp = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
     data = Dict(
@@ -342,8 +401,8 @@ end
     )
     info = pkg_info(data, keys(data); filter = false)
 
-    odd = :test => (p, v) -> v == :v2 # forbid :v2 of every package
-    prob = Problem([:A]; excludes = [odd])
+    odd = (p, v) -> v == :v2 # forbid :v2 of every package
+    prob = Problem([:A]; test = odd)
     @test  is_excluded(prob, :A, :v2)
     @test !is_excluded(prob, :A, :v1)
     @test  is_excluded(prob, :Z, :v2) # a kind applies to packages too
@@ -359,14 +418,14 @@ end
     @test resolve(data, prob) == resolve(data, both)
     test_bake_equivalence(data, prob)
 
-    # sources are indistinguishable once they have emptied a class -- and here
+    # kinds are indistinguishable once they have emptied a class -- and here
     # they have emptied none. Nothing tells :A's two versions apart, nor :B's,
     # so each package is one class; the kind forbids :v2 of each and the class
-    # survives through :v1. Three constraint sources on two packages, and
+    # survives through :v1. Three constraints on two packages, and
     # nothing at all for any of them to say to the solver
     @test info[:A].classes == info[:B].classes == [1, 1]
     prob = Problem([:A]; compat = Dict(:A => [:v1, :v2]),
-                         pins = Dict(:B => :v1), excludes = [odd])
+                         pin = Dict(:B => :v1), test = odd)
     univ = rank_pkg_info(info, prob)
     sat = SAT(univ)
     try
@@ -377,7 +436,7 @@ end
         finalize(sat)
     end
     # ... whereas a pin the kind contradicts leaves the class nothing at all
-    prob = Problem([:A]; pins = Dict(:B => :v2), excludes = [odd])
+    prob = Problem([:A]; pin = Dict(:B => :v2), test = odd)
     univ = rank_pkg_info(info, prob)
     sat = SAT(univ)
     try
@@ -387,12 +446,13 @@ end
         finalize(sat)
     end
 
-    # no kinds means no cost: the shared empty vector, and an unconstrained
+    # no kinds means no cost: the shared empty map, and an unconstrained
     # problem that still allocates nothing but its requirements
     a, b = Problem([:A]), Problem([:B])
-    @test a.excludes === b.excludes
-    @test isempty(a.excludes)
-    @test isempty(Problem([:A]; excludes = Pair{Symbol,Any}[]).excludes)
+    @test a.constraints === b.constraints
+    @test isempty(a.constraints)
+    @test Problem([:A]; compat = Dict{Symbol,Any}()).constraints ===
+          a.constraints # a kind with nothing in it is a kind that isn't there
     @test exclusion_masks(info, a) === exclusion_masks(info, b)
 end
 
@@ -408,13 +468,13 @@ end
             fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
             reqs = collect(make_reqs(rand(1:2^m-1)))
             allowed = Dict(p => [v for v = 1:n if rand(Bool)] for p = 1:m+1)
-            kinds = [:test => (p, v) -> !(v in get(allowed, p, 1:n))]
+            test = (p, v) -> !(v in get(allowed, p, 1:n))
             for cs in (nothing, random_constraints(m, n))
-                compat, pins = cs === nothing ?
+                compat, pin = cs === nothing ?
                     (Dict{Int,Vector{Int}}(), Dict{Int,Int}()) : cs
-                as_kind = Problem(reqs; compat, pins, excludes = kinds)
+                as_kind = Problem(reqs; compat, pin, test)
                 as_compat = Problem(reqs;
-                    compat = mergewith!(∩, Dict(compat), Dict(allowed)), pins)
+                    compat = mergewith!(∩, Dict(compat), Dict(allowed)), pin)
                 for by in (identity, p -> -p)
                     @test resolve(data, as_kind; by) ==
                           resolve(data, as_compat; by)
@@ -448,18 +508,18 @@ end
     )
     cases = [
         (A3B2, Problem([:A]; compat = Dict(:B => [:v1]))),
-        (A3B2, Problem([:A]; pins = Dict(:B => :v2))),
+        (A3B2, Problem([:A]; pin = Dict(:B => :v2))),
         (A3B2, Problem([:A]; compat = Dict(:A => [:v2]))),
         (A3B2, Problem([:A]; compat = Dict(:B => Symbol[]))),
-        (A3B2, Problem([:A]; pins = Dict(:B => :v9))),
+        (A3B2, Problem([:A]; pin = Dict(:B => :v9))),
         (A3B2, Problem([:A, :B]; compat = Dict(:Z => Symbol[]))),
         (A3B2, Problem([:A]; compat = Dict(:A => [:v1, :v2]),
-                             pins = Dict(:A => :v2))),
-        (conflict, Problem([:C]; pins = Dict(:B => :v2))),
+                             pin = Dict(:A => :v2))),
+        (conflict, Problem([:C]; pin = Dict(:B => :v2))),
         (conflict, Problem([:C]; compat = Dict(:A => [:v1, :v2]))),
         (conflict, Problem([:C, :B]; compat = Dict(:B => [:v1]))),
         (conflict, Problem([:C]; compat = Dict(:C => [:v2], :B => [:v1]))),
-        (conflict, Problem([:A, :B, :C]; pins = Dict(:A => :v3, :B => :v1))),
+        (conflict, Problem([:A, :B, :C]; pin = Dict(:A => :v3, :B => :v1))),
     ]
     lo = p -> -Int(first(string(p))) # reverse alphabetical priority
     for (data, prob) in cases, by in (identity, lo)
@@ -486,8 +546,8 @@ end
                 for reqs_bits = 0:2^m-1
                     reqs = collect(make_reqs(reqs_bits))
                     for _ = 1:4
-                        compat, pins = random_constraints(m, n)
-                        prob = Problem(reqs; compat, pins)
+                        compat, pin = random_constraints(m, n)
+                        prob = Problem(reqs; compat, pin)
                         test_bake_equivalence(data, prob)
                     end
                 end
@@ -510,11 +570,11 @@ end
             reqs = collect(make_reqs(rand(1:2^m-1)))
             for shapes in Iterators.product(ntuple(_ -> CONSTRAINT_SHAPES, m)...)
                 compat = Dict{Int,Vector{Int}}()
-                pins   = Dict{Int,Int}()
+                pin    = Dict{Int,Int}()
                 for (p, shape) in enumerate(shapes)
-                    constrain!(compat, pins, p, shape, n)
+                    constrain!(compat, pin, p, shape, n)
                 end
-                prob = Problem(reqs; compat, pins)
+                prob = Problem(reqs; compat, pin)
                 test_bake_equivalence(data, prob; by = hi)
                 test_bake_equivalence(data, prob; by = lo)
             end
@@ -534,8 +594,8 @@ end
             fill_data!(m, n, deps, comp, data)
             reqs = collect(make_reqs(rand(1:2^m-1)))
             for _ = 1:4
-                compat, pins = random_constraints(m, n)
-                prob = Problem(reqs; compat, pins)
+                compat, pin = random_constraints(m, n)
+                prob = Problem(reqs; compat, pin)
                 test_bake_equivalence(data, prob; by = rand((hi, lo)))
             end
         end
@@ -554,8 +614,8 @@ end
             deps = make_deps(0)
             comp = make_comp(0)
             reqs = collect(make_reqs(rand(1:2^m-1)))
-            compat, pins = random_constraints(m, n; mild = true)
-            prob = Problem(reqs; compat, pins)
+            compat, pin = random_constraints(m, n; mild = true)
+            prob = Problem(reqs; compat, pin)
             while true
                 fill_data!(m, n, deps, comp, data)
                 test_bake_equivalence(data, prob)

--- a/test/relaxation.jl
+++ b/test/relaxation.jl
@@ -7,16 +7,16 @@
 # class is empty when every member of it is forbidden; emptiness is what the
 # solver sees, as `reps[p][c] == 0` and one forbidding unit clause. So:
 #
-#     reps[p][c] == 0  ⟺  every member of class c has an excluding source
+#     reps[p][c] == 0  ⟺  every member of class c has an excluding constraint
 #
 # Attribution is a statement about constraints and versions, deactivation is a
 # statement about the instance, and the sweeps below are that they are the same
 # statement — checked over the tiny data grids crossed with randomized compat
 # bounds, pins, an admission kind, and every combination of the three.
 
-using Resolver: PkgData, Problem, SAT, PicoSAT, pkg_info, nclasses, NoKinds,
-    rank_pkg_info, finalize, is_satisfiable, is_excluded,
-    exclusion_sources, class_exclusions, installed_lit, forbidden_lit,
+using Resolver: PkgData, Problem, SAT, PicoSAT, pkg_info, nclasses,
+    rank_pkg_info, finalize, is_satisfiable, is_excluded, Compat, Pins, named,
+    exclusion_kinds, class_exclusions, installed_lit, forbidden_lit,
     with_classes_relaxed, with_temp_clauses, sat_assume_var, sat_push
 
 const NO_DEPS = Dict{Symbol,Vector{Symbol}}()
@@ -24,30 +24,29 @@ const NO_COMP = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
 
 ## references, none of which asks the solver anything
 
-# the sources excluding a version, recomputed straight from the problem
-function ref_sources(prob::Problem{P}, p::P, v) where {P}
-    srcs = Symbol[]
-    haskey(prob.compat, p) && v ∉ prob.compat[p] && push!(srcs, :compat)
-    haskey(prob.pins, p) && v ≠ prob.pins[p] && push!(srcs, :pin)
-    for (kind, forbids) in prob.excludes
-        forbids(p, v) && push!(srcs, kind)
+# the kinds excluding a version, recomputed straight from the problem's
+# constraints, reaching into each shape rather than asking it anything
+function ref_kinds(prob::Problem{P}, p::P, v) where {P}
+    kinds = Symbol[]
+    for (kind, c) in prob.constraints
+        ex = c isa Compat ? (haskey(c.allowed, p) && v ∉ c.allowed[p]) :
+             c isa Pins   ? (haskey(c.at, p) && v ≠ c.at[p]) :
+                            (p ∉ c.except && c.forbids(p, v))
+        ex && push!(kinds, kind)
     end
-    return srcs
+    return sort!(kinds)
 end
 
-# every source of `prob` that could name a version of `p` at all
-sources_of(prob::Problem{P}, p::P) where {P} = Symbol[
-    (haskey(prob.compat, p) ? (:compat,) : ())...,
-    (haskey(prob.pins, p) ? (:pin,) : ())...,
-    first.(prob.excludes)...]
+# every kind of `prob` that could name a version of `p` at all
+kinds_of(prob::Problem{P}, p::P) where {P} = sort!(Symbol[
+    kind for (kind, c) in prob.constraints
+    if (names = named(c); names === nothing || p in names)])
 
-# `prob` with one of its sources kept and the rest dropped, so that what a
-# single source excludes can be asked of `is_excluded` directly
-one_source(prob::Problem, src::Symbol) =
-    src == :compat ? Problem(prob.reqs; compat = prob.compat) :
-    src == :pin    ? Problem(prob.reqs; pins = prob.pins) :
-                     Problem(prob.reqs;
-                         excludes = filter(kf -> first(kf) == src, prob.excludes))
+# `prob` with one of its constraints kept and the rest dropped, so that what a
+# single kind excludes can be asked of `is_excluded` directly
+one_kind(prob::Problem, kind::Symbol) = Problem(prob.reqs,
+    Dict{Symbol, valtype(prob.constraints)}(
+        kc for kc in prob.constraints if first(kc) == kind))
 
 # a random constraint set of the requested shape over `m` packages with `n`
 # versions each. `random_constraints` (problem.jl) draws the compat bounds and
@@ -55,16 +54,16 @@ one_source(prob::Problem, src::Symbol) =
 # kind forbids a random set of (package, version) pairs, reaching every package
 # at once the way a kind does
 function random_problem(reqs, m::Int, n::Int, shape::Symbol)
-    compat, pins = random_constraints(m, n)
+    compat, pin = random_constraints(m, n)
     shape in (:compat, :all) || (compat = Dict{Int,Vector{Int}}())
-    shape in (:pins,   :all) || (pins   = Dict{Int,Int}())
+    shape in (:pin,    :all) || (pin    = Dict{Int,Int}())
     banned = Set((p, v) for p = 1:m+1, v = 1:n if rand(Bool))
-    excludes = shape in (:kind, :all) ?
-        Pair{Symbol,Any}[:ban => (p, v) -> (p, v) in banned] : NoKinds
-    return Problem(reqs; compat, pins, excludes)
+    ban = shape in (:kind, :all) ?
+        (; ban = (p, v) -> (p, v) in banned) : (;)
+    return Problem(reqs; compat, pin, ban...)
 end
 
-const SHAPES = (:none, :compat, :pins, :kind, :all)
+const SHAPES = (:none, :compat, :pin, :kind, :all)
 
 ## instance-level helpers
 
@@ -102,38 +101,44 @@ empty_classes(univ) = sort!(
 
 ## attribution
 
-@testset "attribution: every source that excludes a version, and only those" begin
+@testset "attribution: every kind that excludes a version, and only those" begin
     prob = Problem([:A];
         compat = Dict(:A => [:v1]),
-        pins   = Dict(:A => :v2),
-        excludes = [:pre => (p, v) -> v == :v3, :odd => (p, v) -> p == :B])
-    # each version of :A is excluded by the sources that name it, in source
-    # order, and by no others
-    @test exclusion_sources(prob, :A, :v1) == [:pin]
-    @test exclusion_sources(prob, :A, :v2) == [:compat]
-    @test exclusion_sources(prob, :A, :v3) == [:compat, :pin, :pre]
-    # compat and pins name their packages; a kind reaches every package
-    @test isempty(exclusion_sources(prob, :C, :v1))
-    @test exclusion_sources(prob, :C, :v3) == [:pre]
-    @test exclusion_sources(prob, :B, :v1) == [:odd]
-    @test exclusion_sources(prob, :B, :v3) == [:pre, :odd]
+        pin    = Dict(:A => :v2),
+        pre    = (p, v) -> v == :v3,
+        odd    = (p, v) -> p == :B)
+    # each version of :A is excluded by the kinds that name it, in kind order,
+    # and by no others
+    @test exclusion_kinds(prob, :A, :v1) == [:pin]
+    @test exclusion_kinds(prob, :A, :v2) == [:compat]
+    @test exclusion_kinds(prob, :A, :v3) == [:compat, :pin, :pre]
+    # compat and pins name their packages; a predicate reaches every package
+    @test isempty(exclusion_kinds(prob, :C, :v1))
+    @test exclusion_kinds(prob, :C, :v3) == [:pre]
+    @test exclusion_kinds(prob, :B, :v1) == [:odd]
+    @test exclusion_kinds(prob, :B, :v3) == [:odd, :pre]
     # an unconstrained problem excludes nothing at all
-    @test isempty(exclusion_sources(Problem([:A]), :A, :v1))
-    # ... and a source that excludes nothing names nothing
-    @test isempty(exclusion_sources(Problem([:A];
+    @test isempty(exclusion_kinds(Problem([:A]), :A, :v1))
+    # ... and a kind that excludes nothing names nothing
+    @test isempty(exclusion_kinds(Problem([:A];
         compat = Dict(:A => [:v1, :v2])), :A, :v1))
+    # two constraints cannot share a kind: the map is a namespace, and since a
+    # kind's name *is* its keyword's, a repeat never reaches the constructor —
+    # it is a syntax error, so it takes an `@eval` to write one down at all
+    @test_throws ErrorException @eval Problem([:A];
+        compat = Dict(:A => [:v1]), compat = (p, v) -> true)
 end
 
 @testset "attribution: why a class is empty" begin
     # nothing in the registry tells :A's :v2 and :v1 apart, so they are one
-    # class of two members, and two sources empty it between them: the compat
+    # class of two members, and two kinds empty it between them: the compat
     # bound takes one member, the admission kind the other
     data = Dict(
         :A => PkgData([:v2, :v1], Dict(:v2 => [:B], :v1 => [:B]), NO_COMP),
         :B => PkgData([:w1], NO_DEPS, NO_COMP),
     )
     prob = Problem([:A]; compat = Dict(:A => [:v1]),
-                         excludes = [:pre => (p, v) -> v == :v1])
+                         pre = (p, v) -> v == :v1)
     info = pkg_info(data, prob)
     @test info[:A].members == [[1, 2]]
     @test class_exclusions(prob, :A, info[:A], 1) ==
@@ -177,19 +182,19 @@ end
                     # excludes
                     r = univ.reps[p][k]
                     if !iszero(r)
-                        @test isempty(exclusion_sources(prob, p, info_p.versions[r]))
+                        @test isempty(exclusion_kinds(prob, p, info_p.versions[r]))
                     end
-                    for (v, srcs) in ex
+                    for (v, kinds) in ex
                         # attribution agrees with a recomputation from the
                         # problem, and with `is_excluded` on whether there is
                         # anything to name
-                        @test srcs == ref_sources(prob, p, v)
-                        @test isempty(srcs) == !is_excluded(prob, p, v)
-                        # every source named really does exclude the version on
-                        # its own, and every source that does is named
-                        for src in sources_of(prob, p)
-                            @test (src in srcs) ==
-                                is_excluded(one_source(prob, src), p, v)
+                        @test kinds == ref_kinds(prob, p, v)
+                        @test isempty(kinds) == !is_excluded(prob, p, v)
+                        # every kind named really does exclude the version on
+                        # its own, and every kind that does is named
+                        for kind in kinds_of(prob, p)
+                            @test (kind in kinds) ==
+                                is_excluded(one_kind(prob, kind), p, v)
                         end
                     end
                 end
@@ -285,7 +290,7 @@ end
 end
 
 @testset "the lift is scoped, and selective inside" begin
-    # :P's two classes are emptied by two different sources: the compat bound
+    # :P's two classes are emptied by two different kinds: the compat bound
     # takes the class holding :v3 and :v1, the admission kind the one holding
     # :v2 (which is a class of its own because it conflicts with :Q@:w2)
     data = Dict(
@@ -294,7 +299,7 @@ end
     )
     prob = Problem([:P, :Q];
         compat = Dict(:P => [:v2]),
-        excludes = [:pre => (p, v) -> v == :v2])
+        pre = (p, v) -> v == :v2)
     info = pkg_info(data, prob; filter = false)
     univ = rank_pkg_info(info, prob)
     @test univ.reps[:P] == [0, 0]
@@ -409,7 +414,7 @@ end
 @testset "the substrate stays internal" begin
     # substrate, reached by qualified name: `Resolver` exports none of it
     for name in (:installed_lit, :forbidden_lit, :with_classes_relaxed,
-                 :push_forbidden!, :exclusion_sources, :class_exclusions)
+                 :push_forbidden!, :exclusion_kinds, :class_exclusions)
         @test isdefined(Resolver, name)
         @test name ∉ names(Resolver)
     end

--- a/test/relaxation_stable.jl
+++ b/test/relaxation_stable.jl
@@ -1,6 +1,6 @@
 # The property the filter buys with the two rank keys: a universe filtered for
 # query `Q` still answers every *relaxation* of `Q` — the same query with some
-# requirements or constraint sources dropped, which is exactly the shape of a
+# requirements or constraints relaxed, which is exactly the shape of a
 # repair a user can make to an unsatisfiable problem.
 #
 # The theory page states this as Theorem C. What is checked here is its
@@ -19,9 +19,9 @@
 # kept set is downward closed in `key_∅` (the Remark), which is the invariant
 # that lets it carry an integer frontier instead of a set.
 
-using Resolver: PkgData, Problem, SAT, NoKinds, SparsePerm, RelaxedProblem,
-    pkg_info, nclasses, prepare_pkg_info, rank_pkg_info, resolve, relax, sources,
-    class_ranking, deactivations, is_excluded, with_classes_relaxed,
+using Resolver: PkgData, Problem, SAT, SparsePerm, RelaxedProblem,
+    pkg_info, nclasses, prepare_pkg_info, rank_pkg_info, resolve, relax,
+    relaxations, class_ranking, deactivations, is_excluded, with_classes_relaxed,
     with_temp_clauses, mark_installable!, mark_reachable!, finalize
 
 using .tiny_data
@@ -42,22 +42,29 @@ function is_relaxation(info, Q::Problem{P}, R::Problem{P}) where {P}
     return true
 end
 
-function relaxed(info, univ, Q, drop_reqs, drop_sources)
-    rp = relax(univ, Q, drop_reqs, drop_sources)
+function relaxed(info, univ, Q, drop_reqs, drops)
+    rp = relax(univ, Q, drop_reqs, drops)
     @test is_relaxation(info, Q, rp.prob)
     return rp
 end
 
-# a sample: the bottom of the lattice (everything withdrawn) first, since it is
-# the hardest case and the one caching depends on, then random points
-function relaxations(info, univ, Q::Problem{P}, k::Int) where {P}
-    srcs = sources(Q)
+# a sample: the bottom of the lattice (everything relaxed) first, since it is
+# the hardest case and the one caching depends on, then random points — each a
+# random set of kinds, and for the kinds that name packages, a random set of
+# those, since a kind is relaxed per package like any other
+function sample_relaxations(info, univ, Q::Problem{P}, k::Int) where {P}
+    every = relaxations(Q)
     # the element type is abstract on purpose: a relaxation that reorders
     # carries a different `ord` from one that does not
-    out = RelaxedProblem[relaxed(info, univ, Q, P[], srcs)]
+    out = RelaxedProblem[relaxed(info, univ, Q, P[], every)]
     for _ = 1:k
         dr = P[p for p in unique(Q.reqs) if rand() < 0.35]
-        ds = [s for s in srcs if rand() < 0.5]
+        ds = empty(every)
+        for (kind, pkgs) in every
+            rand() < 0.5 || continue
+            ds[kind] = pkgs === nothing || rand() < 0.5 ? pkgs :
+                Set{P}(p for p in pkgs if rand() < 0.5)
+        end
         isempty(dr) && isempty(ds) && continue
         push!(out, relaxed(info, univ, Q, dr, ds))
     end
@@ -130,14 +137,14 @@ revivals(univ, rp) = count(
         for mode in (:random, :demoting), _ = 1:15
             drawn = draw_query!(mode, m, n, make_deps, make_comp, d, c, data)
             drawn === nothing && continue
-            info, compat, pins = drawn
+            info, compat, pin = drawn
             reqs = collect(make_reqs(rand(1:2^m-1)))
             bad = rand(1:n)
-            # a second source, independently droppable, so that dropping the
-            # compat bound is one point of the lattice rather than all of it
-            excludes = mode === :demoting || rand(Bool) ?
-                Pair{Symbol,Any}[:test => (p, v) -> v == bad] : NoKinds
-            Q = Problem(reqs; compat, pins, excludes)
+            # a second constraint, independently withdrawable, so that dropping
+            # the compat bound is one point of the lattice rather than all of it
+            test = mode === :demoting || rand(Bool) ?
+                (; test = (p, v) -> v == bad) : (;)
+            Q = Problem(reqs; compat, pin, test...)
             univ = prepare_pkg_info(info, Q)
             have = classkeys(univ)
             # one instance for the whole lattice sample, which is the point:
@@ -145,7 +152,7 @@ revivals(univ, rp) = count(
             # resolve already built
             sat = SAT(univ)
             try
-                for rp in relaxations(info, univ, Q, 4)
+                for rp in sample_relaxations(info, univ, Q, 4)
                     R = rp.prob
                     # Theorem C: reuse answers R exactly as a fresh resolve does
                     @test resolve(sat, rp) == resolve(info, R)
@@ -194,8 +201,8 @@ end
     @test univ.reps[:A] == [2, 4]
     @test resolve(info, Q) == Dict(:A => :v3, :C => :x1)
 
-    rp = relaxed(info, univ, Q, Symbol[], sources(Q))
-    @test rp.prob.reqs == [:A] && isempty(rp.prob.compat)
+    rp = relaxed(info, univ, Q, Symbol[], relaxations(Q))
+    @test rp.prob.reqs == [:A] && isempty(rp.prob.constraints)
     @test reranks(rp) # the class order really did move
     @test resolve(info, rp.prob) == Dict(:A => :v4, :B => :w1)
     @test resolve(univ, rp) == Dict(:A => :v4, :B => :w1)
@@ -219,7 +226,7 @@ end
     @test univ.reps[:A] == [0, 3]
     @test resolve(info, Q) == Dict(:A => :v1, :B => :w1)
 
-    rp = relaxed(info, univ, Q, Symbol[], sources(Q))
+    rp = relaxed(info, univ, Q, Symbol[], relaxations(Q))
     @test revivals(univ, rp) == 1
     @test resolve(info, rp.prob) == Dict(:A => :v3)
     # naming through Q's representatives would index version 0 of :A; naming
@@ -230,12 +237,47 @@ end
     try
         @test resolve(sat, rp) == Dict(:A => :v3)
         # the bottom of the lattice requires nothing, so it installs nothing
-        @test resolve(sat, relaxed(info, univ, Q, Q.reqs, sources(Q))) ==
+        @test resolve(sat, relaxed(info, univ, Q, Q.reqs, relaxations(Q))) ==
             Dict{Symbol,Symbol}()
         # Q itself is a relaxation of Q, and answers as Q answers
-        @test resolve(sat, relaxed(info, univ, Q, Symbol[], Pair{Symbol,Any}[])) == resolve(info, Q)
+        @test resolve(sat, relaxed(info, univ, Q, Symbol[], Dict{Symbol,Nothing}())) ==
+            resolve(info, Q)
     finally
         finalize(sat)
+    end
+end
+
+@testset "a kind is relaxed per package, whatever its shape" begin
+    # every kind relaxes the same way — for the packages the map names it
+    # for, or for every package when the map names `nothing` — so `:compat` and
+    # `:pin` are relaxable one package at a time like anything else. What the
+    # map is read with is `haskey`, so a kind that is absent from it and a kind
+    # relaxed for nothing are both simply not relaxed.
+    data = Dict(
+        :A => PkgData([:v2, :v1], NO_DEPS, NO_COMP),
+        :B => PkgData([:w2, :w1], NO_DEPS, NO_COMP),
+    )
+    info = pkg_info(data, keys(data); filter = false)
+    held = Dict(:A => :v1, :B => :w1)
+    both = Dict(:A => :v2, :B => :w2)
+    function relaxes(Q)
+        univ = prepare_pkg_info(info, Q)
+        drops -> resolve(univ, relaxed(info, univ, Q, Symbol[], drops))
+    end
+    # the two well-known kinds, and a predicate that forbids the same versions
+    for (kind, Q) in (
+        :compat => Problem([:A, :B]; compat = Dict(:A => [:v1], :B => [:w1])),
+        :pin    => Problem([:A, :B]; pin = Dict(:A => :v1, :B => :w1)),
+        :test   => Problem([:A, :B]; test = (p, v) -> v in (:v2, :w2)),
+    )
+        relax_it = relaxes(Q)
+        @test resolve(info, Q) == held
+        @test relax_it(Dict(kind => Set([:A]))) == Dict(:A => :v2, :B => :w1)
+        @test relax_it(Dict(kind => Set([:B]))) == Dict(:A => :v1, :B => :w2)
+        @test relax_it(Dict(kind => nothing)) == both
+        @test relax_it(Dict(kind => Set{Symbol}())) == held
+        @test relax_it(Dict(:nosuch => nothing)) == held # a kind Q hasn't got
+        @test relax_it(Dict{Symbol,Nothing}()) == held
     end
 end
 
@@ -247,7 +289,7 @@ end
     info = pkg_info(data, keys(data); filter = false)
     Q = Problem([:A]; compat = Dict(:A => [:v1]))
     univ = prepare_pkg_info(info, Q)
-    rp = relaxed(info, univ, Q, Symbol[], sources(Q))
+    rp = relaxed(info, univ, Q, Symbol[], relaxations(Q))
     sat = SAT(univ)
     try
         want = resolve(sat, rp)
@@ -295,11 +337,11 @@ end
     for _ = 1:200
         drawn = draw_query!(:demoting, 3, 3, make_deps, make_comp, d, c, data)
         drawn === nothing && continue
-        info, compat, pins = drawn
+        info, compat, pin = drawn
         reqs = collect(make_reqs(rand(1:2^3-1)))
-        Q = Problem(reqs; compat, pins)
+        Q = Problem(reqs; compat, pin)
         univ = prepare_pkg_info(info, Q)
-        rp = relax(univ, Q, Int[], sources(Q))
+        rp = relax(univ, Q, Int[], relaxations(Q))
         for (p, ip) in univ.info
             m = nclasses(ip)
             ord = Resolver.ranking(rp.ord, p, m)
@@ -323,12 +365,11 @@ end
         fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
         reqs = collect(make_reqs(rand(1:2^m-1)))
         info = pkg_info(data, keys(data); filter = false)
-        compat, pins = random_constraints(m, n)
+        compat, pin = random_constraints(m, n)
         bad = rand(1:n)
-        Q = Problem(reqs; compat, pins,
-            excludes = Pair{Symbol,Any}[:test => (p, v) -> v == bad])
+        Q = Problem(reqs; compat, pin, test = (p, v) -> v == bad)
         univ = prepare_pkg_info(info, Q)
-        rels = relaxations(info, univ, Q, 8)
+        rels = sample_relaxations(info, univ, Q, 8)
         want = Dict(i => resolve(info, rp.prob) for (i, rp) in enumerate(rels))
         sat = SAT(univ)
         try
@@ -379,8 +420,8 @@ end
             fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
             reqs = collect(make_reqs(rand(1:2^m-1)))
             info = pkg_info(data, keys(data); filter = false)
-            compat, pins = random_constraints(m, n)
-            prob = Problem(reqs; compat, pins)
+            compat, pin = random_constraints(m, n)
+            prob = Problem(reqs; compat, pin)
             univ = rank_pkg_info(info, prob)
             mark_installable!(univ.info)
             mark_reachable!(univ.info, prob.reqs, deactivations(univ), univ.ranks)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,7 +196,7 @@ using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file, nclasses
     roundtrip(sdata, ["A"], [
         Problem(["A"]),
         Problem(["A"]; compat = Dict("B" => [1])),
-        Problem(["A", "B"]; pins = Dict("A" => 1)),
+        Problem(["A", "B"]; pin = Dict("A" => 1)),
     ])
     # roundtrip with Symbol package names & Symbol versions
     ydata = Dict(
@@ -208,7 +208,7 @@ using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file, nclasses
     roundtrip(ydata, [:A], [
         Problem([:A]),
         Problem([:A]; compat = Dict(:B => [:v2])),
-        Problem([:A, :B]; pins = Dict(:B => :v1)),
+        Problem([:A, :B]; pin = Dict(:B => :v1)),
     ])
 end
 
@@ -321,10 +321,11 @@ include("ordering.jl")
     @test issatisfiable(rp, ["JSON"])
     @test issatisfiable(rp, ["DataFrames", "JSON"])
     @test issatisfiable(rp, String[])
-    # ... including through the convenience keywords: no version of JSON can
-    # satisfy a pin at a version that doesn't exist
-    @test !issatisfiable(rp, ["JSON"]; pins = Dict("JSON" => v"0.0.0"))
-    @test resolve(rp, ["JSON"]; pins = Dict("JSON" => v"0.0.0")) === nothing
+    # ... and through a constrained `Problem`: no version of JSON can satisfy a
+    # pin at a version that doesn't exist
+    missing_pin = Resolver.Problem(["JSON"]; pin = Dict("JSON" => v"0.0.0"))
+    @test !issatisfiable(rp, missing_pin)
+    @test resolve(rp, missing_pin) === nothing
 end
 
 @testset "yanked packages" begin

--- a/test/satisfiable.jl
+++ b/test/satisfiable.jl
@@ -49,29 +49,25 @@ end
         :B => PkgData([:v2, :v1], nodeps, nocomp),
     )
     compat = Dict(:B => [:v1])
-    pins = Dict(:A => :v1)
+    pin = Dict(:A => :v1)
 
     # every shape of package data `resolve` accepts, with a `Problem` and with
-    # the convenience keywords that build one
+    # the bare requirements that build the unconstrained one
     deps = DepsProvider(p -> data[p], keys(data))
-    info = pkg_info(data, Problem([:A]; compat, pins))
+    info = pkg_info(data, Problem([:A]; compat, pin))
     for src in (data, deps, info)
         for prob in (Problem([:A]),
                      Problem([:A]; compat),
-                     Problem([:A]; pins),
-                     Problem([:A]; compat, pins),
+                     Problem([:A]; pin),
+                     Problem([:A]; compat, pin),
                      Problem([:A]; compat = Dict(:B => Symbol[])),
-                     Problem([:A]; pins = Dict(:B => :v9)),
+                     Problem([:A]; pin = Dict(:B => :v9)),
                      Problem([:A, :B]; compat = Dict(:Z => Symbol[])),
                      Problem(Symbol[]))
             @test issatisfiable(src, prob) == (resolve(src, prob) !== nothing)
         end
-        # the keyword forms are the same calls as the `Problem` ones
+        # bare requirements are the unconstrained problem
         @test issatisfiable(src, [:A]) == issatisfiable(src, Problem([:A]))
-        @test issatisfiable(src, [:A]; compat) ==
-              issatisfiable(src, Problem([:A]; compat))
-        @test issatisfiable(src, [:A]; compat, pins) ==
-              issatisfiable(src, Problem([:A]; compat, pins))
         # requirements may be a set as well as a vector, and default to the
         # whole universe
         @test issatisfiable(src, Set([:A])) == issatisfiable(src, [:A])
@@ -79,7 +75,7 @@ end
     end
 
     # ... and a SAT instance, the shape the others build internally
-    sat = SAT(prepare_pkg_info(info, Problem([:A]; compat, pins)))
+    sat = SAT(prepare_pkg_info(info, Problem([:A]; compat, pin)))
     try
         @test issatisfiable(sat, [:A]) == (resolve(sat, [:A]) !== nothing)
         @test issatisfiable(sat) == (resolve(sat) !== nothing)
@@ -184,9 +180,9 @@ end
             fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
             reqs = collect(make_reqs(rand(1:2^m-1)))
             for cs in (nothing, random_constraints(m, n))
-                compat, pins = cs === nothing ?
+                compat, pin = cs === nothing ?
                     (Dict{Int,Vector{Int}}(), Dict{Int,Int}()) : cs
-                prob = Problem(reqs; compat, pins)
+                prob = Problem(reqs; compat, pin)
                 verdict = issatisfiable(data, prob)
                 for by in (hi, lo), order in (nothing, up)
                     @test verdict ==


### PR DESCRIPTION
A `Problem`'s constraints were three shapes — `compat` a package-keyed dict of
allowed-version sets, `pins` a package-keyed dict of versions, `excludes` a
list of `kind => predicate` pairs — but every consumer already treated them as
one namespace keyed by symbol. `exclusion_sources` said so plainly:

```julia
s === nothing || v ∈ s || push!(srcs, :compat)
w === nothing || v == w || push!(srcs, :pin)
for (kind, forbids) in prob.excludes
    forbids(p, v)::Bool && push!(srcs, kind)
end
```

One vocabulary at the point of use, three things at the point of storage, and
every consumer paying for the difference with a hard-coded three-way branch:
`is_excluded`, `exclusion_sources`, `exclusion_candidates`, `is_constrained`,
`relax`, `sources`. Code downstream then invented translation layers and
reserved names to bridge the seam.

Now there is one map, `prob.constraints`, from **kind** to constraint.
`:compat` and `:pin` are well-known kinds; anything else is its own. A
constraint answers three questions and nothing else:

```julia
excludes(c, p, v) :: Bool                  # does this forbid v of p?
named(c) :: Union{Nothing, Set{P}}         # the packages it speaks about
relax(c, pkgs) :: Union{C, Nothing}     # it, no longer applying to pkgs
```

`is_excluded` is a loop. `exclusion_kinds` is a loop. `relax(prob, …)` is a
loop.

## `nothing` means one thing

`named` returns `nothing` for a constraint that speaks about *every* package: a
predicate cannot enumerate them, while a compat bound or a pin names its own.
So relaxing a kind outright is relaxing it for `named(c)`, and

```julia
relax(c, named(c)) === nothing
```

holds for every shape. "Withdrawn outright" needs no convention and no
sentinel, which is what makes the map safe to consult with `haskey`.

## Types

```julia
struct Problem{P, C<:AbstractDict{Symbol}}
    reqs :: Vector{P}
    constraints :: C
end

const Constraint{P,V,S} = Union{Compat{P,S}, Pins{P,V}, Predicate{P}}
```

`C` is a parameter, so it is always concrete — the shared empty singleton for
an unconstrained problem, a `Dict` otherwise — and the value type is a closed
union that `is_excluded` splits on rather than dispatching through.

This is *better* than before, not merely preserved: `compat` and `pins` were
`AbstractDict` fields, so every `get` on them was a dynamic call; `Compat` and
`Pins` now hold concrete `Dict`s, which costs nothing because an unconstrained
problem carries no such constraint at all. `code_typed` on `is_excluded` shows
an `isa` chain with the compat lookup inlined to `memoryrefget`, and it
allocates nothing.

**Correction.** An earlier version of this description claimed prepare
allocations drop 4.5–10%. That figure came from a harness I did not run myself,
and it does not reproduce: measuring `main`, this branch and the alternative in
#79 with one script, prepare allocations are identical to within 0.03% on a
constrained query and byte-identical on an unconstrained one, with times inside
this machine's noise. There is no measured performance difference either way.

## Two behaviour changes, both intended and tested

- **Every kind relaxes per package**, `:compat` and `:pin` included. Before,
  a caller could release a whole compat entry or a whole predicate, but not a
  predicate *for one package* — which is the shape a repair takes ("allow
  prereleases of X"). The new testset runs the same six-case matrix over
  `:compat`, `:pin` and a predicate.
- **Two constraints may no longer share a kind.** `Problem(reqs; compat = …,
  excludes = [:compat => f])` throws. That is what makes the map a namespace
  rather than a bag; nothing in the repo did it.

## The constructor says it too

```julia
Problem(reqs; compat = Dict(p => spec), pin = Dict(q => v), pre = (p, v) -> ispre(v))
```

Every keyword is a kind, and the keyword's name *is* the kind's name. `compat`
and `pin` want a package-keyed dictionary; anything else wants a predicate. A
custom kind is spelled the same way as a built-in one instead of being
relegated to a list of pairs.

That deletes the duplicate-kind check outright: a repeated keyword is a syntax
error, raised at lowering, before the call exists.

```
julia> Problem([:A]; compat = Dict(), compat = Dict())
ERROR: syntax: keyword argument "compat" repeated in call to "Problem"
```

Shape checking moved into the constructor, which is what keeps a typo an error
rather than a silent constraint:

```
julia> Problem([:A]; compt = Dict(:B => [:v1]))
ERROR: ArgumentError: constraint kind :compt wants a predicate, `(p, v) -> Bool`
true for the versions it forbids; got a Dict{Symbol, Vector{Symbol}}. `compat`
and `pin` are the only keywords that take a dictionary
```

`resolve` and `issatisfiable` **do not** slurp, and lose their constraint
keywords: their keyword space already holds `by`, `order` and `diagnose`, and
`order` takes a callable — so a typo'd `oder = my_order` would have slurped into
a predicate kind, passed the callable check, and silently applied a nonsense
constraint. The requirements-only methods stay; a constrained resolve goes
through a `Problem`, and `resolve(data, reqs; compat = …)` is now a
`MethodError`.

## Renames

`sources` → `relaxations`, `exclusion_sources` → `exclusion_kinds` (now sorted,
since a `Dict` has no order), the `pins` keyword → `pin` (the keyword's name is
the kind's name now, and `:pin` is how it reads at every point of use), and
"source" retired in favour of "kind". `NoKinds` goes with `excludes`.

## It is not smaller

`Problem.jl` grows about 135 lines for the three constraint types and the shape
checking, against 26 saved in `Resolve.jl`; the test churn is the `pins` → `pin`
and `excludes` → keyword rewrites across ~139 call sites. What it buys is one
vocabulary instead of three, which is what the diagnosis work needs — it keys
repairs by these same symbols, and against the old storage it had to invent a
second set of names and translate between them.

