### PR TITLE
Rename the one-argument is_satisfiable to sat_solve

### DIFF
--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -39,7 +39,7 @@ function resolve_core(
                 sat_assume(sat, p,
                     @inbounds ranking(ord, p, nclasses(sat.info[p]))[1])
             end
-            is_satisfiable(sat) && extract_solution!(sat, sol)
+            sat_solve(sat) && extract_solution!(sat, sol)
         end
         for p in layer
             optimize_version!(sat, sol, p, ord)

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -441,12 +441,19 @@ installed_lit(sat::SAT{P}, p::P) where {P} = sat.vars[p]
 # assuming it says what that clause says, for one solve
 forbidden_lit(sat::SAT{P}, p::P, c::Integer) where {P} = -(sat.vars[p] + c)
 
-is_satisfiable(sat::SAT) =
+# Solve, consuming whatever has been assumed since the last solve — the caller
+# staged the question with `sat_assume`, this answers it. With nothing staged
+# the question is the instance itself, which installing no package satisfies,
+# so a caller asking about *requirements* wants `is_satisfiable(sat, reqs)`:
+# requirements are assumed, not asserted, and an unstaged solve reports them
+# satisfiable however unsatisfiable they are.
+sat_solve(sat::SAT) =
     PicoSAT.sat(sat.pico) == PicoSAT.SATISFIABLE
 
+# Are `reqs` jointly installable? The complete question, staged and answered.
 function is_satisfiable(sat::SAT{P}, reqs::Union{P,SetOrVec{P}}) where {P}
     sat_assume(sat, reqs)
-    is_satisfiable(sat)
+    sat_solve(sat)
 end
 
 const is_unsatisfiable = !is_satisfiable
@@ -484,7 +491,7 @@ end
 
 function solution(sat::SAT{P,V}) where {P,V}
     sol = Dict{P,V}()
-    is_satisfiable(sat) || return sol
+    sat_solve(sat) || return sol
     each_solution_index(sat) do p, i
         sol[p] = sat.info[p].versions[sat.reps[p][i]]
     end
@@ -580,7 +587,7 @@ function optimize_version!(
     # at all — one solve replaces the whole improvement loop
     if sol[p] != best
         sat_assume(sat, p, best)
-        if is_satisfiable(sat)
+        if sat_solve(sat)
             extract_solution!(sat, sol)
             @assert sol[p] == best
         end
@@ -597,7 +604,7 @@ function optimize_version!(
                 sat_add(sat, p, c)
             end
             sat_add(sat)
-            is_satisfiable(sat) || return false
+            sat_solve(sat) || return false
             extract_solution!(sat, sol)
             return true
         end

--- a/src/UnsatCores.jl
+++ b/src/UnsatCores.jl
@@ -20,7 +20,7 @@ module UnsatCores
 
 export sat_mus, sat_disjoint_muses, sat_mcses
 
-using ..Resolver: SAT, PicoSAT, sat_assume_var, is_satisfiable
+using ..Resolver: SAT, PicoSAT, sat_assume_var, sat_solve
 
 # Everything not exported is internal to this module: the solve wrapper, the
 # failed-assumption reader, the shrink pass, and the grow pass with the
@@ -73,7 +73,7 @@ function sat_solve_assuming(sat::SAT, lits)
     for l in lits
         sat_assume_var(sat, l)
     end
-    return is_satisfiable(sat)
+    return sat_solve(sat)
 end
 
 # the failed-assumption core of the solve that just returned unsatisfiable, as
@@ -95,7 +95,7 @@ any single literal dropped). `lits` must be distinct.
 
 Returns an empty vector when `sat` is satisfiable assuming all of `lits` — and
 also when `sat` is unsatisfiable on its own, since the empty set is then itself
-the minimal unsatisfiable subset. Call `is_satisfiable(sat)` to tell the two
+the minimal unsatisfiable subset. Call `sat_solve(sat)` to tell the two
 apart if the instance is not known to be satisfiable without assumptions.
 
 Deletion is attempted in the order given, so the result is biased away from the

--- a/test/class_space.jl
+++ b/test/class_space.jl
@@ -20,7 +20,7 @@
 using Resolver: PkgData, PkgInfo, Problem, SAT, PicoSAT, pkg_info, nclasses,
     rank_pkg_info, prepare_pkg_info, filter_pkg_info!, deactivations,
     mark_installable!, mark_necessary!, class_ranking, finalize,
-    sat_assume, sat_pop, is_satisfiable
+    sat_assume, sat_pop, is_satisfiable, sat_solve
 
 const NODEPS = Dict{Symbol,Vector{Symbol}}()
 const NOCOMP = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
@@ -357,12 +357,12 @@ end
         @test is_satisfiable(sat, [:P])
         # ... and :P's first class, the only thing that needs it, is out
         sat_assume(sat, :P, 1)
-        @test !is_satisfiable(sat)
+        @test !sat_solve(sat)
         # reactivate, and the cone is right there: choosing :P's first class
         # forces :R in
         sat_pop(sat)
         sat_assume(sat, :P, 1)
-        @test is_satisfiable(sat)
+        @test sat_solve(sat)
         @test PicoSAT.deref(sat.pico, sat.vars[:R]) > 0
     finally
         finalize(sat)

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -19,7 +19,7 @@
 # there is no oracle for English.
 
 using Resolver: Problem, PkgData, PkgInfo, SAT, Diagnosis, pkg_info, relax,
-    prepare_pkg_info, finalize, is_satisfiable, installed_lit, forbidden_lit,
+    prepare_pkg_info, finalize, sat_solve, installed_lit, forbidden_lit,
     with_classes_relaxed, class_exclusions, exclusion_kinds, nclasses,
     sat_assume_var
 using Resolver.Diagnostics: Diagnostics, Conflict, Fix, Action, Fact,
@@ -59,7 +59,7 @@ function sat_assuming(sat::SAT, lits)
     for l in lits
         sat_assume_var(sat, l)
     end
-    return is_satisfiable(sat)
+    return sat_solve(sat)
 end
 
 # the withdrawal a set of actions asks for, read off here rather than taken

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -9,7 +9,7 @@
 
 using Resolver: Problem, PkgData, PkgInfo, pkg_info, SAT, PicoSAT,
     exclusion_masks, is_excluded, finalize, sat_assume, sat_pop,
-    is_satisfiable, rank_pkg_info, prepare_pkg_info, Constraint, relax
+    is_satisfiable, sat_solve, rank_pkg_info, prepare_pkg_info, Constraint, relax
 
 # delete the versions `prob` excludes from each package's data, old-style
 function bake(
@@ -378,14 +378,14 @@ end
         @test length(sat.deact) == 2
         # :A's :v2 class is emptied by compat, :B's :v1 class by the pin
         sat_assume(sat, :A, 1)
-        @test !is_satisfiable(sat)
+        @test !sat_solve(sat)
         sat_assume(sat, :B, 2)
-        @test !is_satisfiable(sat)
+        @test !sat_solve(sat)
         # both jointly feasible once the frame is popped
         sat_pop(sat)
         sat_assume(sat, :A, 1)
         sat_assume(sat, :B, 2)
-        @test is_satisfiable(sat)
+        @test sat_solve(sat)
     finally
         finalize(sat)
     end

--- a/test/relaxation.jl
+++ b/test/relaxation.jl
@@ -15,7 +15,7 @@
 # bounds, pins, an admission kind, and every combination of the three.
 
 using Resolver: PkgData, Problem, SAT, PicoSAT, pkg_info, nclasses,
-    rank_pkg_info, finalize, is_satisfiable, is_excluded,
+    rank_pkg_info, finalize, is_satisfiable, sat_solve, is_excluded,
     exclusion_kinds, class_exclusions, installed_lit, forbidden_lit,
     with_classes_relaxed, with_temp_clauses, sat_assume_var, sat_push
 
@@ -76,7 +76,7 @@ function verdicts(sat::SAT{P}, assume::AbstractVector{Int} = Int[]) where {P}
         for l in lits
             sat_assume_var(sat, l)
         end
-        push!(out, is_satisfiable(sat))
+        push!(out, sat_solve(sat))
     end
     ask()
     for p in sort!(collect(keys(sat.vars)))

--- a/test/unsat_cores.jl
+++ b/test/unsat_cores.jl
@@ -14,8 +14,8 @@
 using Resolver.UnsatCores
 
 # instance plumbing, from Resolver proper: none of this is part of the API above
-using Resolver: PkgData, pkg_info, SAT, finalize, is_satisfiable,
-    is_unsatisfiable, sat_new_variable, sat_add, sat_add_var, with_temp_clauses
+using Resolver: PkgData, pkg_info, SAT, finalize, sat_solve,
+    sat_new_variable, sat_add, sat_add_var, with_temp_clauses
 
 # white-box, deliberately: the single-repair pair is unexported — the enumeration
 # is built out of it — and reaching past the export list is how its contracts get
@@ -373,7 +373,7 @@ end
             x = sat_new_variable(sat)
             sat_add_var(sat, x); sat_add(sat)
             sat_add_var(sat, -x); sat_add(sat)
-            @test is_unsatisfiable(sat)
+            @test !sat_solve(sat)
             @test isempty(sat_mus(sat, L))
             @test isempty(sat_disjoint_muses(sat, L))
             @test isempty(sat_mcses(sat, L))
@@ -383,7 +383,7 @@ end
             @test sat_mcs(sat, L) === nothing
         end
         # popping the contradiction restores the instance
-        @test is_satisfiable(sat)
+        @test sat_solve(sat)
         @test sat_mus(sat, L) == first(sat_disjoint_muses(sat, L))
     finally
         finalize(sat)


### PR DESCRIPTION
`is_satisfiable(sat)` and `is_satisfiable(sat, reqs)` look like one function
with an optional argument. They ask different questions.

picosat consumes assumptions on solve, so the one-argument form means "solve
with whatever is staged" — it finishes a query someone else set up. That is
what every caller in `src/` uses it for: `SAT.jl:583` after `sat_assume(sat, p,
best)`, `Resolve.jl:42` after assuming a best class per package,
`UnsatCores.jl:76` inside `sat_solve_assuming`.

The trouble is that it *reads* as a question about the instance. With nothing
staged it answers that question instead — and the answer is always yes, because
installing no package satisfies any instance. Requirements are assumed rather
than asserted, so code that means `is_satisfiable(sat, reqs)` and writes
`is_satisfiable(sat)` gets a cheerful "satisfiable" back from a problem that
fails.

Not hypothetical: a measurement harness I wrote reported a known-unsatisfiable
registry problem (`DataFrames` with `PrettyTables = "99"`) as satisfiable, and
went 200 trials finding zero failures before I checked it against a case with a
known answer.

Requiring `reqs` or defaulting it is the wrong fix — it would delete a
primitive seven call sites and all of `UnsatCores` are built on, and a
non-empty default would silently change what staged-assumption callers compute.
So the fix is to put the staging in the name: `sat_solve`, joining
`sat_assume` / `sat_push` / `sat_pop` / `sat_add`, and sitting next to the
`sat_solve_assuming` that wraps it. `is_satisfiable` keeps only its two-argument
method, so no arity of it can answer a staged question while looking total.

Everything else is call sites. All 24 test uses were read individually rather
than replaced wholesale; every one turned out to be "solve now with what's
staged," so the rename preserves semantics throughout, including the two
bare-instance uses in `test/unsat_cores.jl` where "solve the instance" is still
the right reading.

`is_unsatisfiable` is untouched and still composes over the remaining method.
It has no in-tree caller now that its only one-argument use became
`!sat_solve(sat)` — happy to drop it if you would rather not keep a dead const.

Full suite green locally, including the bin tooling tests and workspaces.