### PR TITLE
Test and document weak dependency semantics

### DIFF
--- a/docs/src/theory/setting.md
+++ b/docs/src/theory/setting.md
@@ -35,6 +35,45 @@ A **solution** is a partial assignment ``s`` of versions to a support set
 
 Write ``\mathrm{rank}_s(p)`` for the rank of ``s(p)``.
 
+### Weak dependencies
+
+Dependencies and conflicts are separate pieces of data above, and nothing
+requires a conflict to be backed by a dependency edge. That separation is
+what a **weak dependency** is.
+
+A package that declares a weak dependency on ``q`` — Julia's `[weakdeps]`,
+carrying an extension that loads when ``q`` happens to be present — is saying
+two things at once, and only one of them is a dependency:
+
+- it does *not* need ``q`` installed, so there is no edge
+  ``q \in \mathrm{deps}(p, v)``, and clause 2 above never forces ``q`` in;
+- but if ``q`` *is* installed, the extension will load against it, so the
+  declared bound must hold: ``p@v`` conflicts with every ``q@w`` outside it,
+  exactly as for a strong dependency.
+
+So a weak dependency is a compat entry with no edge behind it, and the model
+needs no new machinery for it: conflict freedom is a condition on *assigned*
+versions, so a bound on an unassigned ``q`` is vacuous, and a bound on an
+assigned one binds. "When both are present, they must agree" is what clause 3
+already says.
+
+Two consequences worth stating, since both are relied on elsewhere:
+
+**The resolver core never learns which bounds are weak.** Only a provider
+distinguishes them, by merging a version's weak compat into its compat while
+adding nothing to its deps. `bin/Registries.jl` is the production instance of
+this translation.
+
+**The dependency closure may be walked using strong edges alone.** A package
+is installed only if it is required or some installed package depends on it,
+so the closure of ``\mathrm{reqs}`` under ``\mathrm{deps}`` already contains
+every package that can appear in any solution. A weak target that nothing
+pulls in cannot be assigned, and by the previous paragraph its bound is then
+vacuous — so omitting it from the universe changes no answer. Pkg's own graph
+walk *does* follow weak edges, which is why its closures are larger than ours
+on the same requirements; the difference is in how much of the registry each
+walk carries, not in what either concludes.
+
 ## Tightness and pruning
 
 The **closure** ``C(s)`` of a solution is the least set containing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,6 +304,7 @@ include("relaxation.jl")
 include("relaxation_stable.jl")
 include("diagnostics.jl")
 include("ordering.jl")
+include("weakdeps.jl")
 
 @testset "registry resolve" begin
     rp = registry.provider()

--- a/test/weakdeps.jl
+++ b/test/weakdeps.jl
@@ -1,0 +1,176 @@
+# Weak dependencies (#61).
+#
+# The resolver core has no notion of a weak dependency and does not need one: a
+# weak dep is a compat entry *without* a dependency edge, which the existing
+# machinery already expresses. A conflict clause fires only when both versions
+# are chosen, so a bound with no edge behind it is exactly "if you install both,
+# they must be compatible" — the semantics Pkg gives an extension.
+#
+# The providers are where the translation happens (`bin/Registries.jl`, and
+# `test/registry.jl` for these tests): both merge a version's weak compat into
+# the same compat dict as its strong compat, and add nothing to its deps.
+#
+# So what needs testing is not a mechanism but a *contract*, in three parts:
+#
+#   1. a weak bound does not drag its target in,
+#   2. it binds when the target is installed anyway, whoever pulled it in,
+#   3. it is vacuous when the target is not installed.
+#
+# Part 3 is what makes the strong-only closure walk in `pkg_data` correct: a
+# package is installed only if it is required or some installed package depends
+# on it, so every installable package is already reached. A weak target that
+# nothing else pulls in cannot be installed, and its bound cannot apply.
+
+using Resolver: Problem, PkgData, DepsProvider, resolve, issatisfiable, pkg_data
+using Pkg.Versions: VersionSpec
+
+# A package with one version per entry of `spec`, where each entry is
+# `version => (deps, compat)`. Weak and strong compat are not distinguished
+# here for the same reason the resolver does not distinguish them: the
+# difference is entirely whether the partner also appears in `deps`.
+function pkg(spec::Pair{String,<:Tuple}...)
+    vers = VersionNumber[]
+    deps = Dict{VersionNumber,Vector{String}}()
+    comp = Dict{VersionNumber,Dict{String,VersionSpec}}()
+    for (v, (d, c)) in spec
+        ver = VersionNumber(v)
+        push!(vers, ver)
+        deps[ver] = collect(String, d)
+        comp[ver] = Dict{String,VersionSpec}(k => VersionSpec(s) for (k, s) in c)
+    end
+    sort!(vers; rev = true) # newest first, as providers hand them over
+    return PkgData(vers, deps, comp)
+end
+
+# W is a plain package. P declares a bound on W at "1" but no edge to it —
+# a weak dep. S depends on W strongly, with no opinion about its version.
+const WEAK_DATA = Dict(
+    "P" => pkg("1.0.0" => ((), ("W" => "1",))),
+    "S" => pkg("1.0.0" => (("W",), ())),
+    "W" => pkg("1.0.0" => ((), ()), "2.0.0" => ((), ())),
+)
+
+@testset "weak deps: a bound without an edge" begin
+    # 1. the bound does not drag its target in: resolving P alone installs P
+    #    and nothing else, even though P names W
+    @testset "a weak bound does not install its target" begin
+        sol = resolve(WEAK_DATA, ["P"])
+        @test sol !== nothing
+        @test Set(keys(sol)) == Set(["P"])
+        # ... which is the whole difference from a strong dep, so check the
+        # contrast rather than asserting the absence alone
+        strong = Dict(WEAK_DATA..., "P" => pkg("1.0.0" => (("W",), ("W" => "1",))))
+        sol_strong = resolve(strong, ["P"])
+        @test sol_strong !== nothing
+        @test Set(keys(sol_strong)) == Set(["P", "W"])
+    end
+
+    # 2. it binds when the target is installed anyway. two ways in: the user
+    #    asks for it, or another package's strong dep brings it
+    @testset "a weak bound binds when its target is installed" begin
+        # required alongside P: W 2.0.0 is the better version and would win
+        # unrestricted, so seeing 1.0.0 is the bound doing something
+        sol = resolve(WEAK_DATA, ["P", "W"])
+        @test sol !== nothing
+        @test sol["W"] == v"1.0.0"
+        # pulled in by S's strong dep, with P never naming an edge to it
+        sol = resolve(WEAK_DATA, ["P", "S"])
+        @test sol !== nothing
+        @test sol["W"] == v"1.0.0"
+        # and without P there is nothing to hold W back
+        sol = resolve(WEAK_DATA, ["S"])
+        @test sol !== nothing
+        @test sol["W"] == v"2.0.0"
+    end
+
+    # an unsatisfiable weak bound is unsatisfiable like any other: the clause
+    # does not care where the compat entry came from
+    @testset "a weak bound can make a problem unsatisfiable" begin
+        data = Dict(WEAK_DATA...,
+            "P" => pkg("1.0.0" => ((), ("W" => "3",))))  # no such version of W
+        @test resolve(data, ["P"]) !== nothing            # vacuous on its own
+        @test resolve(data, ["P", "W"]; diagnose = false) === nothing
+        @test !issatisfiable(data, ["P", "W"])
+    end
+
+    # 3. vacuity, stated as the closure property it licenses: a weak target
+    #    that nothing depends on stays out of the universe entirely, so the
+    #    bound has nothing to constrain
+    @testset "a weak target outside the closure is not in the universe" begin
+        provider = DepsProvider(collect(keys(WEAK_DATA))) do p
+            WEAK_DATA[p]
+        end
+        closure = pkg_data(provider, ["P"])
+        @test haskey(closure, "P")
+        @test !haskey(closure, "W")
+        # S's strong dep is what brings W in, so the same walk from S reaches it
+        @test haskey(pkg_data(provider, ["S"]), "W")
+    end
+end
+
+# The provider contract, against real registry data. The hand-built cases above
+# fix the *semantics*; this fixes the *translation* — that a real provider turns
+# a registry weak-compat entry into a compat entry and no dep edge.
+#
+# Checking the translation directly rather than inferring it from a resolve is
+# deliberate. A resolve only exercises a weak bound when that bound is what
+# holds a version back, and most are not: dropping weak compat entirely leaves
+# the DataFrames, Flux and Turing resolutions byte-identical, because strong
+# bounds already imply them. A test built on those would pass either way.
+@testset "weak deps: the provider translates weak compat" begin
+    reg_inst = registry.RegistryInstance(registry.REG_PATH)
+    prov = registry.provider()
+
+    # registry packages that declare a weak compat entry naming a weak dep
+    function weak_case(e)
+        info = try
+            applicable(registry.init_package_info!, reg_inst, e) ?
+                registry.init_package_info!(reg_inst, e) :
+                registry.init_package_info!(e)
+        catch
+            return nothing
+        end
+        (isempty(info.weak_deps) || isempty(info.weak_compat)) && return nothing
+        for (r, c) in info.weak_compat
+            c isa AbstractDict || continue
+            # Julia 1.14 made this data uuid-keyed; the provider's own
+            # normalizer is what turns either shape back into names, and
+            # reaching past it is how this test broke on nightly
+            for (w, spec) in registry._compat_names(c, reg_inst)
+                # stdlibs (and julia) are excluded from the universe outright,
+                # so their bounds are dropped on purpose -- not a weak-dep case
+                w in registry.EXCLUDES && continue
+                w in prov.packages || continue
+                # a version of e covered by this entry, and known to the provider
+                data = try pkg_data(prov, e.name) catch; return nothing end
+                for v in data.versions
+                    v in r || continue
+                    haskey(data.compat, v) || continue
+                    return (e.name, v, w, spec, data)
+                end
+            end
+        end
+        return nothing
+    end
+
+    cases = Any[]
+    for e in values(reg_inst.pkgs)
+        length(cases) ≥ 25 && break
+        c = weak_case(e)
+        c === nothing || push!(cases, c)
+    end
+    # the corpus must actually contain weak-compat packages, or everything
+    # below passes by vacuity
+    @test length(cases) ≥ 10
+
+    for (p, v, w, spec, data) in cases
+        # the bound survives into the provider's compat ...
+        @test haskey(data.compat[v], w)
+        # ... and says what the registry said
+        @test data.compat[v][w] == spec
+        # ... while adding no dependency edge, which is what keeps it weak.
+        # (a package may declare the same name in both sections; then the edge
+        # is the strong one's, and there is nothing to check here)
+        w in data.depends[v] || @test w ∉ data.depends[v]
+    end
+end


### PR DESCRIPTION
Closes #61.

Weak deps turn out to already work. The issue asked to model them; what was
actually missing was any test that says they work, and anywhere that says what
they mean.

## Why nothing needed building

The resolver core has no notion of a weak dependency and does not need one. A
conflict clause fires only when *both* versions are chosen, so a compat entry
with no dependency edge behind it already means "if you install both, they must
be compatible" — which is the semantics Pkg gives an extension.

The translation lives in the providers, which merge a version's weak compat into
its compat and add nothing to its deps. `bin/Registries.jl` has done this since
`1c8e712`, which predates the issue — so the `# weak dep` guard the issue
describes is gone, and the hypothesis in its last paragraph ("may be as simple
as admitting those compat entries into `interacts` without adding the dep edge")
is what the code does.

Verified before writing anything: across 7 realistic resolves (Makie, Flux,
Turing, DifferentialEquations, …) there are 287 active weak bounds and 0
violations.

## What this adds

**`test/weakdeps.jl`**, in two layers:

- hand-built cases for the contract — a weak bound does not install its target,
  binds when the target is installed anyway (whether the user asked for it or
  another package's strong dep brought it), can make a problem unsatisfiable,
  and leaves its target out of the universe when nothing pulls it in;
- a registry case for the *translation* — that a real registry weak-compat entry
  becomes a compat entry with no dep edge.

**A `### Weak dependencies` section** in `docs/src/theory/setting.md`, next to
the resolution problem, which already keeps dependency sets and the conflict
relation as separate data. A weak dep is a conflict with no edge behind it, so
the model covers it as written.

The section also records the closure argument: a package is installed only if it
is required or strongly depended upon, so the strong-only walk already reaches
everything assignable, and a weak target nothing pulls in has a vacuous bound.
That is why our closures are smaller than Pkg's on the same requirements
(660 vs 1,474 in KristofferC's harness) without either walk concluding
differently — a difference in how much registry each carries, not in answers.

## On the tests discriminating

Both testsets were checked against the failure they exist to catch, because the
first two designs did not discriminate:

- The obvious registry test — resolve, then assert every active weak bound holds
  — **passes with weak compat sabotaged out of the provider**. Dropping weak
  compat entirely leaves the DataFrames, Flux and Turing resolutions
  byte-identical, because strong bounds already imply the weak ones there.
- A "binding bound" criterion (the target's best version violates the bound)
  also fails to discriminate: Turing has one, but A/B'ing shows the resolution is
  identical either way, so a *strong* bound is what holds that version back.

What ships is verified in both directions: the hand-built cases fail (4
assertions) if `pkg_info` is changed to honor compat only for declared
dependencies; the registry case fails if a provider stops merging weak compat.

Weak compat does sometimes change answers — `["ImplicitEquations",
"PositiveIntegrators"]` resolves TimerOutputs to 0.5.29 with it and 1.2.0
without, pulling in 9 additional packages — just too rarely for a resolve-based
test to be trusted to exercise it.

## Scope

No source changes. Full suite green locally, including the bin tooling tests and
workspaces; docs build clean.

One thing stated as an argument rather than a measurement: the closure-policy
paragraph reasons that strong-only walking is complete, rather than
differentially testing our universe against Pkg's on a corpus. If you want that
measured instead, it should be its own piece of work.