### PR TITLE
Present minimal fixes as a factored product of independent choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Resolver.jl separates *what* to optimize from *how* to solve, handing the solvin
     - a version's dependencies must be present, and
     - conflicting versions cannot both be chosen.
 - Before solving, the problem is shrunk by **reachability analysis** (keeping only versions that could appear in a solution) and **redundancy elimination** (dropping versions that are strictly dominated by others).
-- The solution is optimized **lexicographically, one package at a time**, against a caller-supplied priority order. If the problem is satisfiable, the resolver returns the unique Pareto-optimal resolution that version order and package priority determine. If it is unsatisfiable, it returns a **diagnosis**: which requirements and user constraints are in conflict, why, and a menu of verified fixes.
+- The solution is optimized **lexicographically, one package at a time**, against a caller-supplied priority order. If the problem is satisfiable, the resolver returns the unique Pareto-optimal resolution that version order and package priority determine. If it is unsatisfiable, it returns a **diagnosis**: which requirements and user constraints are in conflict, why, and a menu of verified fixes for each of them.
 - Because the preference order is supplied per package, different strategies — newest, oldest/downgrade, prefer-installed, keep-current — can be mixed **within a single resolve**.
 
 The core resolver in [`src/`](src/) is generic: it knows nothing about Julia versions or registries. The [`bin/resolve.jl`](bin/resolve.jl) command-line tool adapts it to Julia's real registries and can emit a `Manifest.toml`.

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -536,13 +536,14 @@ function named(d::Resolver.Diagnosis, name::Function)
     Resolver.Diagnosis(
         [Diagnostics.Conflict{String,VersionNumber}(
             String[name(p) for p in c.reqs],
-            Diagnostics.Fact[named(f, name) for f in c.chain])
+            Diagnostics.Fact[named(f, name) for f in c.chain],
+            [Diagnostics.Fix{String,VersionNumber}(
+                [Diagnostics.Action(a.kind, name(a.pkg)) for a in fix.actions],
+                Dict{String,VersionNumber}(
+                    name(p) => v for (p, v) in fix.solution))
+             for fix in c.fixes])
          for c in d.conflicts],
-        [Diagnostics.Fix{String,VersionNumber}(
-            [Diagnostics.Action(a.kind, name(a.pkg)) for a in fix.actions],
-            Dict{String,VersionNumber}(
-                name(p) => v for (p, v) in fix.solution))
-         for fix in d.fixes])
+        d.others)
 end
 
 named(f::Diagnostics.Requirement, name::Function) =

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -713,7 +713,7 @@ end
         @test occursin("you require LinearAlgebra", msg)
         @test occursin("no version of LinearAlgebra is available", msg)
         # (the report is filled to a line width, so the clause may be broken)
-        @test occursin("are excluded by", msg)
+        @test occursin("excluded by", msg)
         @test occursin("Fix it by any one of:", msg)
         @test occursin("relax your compat on LinearAlgebra", msg)
         @test !occursin(string(LINEAR_ALGEBRA), msg)

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -714,7 +714,7 @@ end
         @test occursin("no version of LinearAlgebra is available", msg)
         # (the report is filled to a line width, so the clause may be broken)
         @test occursin("are excluded by", msg)
-        @test occursin("Verified fixes:", msg)
+        @test occursin("Fix it by any one of:", msg)
         @test occursin("relax your compat on LinearAlgebra", msg)
         @test !occursin(string(LINEAR_ALGEBRA), msg)
         # and nothing of how the answer was found

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,8 +4,8 @@ A package version resolver built on a real SAT solver (PicoSAT). Given
 package data — versions, dependencies, and compatibility constraints — and a
 set of required packages, [`resolve`](@ref) returns a single optimal solution
 mapping each needed package to a version, or a [`Diagnosis`](@ref) — which
-requirements cannot hold together, why, and a menu of verified fixes — when
-they cannot be satisfied.
+requirements cannot hold together, why, and a menu of verified fixes for
+each of them — when they cannot be satisfied.
 
 What "optimal" means, precisely, and why the resolver's aggressive problem
 filtering provably does not change the answer, is worked out in the Theory

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,6 +7,41 @@ mapping each needed package to a version, or a [`Diagnosis`](@ref) — which
 requirements cannot hold together, why, and a menu of verified fixes for
 each of them — when they cannot be satisfied.
 
+A diagnosis reads like this. Two requirements fail for unrelated reasons, so
+each gets its own menu, and any one alternative from each menu resolves the
+query:
+
+```
+Unsatisfiable — 2 conflicts, each of which must be fixed:
+
+Conflict 1: DataFrames cannot be satisfied.
+  • you require DataFrames
+  • DataFrames: 0.11.7–0.22.7 excluded by your compat
+  • no version of PrettyTables is available: 0.1.0–3.4.8 excluded by your
+    compat
+  Fix it by any one of:
+    1. relax your compat on DataFrames
+       → allows: DataFrames 0.21.8
+    2. relax your compat on PrettyTables
+       → allows: DataFrames 1.8.2, PrettyTables 3.4.8
+    3. drop requirement DataFrames
+
+Conflict 2: Plots cannot be satisfied.
+  • you require Plots
+  • no version of RecipesBase is available: 0.4.0–1.3.4 excluded by your
+    compat
+  Fix it by any one of:
+    1. relax your compat on RecipesBase
+       → allows: Plots 1.41.0, RecipesBase 1.3.4
+    2. drop requirement Plots
+```
+
+Every fix is *verified*: the version list after each one is what a resolve of
+the fixed query actually returns, not a guess. When the menus do not reach
+every minimal fix the report says so — "Larger solutions also exist." when the
+ones left out cost more, "Other solutions also exist." when it cannot promise
+even that — and says nothing at all when the menus are the whole of it.
+
 What "optimal" means, precisely, and why the resolver's aggressive problem
 filtering provably does not change the answer, is worked out in the Theory
 section:

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -144,7 +144,28 @@ anything. A MUS of it therefore exists, and it must contain ``c_i``, since
 withdrawing ``c_i`` as well is withdrawing all of ``M``, which does repair.
 And it contains no other literal of ``M``, because those were withdrawn
 before the question was asked. So the ``i``-th conflict gets a story about
-its own choice and nobody else's — one MUS extraction per coordinate.
+its own choice and nobody else's.
+
+A MUS is not the whole story, though, and the gap is one a report cannot
+afford. Several requirements can fail for one and the same reason; one of
+them is already enough to make that reason unsatisfiable, so a MUS names one
+of them — arbitrarily — and drops the rest as redundant. They are not
+redundant to the user: they are required, they are broken, and this
+conflict's fix is what rescues them. A report that omitted them would let
+someone relax the bound and never learn what else had been failing.
+
+So each requirement the MUS left out is asked one further question: is it
+satisfiable on its own, against the packages as this coordinate finds them
+(that is, with every *other* coordinate's choice already made)? If it is
+not, then it is one this coordinate rescues — because applying ``c_i`` on
+top is applying all of ``M``, and ``M`` repairs the query, so every
+requirement of the query is satisfiable afterwards. Each such requirement
+brings its own MUS, and the chain is the union.
+
+The chain is therefore a union of minimal conflicts rather than a single
+one: unsatisfiable, with every fact in it belonging to at least one of them,
+but not with every fact load-bearing for the whole. A conflict whose
+requirements fail *together* is the special case where there is only one.
 
 ### What the menus leave out
 

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -233,8 +233,8 @@ would want it to hold, so the assumptions a model *satisfies* are the ones the
 repair it witnesses leaves alone. Ruling ``M_i`` out is therefore asking for
 one of its literals, not against it.
 
-A report says nothing when neither holds, "Other, larger solutions exist."
-when only the first does, and "Other solutions exist." whenever the second
+A report says nothing when neither holds, "Larger solutions also exist."
+when only the first does, and "Other solutions also exist." whenever the second
 does. Exploring those other solutions is a question this page does not
 answer.
 

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -108,6 +108,41 @@ set of them whose withdrawal is satisfiable and no proper subset of which is
 A member of ``F_{\min}`` gives up as few of the user's own facts as any
 repair of the query can.
 
+Only ``F_{\min}`` is ever enumerated, and the way to enumerate just it is to
+refuse to look at anything bigger. A repair is the set of assumptions a model
+leaves unsatisfied, so "no repair bigger than ``k``" is an at-most-``k``
+constraint over their negations — a few clauses over counting variables — and
+the bound turns the enumeration into the one that is wanted.
+
+!!! note "Observation (a bound cuts the family off rather than changing it)"
+    Let ``B_k`` be the instance together with a constraint that at most ``k``
+    of the assumptions go unsatisfied. Then ``B_k`` is satisfiable exactly
+    when ``F`` has a member of size ``k`` or less, and the minimal correction
+    sets of ``B_k`` are exactly those members.
+
+    *Proof.* A model of ``B_k`` is a model of the instance leaving at most
+    ``k`` assumptions unsatisfied, and the set it leaves unsatisfied is a
+    correction set, which contains a minimal one; conversely a member of
+    ``F`` of size ``k`` or less is witnessed by a model that leaves exactly
+    it unsatisfied, and that model satisfies ``B_k``. So the two are
+    satisfiable together.
+
+    Let ``C`` be a minimal correction set of ``B_k``, witnessed by a model
+    ``\mu`` of ``B_k``. The assumptions ``\mu`` leaves unsatisfied are a
+    subset of ``C`` and a correction set of ``B_k``, so by minimality they
+    are ``C`` itself, and ``|C| \le k``. And ``C`` is minimal for the
+    instance: anything strictly inside it is smaller than ``k`` too, so it is
+    a correction set of ``B_k`` if it is one at all, which minimality
+    forbids. The converse is the same statement read backwards — a correction
+    set of the instance of size ``k`` or less is one of ``B_k``, and
+    minimality for the instance is minimality for ``B_k`` since ``B_k`` has
+    the fewer models. ∎
+
+So raising ``k`` from 1 until ``B_k`` becomes satisfiable finds the size of a
+smallest repair — ``k`` is 2 to 6 on the registry queries this was measured on,
+so it is a handful of solves, and each counter is as small as the answer — and
+enumerating at that bound enumerates ``F_{\min}`` and nothing else.
+
 !!! note "Observation (a family that counts right is a product)"
     Let ``C_1, \dots, C_k`` partition the literals ``F_{\min}`` uses, and
     suppose every ``M \in F_{\min}`` contains exactly one literal of each
@@ -171,11 +206,32 @@ requirements fail *together* is the special case where there is only one.
 
 Two things can be true beyond what the menus say, and they are independent:
 
-* ``F \ne F_{\min}``: repairs exist that give up more than these do.
+* ``F \ne F_{\min}``: repairs exist that give up more than these do. With
+  ``F_{\min}`` in hand this is decided exactly, by one solve.
 * ``F_{\min}`` is not a product: then the best that can be offered is the
   largest *rectangle* in it — a set of literals every repair in the
   rectangle shares, together with the alternatives that complete it — and
   the repairs outside the rectangle are cheapest ones the menus never reach.
+
+!!! note "Observation (one solve decides whether anything larger exists)"
+    Let ``F_{\min} = \{M_1, \dots, M_t\}`` be *all* the repairs of smallest
+    size, and add to the instance the clause ``\bigvee_{c \in M_i} c`` for
+    each ``i``. The result is satisfiable exactly when ``F \ne F_{\min}``.
+
+    *Proof.* Write ``U(\mu)`` for the assumptions a model ``\mu`` leaves
+    unsatisfied; it is a correction set, and the clause for ``M_i`` says
+    exactly that ``M_i \not\subseteq U(\mu)``. So a model of the augmented
+    instance has a ``U(\mu)`` containing no ``M_i``; the minimal correction
+    set inside it is therefore none of them, and ``F`` has a member outside
+    ``F_{\min}``. Conversely let ``N \in F \setminus F_{\min}``. A model
+    witnessing ``N`` leaves exactly ``N`` unsatisfied, and no ``M_i`` is
+    inside ``N``, since two distinct minimal correction sets are
+    incomparable — so that model satisfies every added clause. ∎
+
+Note which way round the clause goes: an assumption is stated as the user
+would want it to hold, so the assumptions a model *satisfies* are the ones the
+repair it witnesses leaves alone. Ruling ``M_i`` out is therefore asking for
+one of its literals, not against it.
 
 A report says nothing when neither holds, "Other, larger solutions exist."
 when only the first does, and "Other solutions exist." whenever the second

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -95,6 +95,72 @@ the query empties is **deactivated, not deleted**. It keeps its row, its
 column in every partner, and its dependency columns, which is exactly what
 a question about giving it back needs to find still there.
 
+## Conflicts are the coordinates of the repairs
+
+A report hands out one menu per conflict and invites the reader to choose
+from each of them independently. What that claims is that *every*
+combination of choices repairs the query, and it is not something checked
+after the fact: it is how the conflicts are found in the first place.
+
+Write ``F`` for the minimal correction sets of the assumptions above — every
+set of them whose withdrawal is satisfiable and no proper subset of which is
+(`sat_mcses`) — and ``F_{\min} \subseteq F`` for the ones of smallest size.
+A member of ``F_{\min}`` gives up as few of the user's own facts as any
+repair of the query can.
+
+!!! note "Observation (a family that counts right is a product)"
+    Let ``C_1, \dots, C_k`` partition the literals ``F_{\min}`` uses, and
+    suppose every ``M \in F_{\min}`` contains exactly one literal of each
+    ``C_i``, and that ``|F_{\min}| = \prod_i |C_i|``. Then
+    ``F_{\min} = C_1 \times \dots \times C_k``.
+
+    *Proof.* Sending each ``M`` to the tuple of its literals is well defined
+    by the first hypothesis and injective because a set is determined by its
+    elements. An injection between finite sets of equal size is a bijection,
+    so every tuple is some ``M``. ∎
+
+Both hypotheses are cheap to check, and the partition to check them against
+is forced: literals of the same ``C_i`` never share a repair, so the
+candidate partition is the connected components of "never share a repair",
+and if any partition works that one does. So the report offers ``C_i`` as
+its ``i``-th conflict and the literals of ``C_i`` as that conflict's menu.
+Every path through the menus is a member of ``F_{\min}`` — a repair, and one
+of the cheapest. Nothing is left to compose and nothing is left to warn
+about.
+
+It also follows that there are exactly as many conflicts as a cheapest
+repair has literals. The conflict count is not an artifact of how the search
+went: it is the size of the smallest fix.
+
+### The story of a coordinate
+
+A menu says what to choose between without saying why. Fix any
+``M \in F_{\min}``, and for the ``i``-th coordinate let ``c_i`` be its
+literal of ``M``. Withdraw ``M \setminus \{c_i\}`` — every *other*
+coordinate settled the way ``M`` settles it — and ask what is left.
+
+It is unsatisfiable: ``M`` is minimal, so no proper subset of it repairs
+anything. A MUS of it therefore exists, and it must contain ``c_i``, since
+withdrawing ``c_i`` as well is withdrawing all of ``M``, which does repair.
+And it contains no other literal of ``M``, because those were withdrawn
+before the question was asked. So the ``i``-th conflict gets a story about
+its own choice and nobody else's — one MUS extraction per coordinate.
+
+### What the menus leave out
+
+Two things can be true beyond what the menus say, and they are independent:
+
+* ``F \ne F_{\min}``: repairs exist that give up more than these do.
+* ``F_{\min}`` is not a product: then the best that can be offered is the
+  largest *rectangle* in it — a set of literals every repair in the
+  rectangle shares, together with the alternatives that complete it — and
+  the repairs outside the rectangle are cheapest ones the menus never reach.
+
+A report says nothing when neither holds, "Other, larger solutions exist."
+when only the first does, and "Other solutions exist." whenever the second
+does. Exploring those other solutions is a question this page does not
+answer.
+
 ## Versions come from a resolve, not from the instance
 
 Theorem C is about the answer, but the questions above only ask about

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -208,11 +208,17 @@ end
     Resolver.Diagnostics.Conflict{P,V}(reqs, chain, fixes)
 
 One independent choice the query leaves the user: the requirements `reqs`,
-which cannot hold together, `chain`, a short sequence of
+which cannot all hold, `chain`, a short sequence of
 [`Fact`](@ref Resolver.Diagnostics.Fact)s about the packages that says why, and
 `fixes`, the menu of [`Fix`](@ref Resolver.Diagnostics.Fix)es that settle it.
-Every fact in the chain is load-bearing — take any one of them away and the
-rest of the conflict dissolves.
+
+`reqs` is every requirement this conflict's fixes rescue, which need not be one
+thing that fails: requirements can fail together, or each on its own for a
+reason they have in common, and a conflict gathers both. So the chain is
+unsatisfiable and nothing in it is a passenger — every fact belongs to some
+minimal reason the requirements cannot hold — but it is a *union* of those
+reasons rather than a single one, and taking a fact away need not dissolve all
+of them.
 
 The conflicts of a [`Diagnosis`](@ref) are independent in that each has to be
 fixed and any fix of one goes with any fix of another. Their *stories* may well
@@ -380,8 +386,12 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis{P,V}) where {P,V}
     for (k, c) in enumerate(d.conflicts)
         println(io)
         subject = list_phrase(String[string(p) for p in c.reqs])
-        println(io, "Conflict $k: $subject cannot be satisfied",
-            length(c.reqs) > 1 ? " together." : ".")
+        # a conflict can gather requirements that fail together and
+        # requirements that each fail on their own, so what is said of them is
+        # what is true of both: the conjunction is what cannot hold
+        println(io, "Conflict $k: $subject cannot ",
+            length(c.reqs) == 1 ? "be satisfied." :
+            length(c.reqs) == 2 ? "both be satisfied." : "all be satisfied.")
         for f in c.chain
             f isa Requirement ?
                 println(io, "  • you require $(f.pkg)") :
@@ -425,6 +435,12 @@ end
 # and what a truncated enumeration costs is not a fix but a claim: the smallest
 # of the repairs found still factor into conflicts and their menus still repair
 # the query, but the report can no longer say that nothing else would.
+#
+# Truncation is deliberately reported as `:some` — the same thing a family that
+# is not a product reports — because the sentence is the same either way: there
+# are repairs the menus do not offer. It says less than it could, in a case that
+# is rare enough (the ceiling is an order of magnitude above what was measured)
+# that a third sentence would be a shape of report nobody has read.
 const MAX_REPAIRS = 256
 
 # The literals a diagnosis assumes, read back as what they say about the
@@ -497,12 +513,28 @@ function with_emptied_packages(body::Function, sat::SAT{P}, vm::VarMap{P}) where
     end
 end
 
-# The story of one conflict: the smallest set of the query's own facts that is
-# still unsatisfiable, drawn from the ones it is asked about. Deletion is
+# The story of one conflict: the query's own facts that this conflict's fix is
+# what rescues, and why each of them needs rescuing.
+#
+# The smallest unsatisfiable set of them is where it starts. Deletion is
 # attempted in the order given, so putting the requirements first drops the ones
-# the story does not need and keeps the facts the user can act on. The answer is
-# a subsequence of what was asked, so the requirements come back in the
-# problem's requirement order and the emptied packages in package order.
+# that set does not need and keeps the facts the user can act on.
+#
+# But "does not need" is the trap. Several requirements can fail for one and the
+# same reason, and one of them is enough to make that reason a conflict — so the
+# smallest set names one of them, arbitrarily, and the others go unmentioned
+# though this conflict's fix is what rescues them too. A user would fix the
+# bound and never learn the rest had been broken. So every requirement the set
+# left out is asked whether it can be satisfied on its own against the packages
+# as this conflict finds them; the ones that cannot are exactly the ones this
+# fix rescues, since the fixes of the other conflicts are already in force here
+# and carrying this one out satisfies the query. Each of those brings its own
+# smallest explanation, and the chain is all of them at once.
+#
+# One `sat_mus` call per requirement, which answers both questions: empty when
+# the requirement is satisfiable, and its explanation when it is not. What comes
+# back is a subsequence of what was asked, so the requirements are in the
+# problem's requirement order and the packages in package order.
 function conflict_story(
     sat     :: SAT{P,V},
     prob    :: Problem{P},
@@ -510,11 +542,17 @@ function conflict_story(
     emptied :: Dict{Int,P}, # per package literal, the package
     cands   :: Vector{Int},
 ) where {P,V}
-    mus = sat_mus(sat, cands)
+    named = Set{Int}(sat_mus(sat, cands))
+    pkgs = Int[l for l in cands if haskey(emptied, l)]
+    for l in cands
+        (haskey(emptied, l) || l in named) && continue
+        union!(named, sat_mus(sat, Int[l; pkgs]))
+    end
     reqs = P[]
     chain = Fact[]
     avails = Fact[]
-    for l in mus
+    for l in cands
+        l in named || continue
         p = get(emptied, l, nothing)
         if p === nothing
             q, _ = decode(vm, l)

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -304,7 +304,7 @@ end
 # An availability fact as one line. The fact runs over the package's whole
 # version list, so every maximal run of versions excluded by the same kinds is a
 # range and gets one clause, and the runs it admits are simply not mentioned;
-# the clauses after the first drop the verb, as an English list of them would.
+# the clauses after the first drop "excluded", as an English list of them would.
 function availability_phrase(f::Availability)
     members, excluded = f.members, f.excluded
     clauses = String[]
@@ -315,10 +315,9 @@ function availability_phrase(f::Availability)
             j += 1
         end
         if !isempty(excluded[i])
-            verb = i == j ? "is" : "are"
             by = kinds_phrase(excluded[i])
             push!(clauses, isempty(clauses) ?
-                "$(range_phrase(members, i, j)) $verb excluded by $by" :
+                "$(range_phrase(members, i, j)) excluded by $by" :
                 "$(range_phrase(members, i, j)) by $by")
         end
         i = j + 1

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -28,7 +28,7 @@ export Diagnosis, Conflict, Fix, Action, Fact, Requirement, Availability,
 
 using ..Resolver: SAT, Problem, Universe, relax, resolve, installed_lit,
     with_temp_clauses, with_classes_relaxed, sat_new_variable, sat_add_var,
-    sat_add, exclusion_kinds, class_exclusions
+    sat_add, sat_solve, exclusion_kinds, class_exclusions
 using ..UnsatCores: sat_mus, sat_mcses
 
 # What an unsatisfiable resolve says, and how it is found.
@@ -426,14 +426,17 @@ end
 
 ## the diagnosis
 
-# How many repairs to enumerate before settling for the ones already found.
-# What is enumerated over is the requirements and the packages this query left
-# short, of which there are few — 6 to 36 repairs on the registry queries this
-# was measured on — so it is a ceiling rather than the usual stopping point.
+# How many of the smallest repairs to enumerate before settling for the ones
+# already found. What is enumerated over is the requirements and the packages
+# this query left short, of which there are few, and only the smallest repairs
+# among them — a median of 2 of them on the registry queries this was measured
+# on — so it is a ceiling rather than the usual stopping point.
 # Independent conflicts multiply, though, so there can be exponentially many,
-# and what a truncated enumeration costs is not a fix but a claim: the smallest
-# of the repairs found still factor into conflicts and their menus still repair
-# the query, but the report can no longer say that nothing else would.
+# and what a truncated enumeration costs is not a fix but a claim: the repairs
+# found still factor into conflicts and their menus still repair the query, but
+# the report can no longer say that nothing else would, nor ask whether
+# anything larger exists — that question is put by ruling every one of the
+# smallest repairs out, so it needs all of them.
 #
 # Truncation is deliberately reported as `:some` — the same thing a family that
 # is not a product reports — because the sentence is the same either way: there
@@ -441,6 +444,116 @@ end
 # is rare enough (the ceiling is an order of magnitude above what was measured)
 # that a third sentence would be a shape of report nobody has read.
 const MAX_REPAIRS = 256
+
+# "At most `k` of `lits` hold", as clauses over counting variables: Sinz's
+# sequential counter, where the variable for `(i, j)` says that at least `j` of
+# the first `i` literals hold. Nothing forces one of those variables down, only
+# up, so the last clause of each row — which refuses a literal once `k` are
+# already counted — is the whole of what is being asked, and any assignment with
+# `k` or fewer literals true extends to a model by counting honestly.
+#
+# The counter is built for the bound it is asked about rather than for the whole
+# range, so a small bound costs a small counter, and nothing is asked at all
+# when the bound leaves the literals alone. `counts` is the caller's own store
+# of counting variables, extended here when a bound needs more than it holds: a
+# variable outlives the frame that gave it meaning and the solver goes on
+# deciding it afterwards, so a search that raises the bound step by step hands
+# the same store back and leaves one counter behind rather than one per step.
+function add_at_most!(sat::SAT, lits::Vector{Int}, k::Int, counts::Vector{Int})
+    n = length(lits)
+    @assert k ≥ 1
+    k < n || return sat
+    while length(counts) < (n-1)*k
+        push!(counts, sat_new_variable(sat))
+    end
+    at(i, j) = counts[(i-1)*k + j]
+    function clause(ls::Int...)
+        for l in ls
+            sat_add_var(sat, l)
+        end
+        sat_add(sat)
+    end
+    clause(-lits[1], at(1, 1))
+    for j = 2:k
+        clause(-at(1, j))
+    end
+    for i = 2:n-1
+        clause(-lits[i], at(i, 1))
+        clause(-at(i-1, 1), at(i, 1))
+        for j = 2:k
+            clause(-lits[i], -at(i-1, j-1), at(i, j))
+            clause(-at(i-1, j), at(i, j))
+        end
+        clause(-lits[i], -at(i-1, k))
+    end
+    clause(-lits[n], -at(n-1, k))
+    return sat
+end
+
+# Every repair of the smallest size there is, and nothing larger paid for along
+# the way.
+#
+# A repair is the candidates a model leaves unsatisfied, so "no repair larger
+# than `k`" is a bound on how many of them a model may leave — one at-most-`k`
+# constraint over their negations. Under that bound the instance is satisfiable
+# exactly when a repair that small exists, and its minimal correction sets are
+# exactly the query's own repairs of that size or less: a model the bound
+# admits is one the query admits, and anything smaller than a repair the bound
+# admits fits under the bound too, so minimal here and minimal at large are the
+# same thing.
+#
+# So the size of the smallest repair is found by raising the bound until the
+# instance gives way, and enumerating at that bound enumerates exactly the
+# smallest repairs. The sizes seen in practice are 2 to 6, so counting up costs
+# a handful of solves and keeps every counter as small as the answer; a bound of
+# `k-1` that failed is what makes `k` the smallest size, so what comes back at
+# `k` is all of the smallest repairs, not merely some.
+#
+# Dropping every candidate is a repair, so the last bound worth trying is the
+# one that forbids nothing — which is the plain enumeration, and also what a
+# query with no candidate to give up at all wants.
+function smallest_repairs(sat::SAT, cands::Vector{Int}, limit::Int)
+    relaxed = Int[-l for l in cands]
+    counts = Int[]
+    for k = 1:length(cands)-1
+        repairs = with_temp_clauses(sat) do
+            add_at_most!(sat, relaxed, k, counts)
+            sat_solve(sat) ? sat_mcses(sat, cands; limit) : nothing
+        end
+        repairs === nothing || return repairs
+    end
+    return sat_mcses(sat, cands; limit)
+end
+
+# Whether the query has a repair that costs more than the smallest ones do.
+#
+# `smallest` has to be all of the smallest repairs. Ask for a model that leaves
+# a candidate of each of them satisfied: one clause per repair, the plain
+# disjunction of its candidates, since the repair a model witnesses is the
+# candidates it does *not* satisfy. What that model witnesses is then a repair
+# holding none of the smallest ones, so the minimal repair inside it is none of
+# them either, and — all of the smallest being here — is a larger one.
+#
+# There is such a model whenever a larger repair exists: the model witnessing
+# that repair leaves exactly it unsatisfied, and no smallest repair sits inside
+# it, since one minimal repair never contains another. So the answer is exact.
+#
+# Each candidate says something the query asked for — this package installed,
+# this package's emptied classes left empty — so the candidates a model
+# satisfies are the ones the repair it witnesses does not touch, and ruling a
+# repair out is a disjunction of that repair's own literals rather than of their
+# negations.
+function larger_repair_exists(sat::SAT, smallest::Vector{Vector{Int}})
+    with_temp_clauses(sat) do
+        for repair in smallest
+            for l in repair
+                sat_add_var(sat, l)
+            end
+            sat_add(sat)
+        end
+        sat_solve(sat)
+    end
+end
 
 # The literals a diagnosis assumes, read back as what they say about the
 # universe. Package variables are laid out in blocks — the package itself, then
@@ -750,20 +863,17 @@ function diagnose(
             # relaxing a constraint to dropping a dependency, and so that a
             # story drops the requirements it does not need
             cands = [req_lits; pkg_lits]
-            repairs = sat_mcses(sat, cands; limit = MAX_REPAIRS)
-            # the instance is satisfiable with nothing assumed — install
-            # nothing — so there is always a repair to be found
-            @assert !isempty(repairs)
-            smallest = minimum(length, repairs)
-            cheapest = filter(r -> length(r) == smallest, repairs)
+            cheapest = smallest_repairs(sat, cands, MAX_REPAIRS)
             choices, whole = factor_repairs(cheapest)
             order_choices!(choices, cands, length(req_lits))
             # what the menus leave out: nothing when they reach every cheapest
-            # repair and no repair costs more than the cheapest. A truncated
-            # enumeration has both left to prove and repairs it never saw
+            # repair and no repair costs more than the cheapest. The second is
+            # a question to put to the instance, and putting it takes every
+            # cheapest repair, so a truncated enumeration has to leave both
+            # unanswered
             others =
-                length(repairs) ≥ MAX_REPAIRS || !whole ? :some :
-                length(cheapest) < length(repairs) ? :larger : :none
+                length(cheapest) ≥ MAX_REPAIRS || !whole ? :some :
+                larger_repair_exists(sat, cheapest) ? :larger : :none
             # A story explains one choice by settling all the others: drop the
             # rest of one repair from what may be assumed, and what is left is
             # still unsatisfiable, minimally so once this choice is made. The

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -6,10 +6,11 @@ questions to the universe a failed resolve was run against and the instance it
 failed on, and answers with a [`Diagnosis`](@ref): the independent
 [`Conflict`](@ref Resolver.Diagnostics.Conflict)s — sets of requirements that
 cannot hold together, each with a chain of
-[`Fact`](@ref Resolver.Diagnostics.Fact)s about the packages that says why —
-and a menu of [`Fix`](@ref Resolver.Diagnostics.Fix)es, each a set of
+[`Fact`](@ref Resolver.Diagnostics.Fact)s about the packages that says why, and
+a menu of [`Fix`](@ref Resolver.Diagnostics.Fix)es for it, each a set of
 [`Action`](@ref Resolver.Diagnostics.Action)s the user could carry out together
-with the solution that carrying them out yields.
+with the solution that carrying them out yields. One fix from every conflict's
+menu, chosen any way at all, repairs the query.
 
 A `Diagnosis` is plain data, so a caller can render its own report from one
 without asking the resolver anything further; `show(io, MIME("text/plain"), d)`
@@ -28,7 +29,7 @@ export Diagnosis, Conflict, Fix, Action, Fact, Requirement, Availability,
 using ..Resolver: SAT, Problem, Universe, relax, resolve, installed_lit,
     with_temp_clauses, with_classes_relaxed, sat_new_variable, sat_add_var,
     sat_add, exclusion_kinds, class_exclusions
-using ..UnsatCores: sat_mus, sat_disjoint_muses, sat_mcses
+using ..UnsatCores: sat_mus, sat_mcses
 
 # What an unsatisfiable resolve says, and how it is found.
 #
@@ -58,6 +59,15 @@ using ..UnsatCores: sat_mus, sat_disjoint_muses, sat_mcses
 # deleting candidates in order, so a requirement the story does not need drops
 # out of it.
 #
+# The two questions are answered together, and that is what lets the report
+# come apart. The cheapest repairs are enumerated first, and they factor into
+# independent choices (`factor_repairs`); each choice is a conflict, its menu
+# is what the choice is between, and its story is what is left unsatisfiable
+# once every other choice has been made. So a conflict explains the menu under
+# it rather than being arrived at separately, and one fix from each menu —
+# chosen any way at all — is a repair of the whole query, without anything
+# further being asked. See the manual's Diagnostics page.
+#
 # Both are asked a *package* at a time, over one assumable literal per package
 # the query left short (`with_emptied_packages`). That is the granularity of
 # both answers: a report says what has become of a package's versions, and a
@@ -76,9 +86,10 @@ using ..UnsatCores: sat_mus, sat_disjoint_muses, sat_mcses
 # problem — never from a model of the failed instance. The instance's classes
 # were given representatives under constraints a fix relaxes, and were laid out
 # in the order those representatives induce, so a version read off it is a
-# version that fix would not produce. A fix is verified by resolving the
-# relaxation `relax` derives from it, and the solution that comes back is what
-# the report shows.
+# version that fix would not produce. A fix's witness comes from resolving the
+# relaxation `relax` derives from carrying it out — together with the first fix
+# of every other conflict, since it is a combination that repairs the query —
+# and the solution that comes back is what the report shows.
 
 ## the report
 
@@ -178,14 +189,15 @@ Base.hash(a::Availability, h::UInt) =
 """
     Resolver.Diagnostics.Fix{P,V}(actions, solution)
 
-One repair of the whole problem: a set of
-[`Action`](@ref Resolver.Diagnostics.Action)s to carry out, and `solution`,
-what resolving with them carried out actually yields. The solution is a real
-resolve of the relaxed problem, so the versions in it are the versions the user
-would get.
+One way of fixing one [`Conflict`](@ref Resolver.Diagnostics.Conflict): a set
+of [`Action`](@ref Resolver.Diagnostics.Action)s to carry out, and `solution`,
+what carrying them out actually yields. Fixing every conflict is what repairs
+the query, so `solution` is a real resolve of the problem this fix and the
+first fix of every *other* conflict relax — the versions in it are the versions
+the user would get if that is how the rest are fixed.
 
-No fix's actions are a superset of another's, and no two fixes ask for the same
-things.
+No two fixes in a conflict's menu ask for the same things, and none of them
+asks for more than another: the menu is a choice, not an order.
 """
 struct Fix{P,V}
     actions  :: Vector{Action{P}}
@@ -193,20 +205,24 @@ struct Fix{P,V}
 end
 
 """
-    Resolver.Diagnostics.Conflict{P,V}(reqs, chain)
+    Resolver.Diagnostics.Conflict{P,V}(reqs, chain, fixes)
 
-One independent reason the query fails: the requirements `reqs`, which cannot
-hold together, and `chain`, a short sequence of
-[`Fact`](@ref Resolver.Diagnostics.Fact)s about the packages that says why.
+One independent choice the query leaves the user: the requirements `reqs`,
+which cannot hold together, `chain`, a short sequence of
+[`Fact`](@ref Resolver.Diagnostics.Fact)s about the packages that says why, and
+`fixes`, the menu of [`Fix`](@ref Resolver.Diagnostics.Fix)es that settle it.
 Every fact in the chain is load-bearing — take any one of them away and the
 rest of the conflict dissolves.
 
-Conflicts within a [`Diagnosis`](@ref) share no requirement, so each is a
-separate thing to fix.
+The conflicts of a [`Diagnosis`](@ref) are independent in that each has to be
+fixed and any fix of one goes with any fix of another. Their *stories* may well
+overlap: two conflicts can be about the same requirement without being the same
+thing to do about it.
 """
 struct Conflict{P,V}
     reqs  :: Vector{P}
     chain :: Vector{Fact}
+    fixes :: Vector{Fix{P,V}}
 end
 
 """
@@ -215,9 +231,18 @@ end
 What [`resolve`](@ref) returns instead of a solution when the requirements
 cannot be satisfied: the independent
 [`Conflict`](@ref Resolver.Diagnostics.Conflict)s, each with the chain of facts
-that explains it, and a menu of verified
-[`Fix`](@ref Resolver.Diagnostics.Fix)es, each of which repairs the whole
-problem.
+that explains it and its own menu of
+[`Fix`](@ref Resolver.Diagnostics.Fix)es. Every conflict has to be fixed, and
+one fix from each — chosen any way at all — repairs the query, so the fixes of
+the whole problem are the combinations.
+
+`others` says what those combinations leave out:
+
+  * `:none` — nothing at all. They are exactly the minimal fixes of the query,
+    and every one of them changes as few things as any fix can.
+  * `:larger` — only fixes that change more things than these do. Every
+    smallest fix is a combination of these menus.
+  * `:some` — fixes that change no more than these do, as well.
 
 `show(io, MIME("text/plain"), d)` prints the report; the fields are plain data,
 so a caller that wants a different report can build one from them without
@@ -228,7 +253,7 @@ the verdict is wanted.
 """
 struct Diagnosis{P,V}
     conflicts :: Vector{Conflict{P,V}}
-    fixes     :: Vector{Fix{P,V}}
+    others    :: Symbol
 end
 
 ## rendering
@@ -322,16 +347,36 @@ end
 count_phrase(n::Int, one::String, many::String) =
     n == 0 ? "no $many" : n == 1 ? "1 $one" : "$n $many"
 
+# how many ways there are to repair the query: one fix out of every conflict's
+# menu, chosen independently
+nfixes(d::Diagnosis) =
+    isempty(d.conflicts) ? 0 : prod(c -> length(c.fixes), d.conflicts)
+
 function Base.show(io::IO, d::Diagnosis)
     print(io, "Diagnosis: ",
         count_phrase(length(d.conflicts), "conflict", "conflicts"), ", ",
-        count_phrase(length(d.fixes), "fix", "fixes"))
+        count_phrase(nfixes(d), "fix", "fixes"))
+end
+
+# What the menus leave out, once the reader has made a choice in each of them.
+# Nothing to say when they leave out nothing.
+others_phrase(others::Symbol) =
+    others === :larger ? "Other, larger solutions exist." :
+                         "Other solutions exist."
+
+# what the fix gets the user, of the packages this conflict has named; a fix
+# that installs none of them has nothing to show here
+function print_allows(io::IO, fix::Fix{P}, named::Vector{P},
+                      lead::String, rest::String) where {P}
+    allows = String["$p $(fix.solution[p])" for p in named
+                    if haskey(fix.solution, p)]
+    isempty(allows) || print_wrapped(io, join(allows, ", "), lead, rest)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis{P,V}) where {P,V}
     println(io, "Unsatisfiable — ",
-        count_phrase(length(d.conflicts), "conflict", "conflicts"), ", ",
-        count_phrase(length(d.fixes), "fix", "fixes"), ":")
+        count_phrase(length(d.conflicts), "conflict", "conflicts"),
+        length(d.conflicts) > 1 ? ", every one of which has to be fixed:" : ":")
     for (k, c) in enumerate(d.conflicts)
         println(io)
         subject = list_phrase(String[string(p) for p in c.reqs])
@@ -343,38 +388,44 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis{P,V}) where {P,V}
                 print_wrapped(io,
                     availability_phrase(f::Availability), "  • ", "    ")
         end
+        # the versions worth showing are the ones this conflict is about
+        named = P[]
+        for f in c.chain
+            p = f isa Requirement ? f.pkg : (f::Availability).pkg
+            p in named || push!(named, p)
+        end
+        sort!(named)
+        if length(c.fixes) == 1
+            # nothing to choose between: this is the one thing that can be done
+            fix = only(c.fixes)
+            print_wrapped(io, list_phrase(map(action_phrase, fix.actions)),
+                "  The only fix: ", "    ")
+            print_allows(io, fix, named, "    → allows: ", "      ")
+        else
+            println(io, "  Fix it by any one of:")
+            for (j, fix) in enumerate(c.fixes)
+                print_wrapped(io, list_phrase(map(action_phrase, fix.actions)),
+                    lpad(j, 5) * ". ", "       ")
+                print_allows(io, fix, named, "       → allows: ", "         ")
+            end
+        end
     end
-    isempty(d.fixes) && return
+    d.others === :none && return
     println(io)
-    println(io, "Verified fixes:")
-    # the versions worth showing are the ones the report has been talking about
-    named = P[]
-    for c in d.conflicts, f in c.chain
-        p = f isa Requirement ? f.pkg : (f::Availability).pkg
-        p in named || push!(named, p)
-    end
-    sort!(named)
-    for (k, fix) in enumerate(d.fixes)
-        print_wrapped(io, list_phrase(map(action_phrase, fix.actions)),
-            lpad(k, 3) * ". ", "     ")
-        # what the fix gets the user, of the packages the report has named; a
-        # fix that installs none of them has nothing to show here
-        allows = String["$p $(fix.solution[p])" for p in named
-                        if haskey(fix.solution, p)]
-        isempty(allows) ||
-            print_wrapped(io, join(allows, ", "), "     → allows: ", "       ")
-    end
+    print_wrapped(io, others_phrase(d.others), "", "")
 end
 
 ## the diagnosis
 
 # How many repairs to enumerate before settling for the ones already found.
-# Independent conflicts multiply, so there can be exponentially many, and a menu
-# is only useful while it is short; deduplication and dominance cut this down
-# further. What is enumerated over is the requirements and the packages this
-# query left short, of which there are few, so this is a ceiling rather than the
-# usual stopping point.
-const MAX_FIXES = 32
+# What is enumerated over is the requirements and the packages this query left
+# short, of which there are few — 6 to 36 repairs on the registry queries this
+# was measured on — so it is a ceiling rather than the usual stopping point.
+# Independent conflicts multiply, though, so there can be exponentially many,
+# and what a truncated enumeration costs is not a fix but a claim: the smallest
+# of the repairs found still factor into conflicts and their menus still repair
+# the query, but the report can no longer say that nothing else would.
+const MAX_REPAIRS = 256
 
 # The literals a diagnosis assumes, read back as what they say about the
 # universe. Package variables are laid out in blocks — the package itself, then
@@ -447,20 +498,19 @@ function with_emptied_packages(body::Function, sat::SAT{P}, vm::VarMap{P}) where
 end
 
 # The story of one conflict: the smallest set of the query's own facts that is
-# still unsatisfiable. Deletion is attempted in the order given, so putting the
-# requirements first drops the ones the story does not need and keeps the facts
-# the user can act on. The answer is a subsequence of what was asked, so the
-# requirements come back in the problem's requirement order and the emptied
-# packages in package order.
+# still unsatisfiable, drawn from the ones it is asked about. Deletion is
+# attempted in the order given, so putting the requirements first drops the ones
+# the story does not need and keeps the facts the user can act on. The answer is
+# a subsequence of what was asked, so the requirements come back in the
+# problem's requirement order and the emptied packages in package order.
 function conflict_story(
-    sat      :: SAT{P,V},
-    prob     :: Problem{P},
-    vm       :: VarMap{P},
-    cluster  :: Vector{Int},
-    emptied  :: Dict{Int,P}, # per package literal, the package
-    pkg_lits :: Vector{Int},
+    sat     :: SAT{P,V},
+    prob    :: Problem{P},
+    vm      :: VarMap{P},
+    emptied :: Dict{Int,P}, # per package literal, the package
+    cands   :: Vector{Int},
 ) where {P,V}
-    mus = sat_mus(sat, [cluster; pkg_lits])
+    mus = sat_mus(sat, cands)
     reqs = P[]
     chain = Fact[]
     avails = Fact[]
@@ -475,10 +525,14 @@ function conflict_story(
         end
     end
     append!(chain, avails)
-    return Conflict{P,V}(reqs, chain)
+    return reqs, chain
 end
 
-# The user actions one correction set asks for. Dropping a requirement is
+# relaxations before drops, so a set of actions reads as an instruction
+sort_actions!(actions::Vector{<:Action}) =
+    sort!(actions; by = a -> (a.kind === :drop, a.pkg, a.kind))
+
+# The user actions one literal of a repair asks for. Dropping a requirement is
 # already an action; giving a package's versions back is not, since what the
 # user relaxes is a *constraint* — so for each class the query emptied, take the
 # member that costs the fewest kinds (ties going to the better version) and name
@@ -489,34 +543,109 @@ function correction_actions(
     prob    :: Problem{P},
     vm      :: VarMap{P},
     emptied :: Dict{Int,P}, # per package literal, the package
-    mcs     :: Vector{Int},
-    dropped :: Vector{P},
+    lit     :: Int,
 ) where {P}
+    p = get(emptied, lit, nothing)
+    if p === nothing
+        q, _ = decode(vm, lit)
+        return Action{P}[Action{P}(:drop, q)]
+    end
     actions = Action{P}[]
-    for l in mcs
-        p = get(emptied, l, nothing)
-        if p === nothing
-            q, _ = decode(vm, l)
-            push!(actions, Action{P}(:drop, q))
-            continue
+    reps_p = sat.reps[p]
+    for c in eachindex(reps_p)
+        iszero(reps_p[c]) || continue
+        ex = class_exclusions(prob, p, sat.info[p], c)
+        best = argmin(i -> (length(ex[i][2]), i), eachindex(ex))
+        for kind in ex[best][2]
+            push!(actions, Action{P}(kind, p))
         end
-        reps_p = sat.reps[p]
-        for c in eachindex(reps_p)
-            iszero(reps_p[c]) || continue
-            ex = class_exclusions(prob, p, sat.info[p], c)
-            best = argmin(i -> (length(ex[i][2]), i), eachindex(ex))
-            for kind in ex[best][2]
-                push!(actions, Action{P}(kind, p))
+    end
+    return sort_actions!(unique!(actions))
+end
+
+# One fix out of every conflict's menu, as the actions to carry out together
+combined_actions(parts::Vector{Vector{Action{P}}}) where {P} =
+    sort_actions!(unique!(reduce(vcat, parts; init = Action{P}[])))
+
+# The smallest repairs, factored into independent choices.
+#
+# Two literals belong to the same choice when no repair contains both — taking
+# one of them is what makes the other unnecessary — so the choices are the
+# connected components of that relation. The family is exactly their product
+# when every repair takes one literal from each and there are as many repairs as
+# there are ways of doing that: a repair is determined by its literals, so the
+# map from repairs to combinations is injective already, and once the counts
+# agree it is onto. Every combination is then a repair, which is what lets the
+# menus be offered separately.
+#
+# The second answer is whether the choices cover the whole family. When they do
+# not, what comes back is the largest *rectangle* in it — a set of literals
+# every repair in the rectangle shares, and the alternatives that complete it —
+# and the family holds smallest repairs the menus do not reach.
+function factor_repairs(repairs::Vector{Vector{Int}})
+    lits = sort!(unique!(reduce(vcat, repairs; init = Int[])))
+    n = length(lits)
+    at = Dict{Int,Int}(l => i for (i, l) in enumerate(lits))
+    shared = falses(n, n) # do the two literals appear in a repair together?
+    for r in repairs, a in r, b in r
+        shared[at[a], at[b]] = true
+    end
+    group = zeros(Int, n)
+    ngroups = 0
+    for i = 1:n
+        group[i] == 0 || continue
+        group[i] = (ngroups += 1)
+        stack = Int[i]
+        while !isempty(stack)
+            u = pop!(stack)
+            for v = 1:n
+                group[v] == 0 && !shared[u, v] || continue
+                group[v] = ngroups
+                push!(stack, v)
             end
         end
     end
-    for p in dropped
-        push!(actions, Action{P}(:drop, p))
+    choices = Vector{Int}[Int[lits[i] for i = 1:n if group[i] == g]
+                          for g = 1:ngroups]
+    length(repairs) == prod(length, choices; init = 1) &&
+        all(r -> all(c -> count(in(c), r) == 1, choices), repairs) &&
+        return choices, true
+    return largest_rectangle(repairs)
+end
+
+# The largest rectangle in a family of same-sized repairs: a core of literals
+# every repair in it contains, and the alternatives that complete it. A core one
+# literal short of a repair is completed by exactly one literal of every repair
+# that contains it, so every such core is a rectangle and there are few enough
+# of them to try each one. The cores are tried in an order of their own, so that
+# which rectangle wins a tie does not depend on the order the repairs were
+# discovered in.
+function largest_rectangle(repairs::Vector{Vector{Int}})
+    cores = sort!(unique!(Vector{Int}[sort!(Int[k for k in r if k ≠ l])
+                                      for r in repairs for l in r]))
+    core = alts = Int[]
+    for c in cores
+        a = sort!(Int[k for s in repairs if c ⊆ s for k in s if k ∉ c])
+        length(a) > length(alts) || continue
+        core, alts = c, a
     end
-    unique!(actions)
-    # relaxations before drops, so the menu reads as an instruction
-    sort!(actions; by = a -> (a.kind === :drop, a.pkg, a.kind))
-    return actions
+    choices = push!(Vector{Int}[Int[k] for k in core], alts)
+    return choices, length(alts) == length(repairs)
+end
+
+# Presentation order for the choices and the alternatives within them, given the
+# order the repairs were asked for in. Within a choice, relaxing a constraint
+# comes before dropping a requirement, which is the same preference the
+# candidate order states by putting the requirements first; the choices
+# themselves go in the order their earliest alternative was offered in.
+function order_choices!(choices::Vector{Vector{Int}}, cands::Vector{Int},
+                        nreqs::Int)
+    at = Dict{Int,Int}(l => i for (i, l) in enumerate(cands))
+    for c in choices
+        sort!(c; by = l -> (at[l] ≤ nreqs, at[l]))
+    end
+    sort!(choices; by = c -> minimum(at[l] for l in c))
+    return choices
 end
 
 # The withdrawal a set of actions asks for, in the two parts `relax` takes it:
@@ -540,10 +669,10 @@ end
 
 Why the resolve of `prob` against the instance `sat` failed, and what would
 make it succeed. `univ` is the universe `sat` was built from — the one
-`prepare_pkg_info(info, prob; order)` produced, filtered for `prob` — and each
-fix is verified by resolving on it the relaxation of `prob` that carrying the
-fix out gives, with the same `by` and `order` the failed resolve used. The
-solution that comes back is the fix's witness. Filtering for `prob` deletes
+`prepare_pkg_info(info, prob; order)` produced, filtered for `prob` — and every
+fix comes with a witness: the relaxation of `prob` that carrying it out (along
+with the first fix of every other conflict) gives, resolved on `univ` with the
+same `by` and `order` the failed resolve used. Filtering for `prob` deletes
 nothing such a relaxation needs, which is the manual's Theorem C, so no fix
 needs a universe of its own.
 
@@ -563,56 +692,84 @@ function diagnose(
     # a requirement the universe holds no installable version of is not
     # something the instance can be asked about: it has no variable, and no
     # constraint of this query is what took it away, since a constraint empties
-    # classes rather than deleting them. It is a conflict of its own, and every
-    # fix has to drop it
+    # classes rather than deleting them. It is a conflict of its own, and
+    # dropping it is the only thing that could settle that conflict
     gone = P[p for p in reqs if !haskey(vm, p)]
     req_lits = Int[installed_lit(sat, p) for p in reqs if haskey(vm, p)]
 
-    conflicts = Conflict{P,V}[
-        Conflict{P,V}([p], Fact[Requirement(p),
+    # per conflict, in report order: the story it tells and its menu, each
+    # alternative on it a set of actions
+    stories = Tuple{Vector{P},Vector{Fact}}[
+        (P[p], Fact[Requirement(p),
             Availability{P,V}(p, V[], Vector{Symbol}[])]) for p in gone]
+    menus = Vector{Vector{Action{P}}}[
+        Vector{Action{P}}[Action{P}[Action{P}(:drop, p)]] for p in gone]
 
-    # partition the requirements into independent conflicts, with the query
-    # exactly as production posed it
-    clusters = sat_disjoint_muses(sat, req_lits)
-
-    # distinct correction sets can ask for the same actions, and one action set
-    # can be a strict superset of another; keep the minimal ones, in
-    # enumeration order. Doing this before the witnesses are resolved saves the
-    # resolves the surviving fixes do not need
-    action_sets = Vector{Action{P}}[]
-    seen = Set{Set{Action{P}}}()
+    others = :none
     with_classes_relaxed(sat) do
         with_emptied_packages(sat, vm) do pkg_lits, pkgs
             emptied = Dict{Int,P}(zip(pkg_lits, pkgs))
-            for cluster in clusters
-                push!(conflicts,
-                    conflict_story(sat, prob, vm, cluster, emptied, pkg_lits))
-            end
-            # every minimal repair, requirements first so they are kept and the
-            # menu prefers relaxing a constraint to dropping a dependency
-            for mcs in sat_mcses(sat, [req_lits; pkg_lits]; limit = MAX_FIXES)
-                actions = correction_actions(sat, prob, vm, emptied, mcs, gone)
-                key = Set(actions)
-                key in seen && continue
-                push!(seen, key)
-                push!(action_sets, actions)
+            # requirements first, so that a repair keeps them and prefers
+            # relaxing a constraint to dropping a dependency, and so that a
+            # story drops the requirements it does not need
+            cands = [req_lits; pkg_lits]
+            repairs = sat_mcses(sat, cands; limit = MAX_REPAIRS)
+            # the instance is satisfiable with nothing assumed — install
+            # nothing — so there is always a repair to be found
+            @assert !isempty(repairs)
+            smallest = minimum(length, repairs)
+            cheapest = filter(r -> length(r) == smallest, repairs)
+            choices, whole = factor_repairs(cheapest)
+            order_choices!(choices, cands, length(req_lits))
+            # what the menus leave out: nothing when they reach every cheapest
+            # repair and no repair costs more than the cheapest. A truncated
+            # enumeration has both left to prove and repairs it never saw
+            others =
+                length(repairs) ≥ MAX_REPAIRS || !whole ? :some :
+                length(cheapest) < length(repairs) ? :larger : :none
+            # A story explains one choice by settling all the others: drop the
+            # rest of one repair from what may be assumed, and what is left is
+            # still unsatisfiable, minimally so once this choice is made. The
+            # repair's own minimality is what puts this choice's literal in the
+            # conflict and keeps the other choices' literals out of it.
+            settled = Int[first(c) for c in choices]
+            for (i, choice) in enumerate(choices)
+                rest = Set{Int}(settled[j] for j in eachindex(settled) if j ≠ i)
+                push!(stories, conflict_story(sat, prob, vm, emptied,
+                    Int[l for l in cands if l ∉ rest]))
+                push!(menus, Vector{Action{P}}[
+                    correction_actions(sat, prob, vm, emptied, l)
+                    for l in choice])
             end
         end
     end
-    filter!(a -> !any(b -> Set(b) ⊊ Set(a), action_sets), action_sets)
 
     # the instance is back as the query posed it, which is what answering a
-    # relaxation on it needs — the deactivation frame in place for it to lift
-    fixes = Fix{P,V}[]
-    for actions in action_sets
-        sol = resolve(sat, relax(univ, prob, withdrawal(actions)...; order); by)
-        # relaxing a kind admits at least what the correction set asked for and
-        # never less, so a repair the instance verified resolves here too
-        @assert sol !== nothing
-        push!(fixes, Fix{P,V}(actions, sol))
+    # relaxation on it needs — the deactivation frame in place for it to lift.
+    # A fix repairs one conflict, so what it is resolved with is the first fix
+    # of every other one; those combinations repeat, and a solution is a
+    # resolve, so they are answered once each
+    defaults = Vector{Action{P}}[first(menu) for menu in menus]
+    solutions = Dict{Vector{Action{P}},Dict{P,V}}()
+    conflicts = Conflict{P,V}[]
+    for (i, (creqs, chain)) in enumerate(stories)
+        fixes = Fix{P,V}[]
+        for actions in menus[i]
+            together = combined_actions(Vector{Action{P}}[
+                j == i ? actions : defaults[j] for j in eachindex(menus)])
+            sol = get!(solutions, together) do
+                s = resolve(sat,
+                    relax(univ, prob, withdrawal(together)...; order); by)
+                # relaxing a kind admits at least what the repair asked for and
+                # never less, so a repair the instance found resolves here too
+                @assert s !== nothing
+                s
+            end
+            push!(fixes, Fix{P,V}(actions, sol))
+        end
+        push!(conflicts, Conflict{P,V}(creqs, chain, fixes))
     end
-    return Diagnosis{P,V}(conflicts, fixes)
+    return Diagnosis{P,V}(conflicts, others)
 end
 
 end # module

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -366,8 +366,8 @@ end
 # What the menus leave out, once the reader has made a choice in each of them.
 # Nothing to say when they leave out nothing.
 others_phrase(others::Symbol) =
-    others === :larger ? "Other, larger solutions exist." :
-                         "Other solutions exist."
+    others === :larger ? "Larger solutions also exist." :
+                         "Other solutions also exist."
 
 # what the fix gets the user, of the packages this conflict has named; a fix
 # that installs none of them has nothing to show here
@@ -381,7 +381,7 @@ end
 function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis{P,V}) where {P,V}
     println(io, "Unsatisfiable — ",
         count_phrase(length(d.conflicts), "conflict", "conflicts"),
-        length(d.conflicts) > 1 ? ", every one of which has to be fixed:" : ":")
+        length(d.conflicts) > 1 ? ", each of which must be fixed:" : ":")
     for (k, c) in enumerate(d.conflicts)
         println(io)
         subject = list_phrase(String[string(p) for p in c.reqs])
@@ -512,17 +512,17 @@ end
 # Dropping every candidate is a repair, so the last bound worth trying is the
 # one that forbids nothing — which is the plain enumeration, and also what a
 # query with no candidate to give up at all wants.
-function smallest_repairs(sat::SAT, cands::Vector{Int}, limit::Int)
-    relaxed = Int[-l for l in cands]
+function smallest_repairs(sat::SAT, candidates::Vector{Int}, limit::Int)
+    relaxed = Int[-l for l in candidates]
     counts = Int[]
-    for k = 1:length(cands)-1
+    for k = 1:length(candidates)-1
         repairs = with_temp_clauses(sat) do
             add_at_most!(sat, relaxed, k, counts)
-            sat_solve(sat) ? sat_mcses(sat, cands; limit) : nothing
+            sat_solve(sat) ? sat_mcses(sat, candidates; limit) : nothing
         end
         repairs === nothing || return repairs
     end
-    return sat_mcses(sat, cands; limit)
+    return sat_mcses(sat, candidates; limit)
 end
 
 # Whether the query has a repair that costs more than the smallest ones do.
@@ -648,22 +648,22 @@ end
 # back is a subsequence of what was asked, so the requirements are in the
 # problem's requirement order and the packages in package order.
 function conflict_story(
-    sat     :: SAT{P,V},
-    prob    :: Problem{P},
-    vm      :: VarMap{P},
-    emptied :: Dict{Int,P}, # per package literal, the package
-    cands   :: Vector{Int},
+    sat        :: SAT{P,V},
+    prob       :: Problem{P},
+    vm         :: VarMap{P},
+    emptied    :: Dict{Int,P}, # per package literal, the package
+    candidates :: Vector{Int}, # the literals a repair may withdraw
 ) where {P,V}
-    named = Set{Int}(sat_mus(sat, cands))
-    pkgs = Int[l for l in cands if haskey(emptied, l)]
-    for l in cands
+    named = Set{Int}(sat_mus(sat, candidates))
+    pkgs = Int[l for l in candidates if haskey(emptied, l)]
+    for l in candidates
         (haskey(emptied, l) || l in named) && continue
         union!(named, sat_mus(sat, Int[l; pkgs]))
     end
     reqs = P[]
     chain = Fact[]
     avails = Fact[]
-    for l in cands
+    for l in candidates
         l in named || continue
         p = get(emptied, l, nothing)
         if p === nothing
@@ -788,9 +788,12 @@ end
 # comes before dropping a requirement, which is the same preference the
 # candidate order states by putting the requirements first; the choices
 # themselves go in the order their earliest alternative was offered in.
-function order_choices!(choices::Vector{Vector{Int}}, cands::Vector{Int},
-                        nreqs::Int)
-    at = Dict{Int,Int}(l => i for (i, l) in enumerate(cands))
+function order_choices!(
+    choices    :: Vector{Vector{Int}},
+    candidates :: Vector{Int},
+    nreqs      :: Int,
+)
+    at = Dict{Int,Int}(l => i for (i, l) in enumerate(candidates))
     for c in choices
         sort!(c; by = l -> (at[l] ≤ nreqs, at[l]))
     end
@@ -862,10 +865,10 @@ function diagnose(
             # requirements first, so that a repair keeps them and prefers
             # relaxing a constraint to dropping a dependency, and so that a
             # story drops the requirements it does not need
-            cands = [req_lits; pkg_lits]
-            cheapest = smallest_repairs(sat, cands, MAX_REPAIRS)
+            candidates = [req_lits; pkg_lits]
+            cheapest = smallest_repairs(sat, candidates, MAX_REPAIRS)
             choices, whole = factor_repairs(cheapest)
-            order_choices!(choices, cands, length(req_lits))
+            order_choices!(choices, candidates, length(req_lits))
             # what the menus leave out: nothing when they reach every cheapest
             # repair and no repair costs more than the cheapest. The second is
             # a question to put to the instance, and putting it takes every
@@ -883,7 +886,7 @@ function diagnose(
             for (i, choice) in enumerate(choices)
                 rest = Set{Int}(settled[j] for j in eachindex(settled) if j ≠ i)
                 push!(stories, conflict_story(sat, prob, vm, emptied,
-                    Int[l for l in cands if l ∉ rest]))
+                    Int[l for l in candidates if l ∉ rest]))
                 push!(menus, Vector{Action{P}}[
                     correction_actions(sat, prob, vm, emptied, l)
                     for l in choice])

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -108,7 +108,7 @@ A `Diagnosis` says which requirements cannot hold together, why, and what the
 user could change to make them; `show`ing it prints the report. Pass
 `diagnose = false` for the bare `nothing` instead, which is what a caller that
 only wants the verdict should do — the diagnosis costs several more solves and
-one resolve per fix it offers.
+one resolve per fix on the menus it offers.
 
 A [`Problem`](@ref) additionally constrains the admissible versions with user
 constraints; the answer is the one the same universe with those versions

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -15,6 +15,13 @@
 #     withdrawal of demands from a `Problem`, which is not this file's to check
 #     (test/problem.jl and test/relaxation_stable.jl do).
 #
+# A report hands out one menu per conflict and lets the reader choose from each
+# independently, so the claim it rests on is that *every* combination of choices
+# repairs the query. The menus are small, so every check_diagnosis checks every
+# combination, from scratch. What the combinations leave out (`others`) is
+# checked against a third oracle, in the cases small enough for it: every subset
+# of a pool of actions, resolved from the artifact, reduced to the minimal ones.
+#
 # What the report says is checked separately, against hand-built cases, since
 # there is no oracle for English.
 
@@ -81,6 +88,32 @@ fix_resolve(info, prob::Problem{P}, actions::Vector{Action{P}};
             order = nothing, by = identity) where {P} =
     resolve(info, relax(prob, withdrawal(actions)...); order, by, diagnose = false)
 
+# one fix out of every conflict's menu, as the actions to carry out together
+# (over copies, so that a one-conflict choice does not hand back the fix's own
+# vector for `unique!` to work on)
+combined(choice) = unique!(reduce(vcat, (copy(fix.actions) for fix in choice)))
+
+# every way of choosing one fix per conflict, as a set of action sets — the
+# fixes of the whole query the report offers
+fix_combinations(d::Diagnosis) =
+    Set(Set(combined(choice))
+        for choice in Iterators.product((c.fixes for c in d.conflicts)...))
+
+# every minimal repair drawn from `pool`, the slow way: each subset of it
+# prepared and resolved from the artifact, and the ones that resolve reduced to
+# the minimal ones. The oracle for what a report's combinations leave out
+function minimal_repairs(info, prob::Problem{P}, pool::Vector{Action{P}};
+                         order = nothing, by = identity) where {P}
+    repairs = Set{Set{Action{P}}}()
+    for bits = 0:(1 << length(pool)) - 1
+        actions = Action{P}[pool[i] for i in eachindex(pool)
+                            if !iszero(bits & (1 << (i-1)))]
+        fix_resolve(info, prob, actions; order, by) === nothing && continue
+        push!(repairs, Set(actions))
+    end
+    return Set(r for r in repairs if !any(s -> s ⊊ r, repairs))
+end
+
 # every property a `Diagnosis` of `prob` claims, checked against the instance
 # it was drawn from and against fresh resolves of the artifact. Returns the
 # diagnosis, or `nothing` when the problem is satisfiable after all
@@ -108,15 +141,11 @@ function check_diagnosis(data, prob::Problem{P}; order = nothing,
 
         ## conflicts
 
-        # independent: no requirement is in two of them, and each names only
-        # requirements
-        seen = Set{P}()
+        # each names requirements of the query, and its chain names them in
+        # order and then the packages
         for c in d.conflicts
             @test !isempty(c.reqs)
             @test c.reqs ⊆ prob.reqs
-            @test isempty(intersect(seen, c.reqs))
-            union!(seen, c.reqs)
-            # the chain names the conflict's requirements, then packages
             @test [f.pkg for f in c.chain if f isa Requirement] == c.reqs
             @test allunique(f.pkg for f in c.chain if f isa Availability)
         end
@@ -166,21 +195,39 @@ function check_diagnosis(data, prob::Problem{P}; order = nothing,
 
         ## fixes
 
-        for fix in d.fixes
-            @test !isempty(fix.actions)
-            @test allunique(fix.actions)
-            # the central property: carrying the actions out resolves, and to
-            # exactly the solution the fix shows — the diagnosis answered the
-            # relaxation on the universe filtered for the query, this answers it
-            # on a universe filtered for the relaxation itself
-            @test fix_resolve(info, prob, fix.actions; order, by) == fix.solution
+        for (i, c) in enumerate(d.conflicts)
+            for fix in c.fixes
+                @test !isempty(fix.actions)
+                @test allunique(fix.actions)
+                # a fix shows what it gets you when the other conflicts are
+                # fixed the first way their menus offer, so that is what is
+                # resolved here — the diagnosis answered the relaxation on the
+                # universe filtered for the query, this answers it on a
+                # universe filtered for the relaxation itself
+                actions = combined([j == i ? fix : first(d.conflicts[j].fixes)
+                                    for j in eachindex(d.conflicts)])
+                @test fix_resolve(info, prob, actions; order, by) == fix.solution
+            end
+            # minimal and distinct: within one menu, no fix asks for a strict
+            # superset of another's actions, and no two ask for the same things
+            sets = [Set(fix.actions) for fix in c.fixes]
+            @test allunique(sets)
+            for a in sets, b in sets
+                @test !(b ⊊ a)
+            end
         end
-        # minimal and distinct: no fix asks for a strict superset of another's
-        # actions, and no two ask for the same things
-        sets = [Set(fix.actions) for fix in d.fixes]
-        @test allunique(sets)
-        for a in sets, b in sets
-            @test !(b ⊊ a)
+
+        ## every combination is a fix
+        #
+        # The claim the whole report rests on: the menus are independent, so
+        # any one fix from each of them repairs the query. Checked from
+        # scratch, exhaustively — the menus are small enough that they can be
+        menus = [c.fixes for c in d.conflicts]
+        if !isempty(menus) && prod(length, menus) ≤ 64
+            for choice in Iterators.product(menus...)
+                @test fix_resolve(info, prob, combined(choice);
+                    order, by) !== nothing
+            end
         end
     finally
         finalize(sat)
@@ -212,17 +259,51 @@ const needs_dep = Dict(
     :B => PkgData([:w3, :w2, :w1], DEPS_NONE, COMP_NONE),
 )
 
+# two requirements, one dependency between them: giving :C back fixes both at
+# once, and dropping both requirements is the only other way — a repair that
+# gives up strictly more, so a report that offers the first has left it out
+const shared_dep = Dict(
+    :A => PkgData([:v1], Dict(:v1 => [:C]), COMP_NONE),
+    :B => PkgData([:v1], Dict(:v1 => [:C]), COMP_NONE),
+    :C => PkgData([:c1], DEPS_NONE, COMP_NONE),
+)
+
+# four requirements whose disagreements form a path — :C with :B, :B with :A,
+# :A with :D — so the cheapest repairs are {A,B}, {A,C} and {B,D}, which is
+# three of them and therefore not a product of anything
+const conflict_path = Dict(
+    :A => PkgData([:v1], Dict(:v1 => [:P, :Q]),
+        Dict(:v1 => Dict(:P => [:p1], :Q => [:q1]))),
+    :B => PkgData([:v1], Dict(:v1 => [:P, :R]),
+        Dict(:v1 => Dict(:P => [:p2], :R => [:r1]))),
+    :C => PkgData([:v1], Dict(:v1 => [:R]), Dict(:v1 => Dict(:R => [:r2]))),
+    :D => PkgData([:v1], Dict(:v1 => [:Q]), Dict(:v1 => Dict(:Q => [:q2]))),
+    :P => PkgData([:p2, :p1], DEPS_NONE, COMP_NONE),
+    :Q => PkgData([:q2, :q1], DEPS_NONE, COMP_NONE),
+    :R => PkgData([:r2, :r1], DEPS_NONE, COMP_NONE),
+)
+
 @testset "diagnosis: independent conflicts come out separately" begin
-    d = check_diagnosis(two_conflicts, Problem([:A, :B, :E, :F]))
+    prob = Problem([:A, :B, :E, :F])
+    d = check_diagnosis(two_conflicts, prob)
     @test d isa Diagnosis
     @test length(d.conflicts) == 2
     @test Set(Set(c.reqs) for c in d.conflicts) ==
         Set([Set([:A, :B]), Set([:E, :F])])
-    # repairing needs one requirement out of each conflict: 2 × 2 ways
-    @test length(d.fixes) == 4
-    @test Set(Set(a.pkg for a in fix.actions) for fix in d.fixes) ==
-        Set(Set([x, y]) for x in (:A, :B), y in (:E, :F))
-    @test all(a.kind === :drop for fix in d.fixes for a in fix.actions)
+    # each conflict is settled by dropping one of its own requirements, and
+    # says nothing about the other's: 2 and 2, not 2 × 2
+    for c in d.conflicts
+        @test Set(Set(a.pkg for a in fix.actions) for fix in c.fixes) ==
+            Set(Set([p]) for p in c.reqs)
+        @test all(a.kind === :drop for fix in c.fixes for a in fix.actions)
+    end
+    # ... and one from each is a repair, in all 2 × 2 ways. There is nothing
+    # else: the combinations are exactly the minimal repairs, which is what
+    # entitles the report to say nothing further
+    pool = [Action(:drop, p) for p in (:A, :B, :E, :F)]
+    @test fix_combinations(d) ==
+        minimal_repairs(pkg_info(two_conflicts, prob), prob, pool)
+    @test d.others === :none
     # and the requirements the conflict does not need stay out of it
     d = check_diagnosis(two_conflicts, Problem([:A, :B, :C]))
     @test length(d.conflicts) == 1
@@ -259,10 +340,11 @@ end
     @test unavailable(c.chain[2])
     # the cheapest version to give back costs one kind, so that is the fix —
     # and not requiring :A is the other
-    @test [fix.actions for fix in d.fixes] ==
+    @test [fix.actions for fix in c.fixes] ==
         [[Action(:compat, :B)], [Action(:drop, :A)]]
-    @test d.fixes[1].solution == Dict(:A => :v1, :B => :w2)
-    @test isempty(d.fixes[2].solution)
+    @test c.fixes[1].solution == Dict(:A => :v1, :B => :w2)
+    @test isempty(c.fixes[2].solution)
+    @test d.others === :none
 end
 
 @testset "diagnosis: a package with a version left over" begin
@@ -279,16 +361,15 @@ end
     @test f.excluded == [[:compat], Symbol[]]
     @test !unavailable(f)
     @test sprint(show, MIME("text/plain"), d) == """
-        Unsatisfiable — 1 conflict, 2 fixes:
+        Unsatisfiable — 1 conflict:
 
         Conflict 1: R cannot be satisfied.
           • you require R
           • P: p2 is excluded by your compat
-
-        Verified fixes:
-          1. relax your compat on P
-             → allows: P p2, R r1
-          2. drop requirement R
+          Fix it by any one of:
+            1. relax your compat on P
+               → allows: P p2, R r1
+            2. drop requirement R
         """
 end
 
@@ -301,9 +382,10 @@ end
     @test f.excluded == [[:prerelease], [:prerelease], [:yanked]]
     # one kind is enough to give the package back, and the best version it
     # would give back costs the prerelease one
-    @test [fix.actions for fix in d.fixes] ==
+    fixes = only(d.conflicts).fixes
+    @test [fix.actions for fix in fixes] ==
         [[Action(:prerelease, :B)], [Action(:drop, :A)]]
-    @test d.fixes[1].solution == Dict(:A => :v1, :B => :w3)
+    @test fixes[1].solution == Dict(:A => :v1, :B => :w3)
     @test occursin("allow prerelease versions of B",
         sprint(show, MIME("text/plain"), d))
 end
@@ -320,10 +402,62 @@ end
         Availability{Symbol,Symbol}(:A, Symbol[], Vector{Symbol}[])]
     # nothing this query does is what took it away, so dropping it is all that
     # could help — and :B still resolves once it is gone
-    @test [fix.actions for fix in d.fixes] == [[Action(:drop, :A)]]
-    @test only(d.fixes).solution == Dict(:B => :v1)
-    @test occursin("no version of A is available",
-        sprint(show, MIME("text/plain"), d))
+    fixes = only(d.conflicts).fixes
+    @test [fix.actions for fix in fixes] == [[Action(:drop, :A)]]
+    @test only(fixes).solution == Dict(:B => :v1)
+    @test d.others === :none
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("no version of A is available", report)
+    # one thing to do reads as one thing to do, not as a menu of one
+    @test occursin("The only fix: drop requirement A", report)
+    @test !occursin("any one of", report)
+end
+
+@testset "diagnosis: a repair that gives up more is not on the menu" begin
+    # :A and :B both need :C, and the bound leaves :C with nothing. Giving :C
+    # back is the one cheapest repair; dropping both requirements is a repair
+    # too, and gives up strictly more, so the report says there is more
+    prob = Problem([:A, :B]; compat = Dict(:C => Symbol[]))
+    d = check_diagnosis(shared_dep, prob)
+    c = only(d.conflicts)
+    @test [fix.actions for fix in c.fixes] == [[Action(:compat, :C)]]
+    @test only(c.fixes).solution == Dict(:A => :v1, :B => :v1, :C => :c1)
+    # the oracle: the minimal repairs are those two, and the report offers the
+    # smaller of them and nothing else
+    info = pkg_info(shared_dep, prob)
+    pool = [Action(:compat, :C), Action(:drop, :A), Action(:drop, :B)]
+    repairs = minimal_repairs(info, prob, pool)
+    @test repairs == Set([Set([Action(:compat, :C)]),
+                          Set([Action(:drop, :A), Action(:drop, :B)])])
+    @test fix_combinations(d) == Set([Set([Action(:compat, :C)])])
+    # ... and every repair it left out is bigger than the ones it offers
+    @test all(length(r) > 1 for r in setdiff(repairs, fix_combinations(d)))
+    @test d.others === :larger
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("The only fix: relax your compat on C", report)
+    @test occursin("Other, larger solutions exist.", report)
+end
+
+@testset "diagnosis: cheapest repairs that are not a product" begin
+    # The disagreements form a path :C–:B–:A–:D, so the cheapest repairs are
+    # {A,B}, {A,C} and {B,D} — three of them, which is not a product of menu
+    # sizes. The report offers the largest rectangle in that family and says
+    # there is more of it
+    prob = Problem([:A, :B, :C, :D])
+    d = check_diagnosis(conflict_path, prob)
+    info = pkg_info(conflict_path, prob)
+    pool = [Action(:drop, p) for p in (:A, :B, :C, :D)]
+    repairs = minimal_repairs(info, prob, pool)
+    @test repairs == Set(Set([Action(:drop, x), Action(:drop, y)])
+                         for (x, y) in ((:A, :B), (:A, :C), (:B, :D)))
+    # what the report offers is a proper part of that, all of it cheapest
+    offered = fix_combinations(d)
+    @test offered ⊊ repairs
+    @test length(offered) == 2
+    @test d.others === :some
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("Other solutions exist.", report)
+    @test !occursin("larger", report)
 end
 
 @testset "diagnosis: the instance is left as it was found" begin
@@ -406,47 +540,50 @@ end
 ## rendering
 
 @testset "diagnosis: the report" begin
+    # each conflict carries its own menu, and the menus do not multiply: two
+    # menus of two, not one of four. There is no closing sentence — every
+    # combination of them is a repair and there are no others
     d = resolve(two_conflicts, Problem([:A, :B, :E, :F]))
     @test sprint(show, MIME("text/plain"), d) == """
-        Unsatisfiable — 2 conflicts, 4 fixes:
+        Unsatisfiable — 2 conflicts, every one of which has to be fixed:
 
         Conflict 1: A and B cannot be satisfied together.
           • you require A
           • you require B
+          Fix it by any one of:
+            1. drop requirement A
+               → allows: B v1
+            2. drop requirement B
+               → allows: A v1
 
         Conflict 2: E and F cannot be satisfied together.
           • you require E
           • you require F
-
-        Verified fixes:
-          1. drop requirement B and drop requirement F
-             → allows: A v1, E v1
-          2. drop requirement B and drop requirement E
-             → allows: A v1, F v1
-          3. drop requirement A and drop requirement F
-             → allows: B v1, E v1
-          4. drop requirement A and drop requirement E
-             → allows: B v1, F v1
+          Fix it by any one of:
+            1. drop requirement E
+               → allows: F v1
+            2. drop requirement F
+               → allows: E v1
         """
-    # the one-line summary
+    # the one-line summary counts the ways of repairing the whole query
     @test sprint(show, d) == "Diagnosis: 2 conflicts, 4 fixes"
 
     # every kind that excludes a version is named, and a long line is filled
     d = resolve(needs_dep,
         Problem([:A]; compat = Dict(:B => [:w1]), pin = Dict(:B => :w2)))
     @test sprint(show, MIME("text/plain"), d) == """
-        Unsatisfiable — 1 conflict, 2 fixes:
+        Unsatisfiable — 1 conflict:
 
         Conflict 1: A cannot be satisfied.
           • you require A
           • no version of B is available: w3 is excluded by your compat and your pin,
             w2 by your compat, w1 by your pin
-
-        Verified fixes:
-          1. relax your compat on B
-             → allows: A v1, B w2
-          2. drop requirement A
+          Fix it by any one of:
+            1. relax your compat on B
+               → allows: A v1, B w2
+            2. drop requirement A
         """
+    @test sprint(show, d) == "Diagnosis: 1 conflict, 2 fixes"
 end
 
 @testset "diagnosis: the report says nothing about how it was found" begin
@@ -492,9 +629,10 @@ end
                 diag = check_diagnosis(data, prob; by)
                 diag === nothing && continue
                 diagnoses += 1
-                fixes += length(diag.fixes)
+                fixes += sum(c -> length(c.fixes), diag.conflicts)
                 relaxations += count(a.kind !== :drop
-                    for fix in diag.fixes for a in fix.actions)
+                    for c in diag.conflicts for fix in c.fixes
+                    for a in fix.actions)
             end
         end
     end
@@ -540,10 +678,10 @@ end
     @test any(f isa Availability && f.pkg == "PrettyTables" && unavailable(f)
               for f in c.chain)
     # relaxing either bound is a fix, and so is not requiring DataFrames
-    sets = Set(Set(fix.actions) for fix in d.fixes)
+    sets = Set(Set(fix.actions) for fix in c.fixes)
     @test Set([Action(:compat, "PrettyTables")]) ∈ sets
     @test Set([Action(:drop, "DataFrames")]) ∈ sets
-    for fix in d.fixes
+    for fix in c.fixes
         fix.actions == [Action(:compat, "PrettyTables")] || continue
         @test fix.solution["DataFrames"] ∈ VersionSpec("1")
         @test haskey(fix.solution, "PrettyTables")

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -533,7 +533,7 @@ end
     @test d.others === :larger
     report = sprint(show, MIME("text/plain"), d)
     @test occursin("The only fix: relax your compat on C", report)
-    @test occursin("Other, larger solutions exist.", report)
+    @test occursin("Larger solutions also exist.", report)
 end
 
 @testset "diagnosis: a costlier repair is asked about, not counted" begin
@@ -563,7 +563,7 @@ end
     @test all(length(r) > smallest
               for r in setdiff(repairs, fix_combinations(d)))
     @test d.others === :larger
-    @test occursin("Other, larger solutions exist.",
+    @test occursin("Larger solutions also exist.",
         sprint(show, MIME("text/plain"), d))
 
     # the same shape of menu over a query where every repair is a smallest one:
@@ -631,7 +631,7 @@ end
     @test length(offered) == 2
     @test d.others === :some
     report = sprint(show, MIME("text/plain"), d)
-    @test occursin("Other solutions exist.", report)
+    @test occursin("Other solutions also exist.", report)
     @test !occursin("larger", report)
 end
 
@@ -720,7 +720,7 @@ end
     # combination of them is a repair and there are no others
     d = resolve(two_conflicts, Problem([:A, :B, :E, :F]))
     @test sprint(show, MIME("text/plain"), d) == """
-        Unsatisfiable — 2 conflicts, every one of which has to be fixed:
+        Unsatisfiable — 2 conflicts, each of which must be fixed:
 
         Conflict 1: A and B cannot both be satisfied.
           • you require A

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -22,6 +22,11 @@
 # checked against a third oracle, in the cases small enough for it: every subset
 # of a pool of actions, resolved from the artifact, reduced to the minimal ones.
 #
+# Half of what `others` says is that no repair costs more than the ones on the
+# menus, which the diagnosis decides with a single solve against a bounded
+# enumeration. That gets a fourth oracle: the whole family of repairs,
+# enumerated with no bound at all, judged by its sizes.
+#
 # What the report says is checked separately, against hand-built cases, since
 # there is no oracle for English.
 
@@ -31,6 +36,7 @@ using Resolver: Problem, PkgData, PkgInfo, SAT, Diagnosis, pkg_info, relax,
     sat_assume_var
 using Resolver.Diagnostics: Diagnostics, Conflict, Fix, Action, Fact,
     Requirement, Availability, unavailable, action_phrase
+using Resolver.UnsatCores: sat_mcses
 
 using Pkg.Versions: VersionSpec
 
@@ -147,6 +153,30 @@ function minimal_repairs(info, prob::Problem{P}, pool::Vector{Action{P}};
     return Set(r for r in repairs if !any(s -> s ⊊ r, repairs))
 end
 
+# How many repairs to enumerate for the oracle below before giving up on it.
+const REPAIR_LIMIT = 512
+
+# Every repair of `prob` there is, as sets of the literals a diagnosis assumes,
+# or `nothing` when there are too many to enumerate. The oracle for what a
+# report says it leaves out: the diagnosis decides whether anything costs more
+# than its menus do with a single solve, and this decides it by enumerating the
+# whole family and looking at the sizes.
+#
+# It asks the same questions of the same instance `diagnose` does, so it goes
+# through the same helpers — and, like `diagnose`, leaves the instance as it
+# found it.
+function all_repairs(sat::SAT{P}, prob::Problem{P}) where {P}
+    vm = Diagnostics.VarMap(sat)
+    req_lits = Int[installed_lit(sat, p) for p in unique(prob.reqs)
+                   if haskey(vm, p)]
+    repairs = with_classes_relaxed(sat) do
+        Diagnostics.with_emptied_packages(sat, vm) do pkg_lits, _
+            sat_mcses(sat, [req_lits; pkg_lits]; limit = REPAIR_LIMIT)
+        end
+    end
+    return length(repairs) < REPAIR_LIMIT ? repairs : nothing
+end
+
 # every property a `Diagnosis` of `prob` claims, checked against the instance
 # it was drawn from and against fresh resolves of the artifact. Returns the
 # diagnosis, or `nothing` when the problem is satisfiable after all
@@ -259,6 +289,21 @@ function check_diagnosis(data, prob::Problem{P}; order = nothing,
                     order, by) !== nothing
             end
         end
+
+        ## what the menus leave out
+        #
+        # Half of what `others` says is that no repair of the query costs more
+        # than the ones the menus reach. The diagnosis decides that by asking
+        # the instance for a repair holding none of the cheapest ones; this
+        # decides it by enumerating every repair there is and comparing sizes.
+        # `:some` claims nothing either way — it is what a family the menus do
+        # not cover reports, whatever else is true of it
+        repairs = all_repairs(sat, prob)
+        if repairs !== nothing && !isempty(repairs)
+            larger = maximum(length, repairs) > minimum(length, repairs)
+            d.others === :none   && @test !larger
+            d.others === :larger && @test larger
+        end
     finally
         finalize(sat)
     end
@@ -306,6 +351,19 @@ const shared_bound = Dict(
     :A => PkgData([:a2, :a1], Dict(:a2 => [:C]), Dict(:a2 => Dict(:C => [:c2]))),
     :B => PkgData([:b2, :b1], Dict(:b2 => [:C]), Dict(:b2 => Dict(:C => [:c2]))),
     :C => PkgData([:c2, :c1], DEPS_NONE, COMP_NONE),
+)
+
+# :A and :B both need :C, and :E and :F disagree about :G. With a bound that
+# leaves :C nothing, settling the first conflict cheaply takes one action and
+# settling it any other way takes two — so the smallest repairs are a product of
+# two menus and there are repairs beyond them that cost more
+const larger_repair = Dict(
+    :A => PkgData([:v1], Dict(:v1 => [:C]), COMP_NONE),
+    :B => PkgData([:v1], Dict(:v1 => [:C]), COMP_NONE),
+    :C => PkgData([:c1], DEPS_NONE, COMP_NONE),
+    :E => PkgData([:v1], Dict(:v1 => [:G]), Dict(:v1 => Dict(:G => [:v1]))),
+    :F => PkgData([:v1], Dict(:v1 => [:G]), Dict(:v1 => Dict(:G => [:v2]))),
+    :G => PkgData([:v2, :v1], DEPS_NONE, COMP_NONE),
 )
 
 # four requirements whose disagreements form a path — :C with :B, :B with :A,
@@ -476,6 +534,48 @@ end
     report = sprint(show, MIME("text/plain"), d)
     @test occursin("The only fix: relax your compat on C", report)
     @test occursin("Other, larger solutions exist.", report)
+end
+
+@testset "diagnosis: a costlier repair is asked about, not counted" begin
+    # Two queries whose menus have the same shape — a product of choices
+    # reaching every smallest repair — and that differ only in whether anything
+    # beyond those repairs exists at all. The oracle for both is every minimal
+    # repair drawn from the actions involved, resolved from scratch.
+
+    # relaxing the bound on :C is the cheap way to settle :A with :B, and
+    # dropping both of them is the expensive one; :E with :F is settled by
+    # dropping either. So the smallest repairs are two, and two more cost three
+    # actions each
+    prob = Problem([:A, :B, :E, :F]; compat = Dict(:C => Symbol[]))
+    d = check_diagnosis(larger_repair, prob)
+    pool = [Action(:compat, :C), Action(:drop, :A), Action(:drop, :B),
+            Action(:drop, :E), Action(:drop, :F)]
+    repairs = minimal_repairs(pkg_info(larger_repair, prob), prob, pool)
+    @test repairs == Set(Set(r) for r in (
+        [Action(:compat, :C), Action(:drop, :E)],
+        [Action(:compat, :C), Action(:drop, :F)],
+        [Action(:drop, :A), Action(:drop, :B), Action(:drop, :E)],
+        [Action(:drop, :A), Action(:drop, :B), Action(:drop, :F)]))
+    smallest = minimum(length, repairs)
+    # the menus are exactly the smallest of them ...
+    @test fix_combinations(d) == Set(r for r in repairs if length(r) == smallest)
+    # ... and what they leave out costs more, which is what the report says
+    @test all(length(r) > smallest
+              for r in setdiff(repairs, fix_combinations(d)))
+    @test d.others === :larger
+    @test occursin("Other, larger solutions exist.",
+        sprint(show, MIME("text/plain"), d))
+
+    # the same shape of menu over a query where every repair is a smallest one:
+    # two conflicts with nothing to do but drop a requirement from each
+    prob = Problem([:A, :B, :E, :F])
+    d = check_diagnosis(two_conflicts, prob)
+    pool = [Action(:drop, p) for p in (:A, :B, :E, :F)]
+    repairs = minimal_repairs(pkg_info(two_conflicts, prob), prob, pool)
+    @test allequal(length(r) for r in repairs)
+    @test fix_combinations(d) == repairs
+    @test d.others === :none
+    @test !occursin("Other", sprint(show, MIME("text/plain"), d))
 end
 
 @testset "diagnosis: one reason, every requirement it breaks" begin

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -405,7 +405,7 @@ end
 
         Conflict 1: R cannot be satisfied.
           • you require R
-          • P: p2 is excluded by your compat
+          • P: p2 excluded by your compat
           Fix it by any one of:
             1. relax your compat on P
                → allows: P p2, R r1
@@ -651,8 +651,8 @@ end
 
         Conflict 1: A cannot be satisfied.
           • you require A
-          • no version of B is available: w3 is excluded by your compat and your pin,
-            w2 by your compat, w1 by your pin
+          • no version of B is available: w3 excluded by your compat and your pin, w2
+            by your compat, w1 by your pin
           Fix it by any one of:
             1. relax your compat on B
                → allows: A v1, B w2

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -69,6 +69,39 @@ function sat_assuming(sat::SAT, lits)
     return sat_solve(sat)
 end
 
+# Does the chain consist of exactly the reasons its requirements fail? Every
+# subset of its facts is put to the solver, the minimal unsatisfiable ones are
+# read off, and what has to hold is that between them they use every fact.
+#
+# This is the general form of "every fact is load-bearing", which is the case
+# where the only minimal subset is the whole chain — a conflict whose
+# requirements fail *together*. A conflict that gathers requirements failing
+# separately for a shared reason has one minimal subset per requirement, and
+# the test is that the chain is their union: no fact left over, and none of the
+# requirements dropped for being redundant.
+#
+# Brute force, which is what makes it an oracle; chains are a handful of facts,
+# and one too big to enumerate falls back to the unsatisfiability check alone.
+function chain_is_covered(sat::SAT, c::Conflict)
+    n = length(c.chain)
+    n ≤ 8 || return !sat_assuming(sat, conflict_literals(sat, c))
+    lits = [fact_literals(sat, f) for f in c.chain]
+    subset(bits) = reduce(vcat,
+        (lits[i] for i = 1:n if !iszero(bits & (1 << (i-1)))); init = Int[])
+    unsat = Bool[!sat_assuming(sat, subset(bits)) for bits = 0:(1 << n) - 1]
+    covered = falses(n)
+    for bits = 0:(1 << n) - 1
+        unsat[bits+1] || continue
+        # minimal iff dropping any one of its facts makes it satisfiable
+        any(i -> !iszero(bits & (1 << (i-1))) && unsat[(bits ⊻ (1 << (i-1)))+1],
+            1:n) && continue
+        for i = 1:n
+            iszero(bits & (1 << (i-1))) || (covered[i] = true)
+        end
+    end
+    return all(covered)
+end
+
 # the withdrawal a set of actions asks for, read off here rather than taken
 # from the diagnosis: `:drop` names a requirement to stop requiring, every
 # other kind names a constraint of the problem and a package to lift it for
@@ -161,12 +194,9 @@ function check_diagnosis(data, prob::Problem{P}; order = nothing,
                 end
                 # the chain is a conflict: assuming just these facts fails
                 @test !sat_assuming(sat, lits)
-                # ... and every fact in it is load-bearing: take one away and
-                # what is left of the conflict is satisfiable
-                for f in c.chain
-                    drop = Set(fact_literals(sat, f))
-                    @test sat_assuming(sat, filter(∉(drop), lits))
-                end
+                # ... and nothing in it is a passenger: the minimal conflicts
+                # among its own facts cover every one of them
+                @test chain_is_covered(sat, c)
             end
         end
 
@@ -266,6 +296,16 @@ const shared_dep = Dict(
     :A => PkgData([:v1], Dict(:v1 => [:C]), COMP_NONE),
     :B => PkgData([:v1], Dict(:v1 => [:C]), COMP_NONE),
     :C => PkgData([:c1], DEPS_NONE, COMP_NONE),
+)
+
+# two requirements that each need :C at its newer version, and a bound of their
+# own holding each of them at the version that does. One bound on :C is what
+# breaks both, and relaxing it is the one cheapest fix — so the conflict has to
+# name both requirements, not whichever of them the search reached first
+const shared_bound = Dict(
+    :A => PkgData([:a2, :a1], Dict(:a2 => [:C]), Dict(:a2 => Dict(:C => [:c2]))),
+    :B => PkgData([:b2, :b1], Dict(:b2 => [:C]), Dict(:b2 => Dict(:C => [:c2]))),
+    :C => PkgData([:c2, :c1], DEPS_NONE, COMP_NONE),
 )
 
 # four requirements whose disagreements form a path — :C with :B, :B with :A,
@@ -438,6 +478,41 @@ end
     @test occursin("Other, larger solutions exist.", report)
 end
 
+@testset "diagnosis: one reason, every requirement it breaks" begin
+    # :A and :B are each unsatisfiable on their own, for the same reason, and
+    # one action rescues both. Either of them alone is enough to make that
+    # reason a conflict, so a story that stopped at the smallest one would name
+    # one of them and leave the other out of the report altogether — the user
+    # would relax the bound on :C and never learn the other had been broken
+    prob = Problem([:A, :B];
+        compat = Dict(:A => [:a2], :B => [:b2], :C => [:c1]))
+    d = check_diagnosis(shared_bound, prob)
+    c = only(d.conflicts)
+    # both requirements, each with the bound that pins it to the version that
+    # needs :C, and the bound on :C they share
+    @test c.reqs == [:A, :B]
+    @test c.chain == Fact[Requirement(:A), Requirement(:B),
+        Availability{Symbol,Symbol}(:A, [:a2, :a1], [Symbol[], [:compat]]),
+        Availability{Symbol,Symbol}(:B, [:b2, :b1], [Symbol[], [:compat]]),
+        Availability{Symbol,Symbol}(:C, [:c2, :c1], [[:compat], Symbol[]])]
+    @test [fix.actions for fix in c.fixes] == [[Action(:compat, :C)]]
+    @test only(c.fixes).solution == Dict(:A => :a2, :B => :b2, :C => :c2)
+    # ... and neither of them can be satisfied on its own, which is what makes
+    # leaving one out a lie rather than a shortening
+    for p in (:A, :B)
+        @test resolve(shared_bound, Problem([p];
+            compat = Dict(p => [Symbol("$(lowercase(string(p)))2")],
+                          :C => [:c1])); diagnose = false) === nothing
+    end
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("you require A", report)
+    @test occursin("you require B", report)
+    @test occursin("A and B cannot both be satisfied", report)
+    @test occursin("The only fix: relax your compat on C", report)
+    # the witness names both of them too
+    @test occursin("→ allows: A a2, B b2, C c2", report)
+end
+
 @testset "diagnosis: cheapest repairs that are not a product" begin
     # The disagreements form a path :C–:B–:A–:D, so the cheapest repairs are
     # {A,B}, {A,C} and {B,D} — three of them, which is not a product of menu
@@ -547,7 +622,7 @@ end
     @test sprint(show, MIME("text/plain"), d) == """
         Unsatisfiable — 2 conflicts, every one of which has to be fixed:
 
-        Conflict 1: A and B cannot be satisfied together.
+        Conflict 1: A and B cannot both be satisfied.
           • you require A
           • you require B
           Fix it by any one of:
@@ -556,7 +631,7 @@ end
             2. drop requirement B
                → allows: A v1
 
-        Conflict 2: E and F cannot be satisfied together.
+        Conflict 2: E and F cannot both be satisfied.
           • you require E
           • you require F
           Fix it by any one of:


### PR DESCRIPTION
Closes #83.

An unsatisfiable diagnosis used to report "N conflicts" and then one flat menu of
fixes covering all of them at once. That menu enumerates *across* conflicts, so
it is a product — k conflicts of m repairs each give up to mᵏ combinations,
truncated at 32. Long, repetitive, and silently incomplete.

This computes the minimal correction sets, keeps the smallest, and **factors
them**. Each coordinate of that product becomes a conflict with its own short
menu, and every path through the menus is a complete fix by construction — so
there is no composition check and no hedged warning about what might still be
broken.

## Before / after

Three requirements, three independent bounds. Before, an 18-item flat product
(4 of 18 shown):

```
Unsatisfiable — 3 conflicts, 18 fixes:

Conflict 1: DataFrames cannot be satisfied.
  • no version of PrettyTables is available: 0.1.0–3.4.8 are excluded by your compat
Conflict 2: Plots cannot be satisfied. …
Conflict 3: HTTP cannot be satisfied. …

Verified fixes:
  1. relax your compat on PrettyTables, relax your compat on RecipesBase and
     relax your compat on URIs
     → allows: DataFrames 1.8.2, HTTP 1.11.0, Plots 1.41.6, PrettyTables 3.4.8,
       RecipesBase 1.3.4, URIs 1.7.0
  2. relax your compat on HTTP, relax your compat on PrettyTables and relax
     your compat on RecipesBase
     → allows: DataFrames 1.8.2, HTTP 0.8.19, Plots 1.41.6, …
  … 16 more …
```

After — and with **no qualifier**, because those 18 combinations are exactly the
minimal fixes:

```
Unsatisfiable — 3 conflicts, every one of which has to be fixed:

Conflict 1: DataFrames cannot be satisfied.
  • you require DataFrames
  • DataFrames: 0.11.7–0.22.7 are excluded by your compat
  • no version of PrettyTables is available: 0.1.0–3.4.8 are excluded by your compat
  Fix it by any one of:
    1. relax your compat on DataFrames   → allows: DataFrames 0.21.8
    2. relax your compat on PrettyTables → allows: DataFrames 1.8.2, PrettyTables 3.4.8
    3. drop requirement DataFrames

Conflict 2: Plots cannot be satisfied.
  • no version of RecipesBase is available: 0.4.0–1.3.4 are excluded by your compat
  Fix it by any one of:
    1. relax your compat on RecipesBase  → allows: Plots 1.41.0, RecipesBase 1.3.4
    2. drop requirement Plots

Conflict 3: HTTP cannot be satisfied. …
```

## How it works

1. Enumerate the minimal correction sets, keep the minimum-cardinality ones.
2. Factor that family: two actions share a coordinate iff they never appear in
   the same repair. Verify it really is the product (one action per coordinate,
   counts agree); if not, cover with the largest rectangle.
3. Each coordinate is a conflict. Its story is a minimal explanation taken with
   the other coordinates' choices already settled, so it explains *this* choice.
4. `Diagnosis.fixes` is gone; `Conflict.fixes` is new. `others :: Symbol` says
   what the menus leave out: `:none`, `:larger`, `:some`.

Two qualifier sentences, printed only when earned:

- **"Other, larger solutions exist."** — repairs exist that cost more.
- **"Other solutions exist."** — the menus do not reach every cheapest repair.

When neither applies the product *is* the complete set of minimal fixes, and the
report says nothing extra. Measured on 80 generated registry failures: no
qualifier in 29%, one rectangle covers the cheapest repairs in 83%.

## Why "N conflicts" changed meaning

The old count was `length(sat_disjoint_muses(...))` — a greedy loop that extracts
a conflict, deletes all its literals, and repeats, so disjointness was
manufactured rather than discovered. Three measurements said it overstates
independence; #83 records them. The count is now the number of coordinates,
which equals the minimum number of actions any fix needs.

## Conflicts name every requirement they rescue

Worth calling out because it is subtle. When several requirements fail for the
same reason, any one of them already makes that reason unsatisfiable, so
minimality *forces* the others out of the explanation — the report would name one
arbitrarily and the rest would vanish. A user would fix the bound and never learn
the rest had been broken:

```
Conflict 1: DataFrames and CSV cannot both be satisfied.
  • you require DataFrames
  • you require CSV
  • CSV: 0.3.0–0.9.4 are excluded by your compat
  • DataFrames: 0.11.7–0.22.7 are excluded by your compat
  • no version of Tables is available: 0.1.0–1.13.0 are excluded by your compat
  The only fix: relax your compat on Tables
    → allows: CSV 0.10.16, DataFrames 1.8.2, Tables 1.13.0
```

Every requirement the smallest explanation left out is asked whether it can be
satisfied on its own; the ones that cannot are exactly the ones this fix rescues.

## Testing

The design's core claim — every combination of per-coordinate choices resolves —
is checked directly and from scratch, never by asking the diagnosis: 1550
diagnoses, 2507 combinations, 0 failures, with 232 conflicts naming more than one
requirement. `check_diagnosis` also brute-forces every subset of a chain to
confirm the facts are covered by minimal reasons with no passengers.

Every new test was verified to fail when the thing it tests is broken. Disabling
the rescue pass produces exactly 5 failures; swapping the two qualifier sentences,
forcing `others`, truncating menus, and disabling the forced-action branch each
fail their own assertions.

Full suite green on 1.12.6 and on nightly 1.14.0-DEV; docs build clean.

`sat_disjoint_muses` now has no caller but is left in place — it is a documented,
tested `UnsatCores` API, and #83 rejects it as a decomposition, not as a function.

🤖 Reviewed and pushed with [Claude Code](https://claude.com/claude-code)