### PR TITLE
Say why one package matters to another

### DIFF
--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -552,10 +552,10 @@ named(f::Diagnostics.Availability, name::Function) =
     Diagnostics.Availability(name(f.pkg), f.members, f.excluded)
 named(f::Diagnostics.Dependency, name::Function) =
     Diagnostics.Dependency(name(f.pkg), f.versions, name(f.dep),
-        f.offering, f.allowed)
+        f.offering, f.allowed, f.newest, f.oldest)
 named(f::Diagnostics.Incompatibility, name::Function) =
     Diagnostics.Incompatibility(name(f.pkg), f.versions, name(f.other),
-        f.offering, f.allowed)
+        f.offering, f.allowed, f.newest, f.oldest)
 
 function package_name(uuid::UUID)
     uuid == JULIA_UUID && return "julia"

--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -550,6 +550,12 @@ named(f::Diagnostics.Requirement, name::Function) =
     Diagnostics.Requirement(name(f.pkg))
 named(f::Diagnostics.Availability, name::Function) =
     Diagnostics.Availability(name(f.pkg), f.members, f.excluded)
+named(f::Diagnostics.Dependency, name::Function) =
+    Diagnostics.Dependency(name(f.pkg), f.versions, name(f.dep),
+        f.offering, f.allowed)
+named(f::Diagnostics.Incompatibility, name::Function) =
+    Diagnostics.Incompatibility(name(f.pkg), f.versions, name(f.other),
+        f.offering, f.allowed)
 
 function package_name(uuid::UUID)
     uuid == JULIA_UUID && return "julia"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,8 @@ Resolver.Diagnostics.action_phrase
 Resolver.Diagnostics.Fact
 Resolver.Diagnostics.Requirement
 Resolver.Diagnostics.Availability
+Resolver.Diagnostics.Dependency
+Resolver.Diagnostics.Incompatibility
 Resolver.Diagnostics.unavailable
 Resolver.Diagnostics.diagnose
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,7 +16,8 @@ Unsatisfiable — 2 conflicts, each of which must be fixed:
 
 Conflict 1: DataFrames cannot be satisfied.
   • you require DataFrames
-  • DataFrames: 0.11.7–0.22.7 excluded by your compat
+  • DataFrames: ≤ 0.22.7 excluded by your compat
+  • DataFrames 1.3.5–1.8.2 requires PrettyTables
   • no version of PrettyTables is available: 0.1.0–3.4.8 excluded by your
     compat
   Fix it by any one of:
@@ -28,6 +29,7 @@ Conflict 1: DataFrames cannot be satisfied.
 
 Conflict 2: Plots cannot be satisfied.
   • you require Plots
+  • Plots 1.0.6–1.41.7 requires RecipesBase
   • no version of RecipesBase is available: 0.4.0–1.3.4 excluded by your
     compat
   Fix it by any one of:

--- a/docs/src/theory/diagnostics.md
+++ b/docs/src/theory/diagnostics.md
@@ -284,3 +284,74 @@ This is the one place a report can name a *user's* constraint at all —
 registry compatibility is in the conflict matrices, where it is
 indistinguishable from any other conflict — and it is why a story can say
 which bound emptied a class without asking anything.
+
+## Why one package matters to another
+
+A chain of requirements and availabilities says what the query asked for and
+what its constraints left of the packages, and stops there. The step between
+the two — that these versions of one package need that other one, at these
+versions of it — belongs to the registry, and it is the only part of the
+story the user could not have written down themselves.
+
+It is read off the universe and nothing else. For a class ``c`` of ``p``, the
+dependency columns of ``p``'s matrix say which packages ``c`` depends on and
+the interaction blocks say which classes of each partner ``c`` admits. Both
+are registry facts, untouched by any constraint. What has to be decided is
+which of them to say.
+
+The walk that decides is a *forced descent*. Write ``A(p)`` for the classes of
+``p`` this query admits, and ``\mathrm{adm}_p(S, q)`` for the classes of ``q``
+that some class in ``S`` of ``p`` admits. Start from the conflict's
+requirements with ``L(p) = A(p)`` and iterate two rules:
+
+* **forcing** — if ``p`` is forced and *every* class in ``L(p)`` depends on
+  ``q``, then ``q`` is forced. No choice of a version of ``p`` avoids it.
+* **narrowing** — for forced ``p`` and forced ``q``,
+  ``L(q) \leftarrow L(q) \cap \mathrm{adm}_p(L(p), q)``. Two packages both
+  installed have to agree, however the bound got there.
+
+Both rules only add to the forced set and only remove from the ``L``'s, so the
+iteration settles. It stops at the first pass that leaves a forced ``q`` with
+``L(q) = \emptyset``: that ``q`` is where the story ends.
+
+The walk answers with a set per package rather than pairing versions up, so
+the union inside ``\mathrm{adm}`` over-approximates what is really reachable.
+That is the safe direction: ``L(q) = \emptyset`` really does mean no version
+of ``q`` can be installed, while ``L(q) \ne \emptyset`` promises nothing.
+A walk that finds nothing costs the report a sentence; it never invents one.
+And nothing it emits is a claim about satisfiability — the requirements and
+the availabilities carry that, and the solver checked them.
+
+What the report says of the starved ``q`` is the packages whose bounds left it
+nothing, cut down to a set that still does — and then, exactly as with the
+requirements above, every one of the rest that starves ``q`` on its own, since
+otherwise minimality would name one of several and drop the others. Each comes
+with the forcing steps that put it in the query's way, so every package the
+story names is one the story has already reached.
+
+A step also has to decide whether to state its bound at all. On the last
+one it is the whole point: it is what the query's own constraints have left
+nothing of, and the reader wants to know what would have done instead. On the
+steps that lead there it is decoration — and worse, because versions that
+agree about needing a package often disagree about which of it they will
+take, so a step carrying its bound is several sentences where one was
+wanted, and the versions it would name are the subject of the next step
+anyway. So only the relations about the starved package carry a bound.
+
+### Which way round a bound may be said
+
+`PkgInfo` records compatibility symmetrically: a conflict between class ``c``
+of ``p`` and class ``d`` of ``q`` sits in both matrices, and which side's
+`Project.toml` declared it is not recoverable. So "``p`` requires ``q`` at
+``V``" is not a sentence the instance licenses on its own. What it does
+license is the dependency: the columns saying that ``c`` depends on ``q`` are
+``p``'s own, and the package that declares a dependency is the one whose
+`[compat]` entry a bound on it would be in.
+
+A directed sentence is therefore stated exactly where every version it speaks
+for depends on the package it speaks about; versions that merely have to get
+along with it get the symmetric sentence, which attributes nothing to either
+side. Splitting the versions of ``p`` by what they say about ``q`` is what
+makes this a decision per fact rather than per package: a package whose older
+versions depend on ``q`` and whose newer ones do not is two facts, not one
+averaged over both.

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -411,10 +411,10 @@ function availability_phrase(f::Availability)
         if !isempty(excluded[i])
             by = kinds_phrase(excluded[i])
             push!(clauses, isempty(clauses) ?
-                "$(range_phrase(members, i, j; high = i == 1,
-                    low = j == length(members))) excluded by $by" :
-                "$(range_phrase(members, i, j; high = i == 1,
-                    low = j == length(members))) by $by")
+                "$(range_phrase(members, i, j; high = open_high(i, j, members),
+                    low = open_low(i, j, members))) excluded by $by" :
+                "$(range_phrase(members, i, j; high = open_high(i, j, members),
+                    low = open_low(i, j, members))) by $by")
         end
         i = j + 1
     end
@@ -448,6 +448,12 @@ end
 # the versions this query left standing, so leaving them out would let the
 # sentence be read as one about the package rather than about the choice the
 # resolve had — and a version range is shorter than saying so.
+# A run reaching one end of the offering is stated as an open bound; a run
+# reaching *both* is not "any version" — it is every version there is, and the
+# sentence around it already says so — so it is named in full.
+open_high(i::Int, j::Int, members) = i == 1 && j != length(members)
+open_low(i::Int, j::Int, members) = j == length(members) && i != 1
+
 # An open bound is stated only at one end: a run reaching *both* ends of what
 # the query admits is still not "any version" — the availability fact just said
 # which versions were taken away — so it is named in full.

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -24,11 +24,11 @@ re-exports none of the others.
 module Diagnostics
 
 export Diagnosis, Conflict, Fix, Action, Fact, Requirement, Availability,
-    unavailable, action_phrase, diagnose
+    Dependency, Incompatibility, unavailable, action_phrase, diagnose
 
-using ..Resolver: SAT, Problem, Universe, relax, resolve, installed_lit,
-    with_temp_clauses, with_classes_relaxed, sat_new_variable, sat_add_var,
-    sat_add, sat_solve, exclusion_kinds, class_exclusions
+using ..Resolver: SAT, PkgInfo, Problem, Universe, relax, resolve, nclasses,
+    installed_lit, with_temp_clauses, with_classes_relaxed, sat_new_variable,
+    sat_add_var, sat_add, sat_solve, exclusion_kinds, class_exclusions
 using ..UnsatCores: sat_mus, sat_mcses
 
 # What an unsatisfiable resolve says, and how it is found.
@@ -97,10 +97,18 @@ using ..UnsatCores: sat_mus, sat_mcses
     Resolver.Diagnostics.Fact
 
 One statement in a conflict's chain: something true of the packages that helps
-explain why the requirements cannot hold together. The two kinds are
+explain why the requirements cannot hold together. The kinds are
 [`Requirement`](@ref Resolver.Diagnostics.Requirement) — "you require this
-package" — and [`Availability`](@ref Resolver.Diagnostics.Availability) — "this
-is what your constraints leave of the package's versions".
+package"; [`Availability`](@ref Resolver.Diagnostics.Availability) — "this is
+what your constraints leave of the package's versions";
+[`Dependency`](@ref Resolver.Diagnostics.Dependency) — "these versions of this
+package need that one, at these versions"; and
+[`Incompatibility`](@ref Resolver.Diagnostics.Incompatibility) — "these
+versions of the two do not go together".
+
+The first two are about what the query asked for, and the last two about what
+the registry says, which is the step from one to the next that a reader could
+not have worked out for themselves.
 
 Facts are plain data, so a caller can render its own report from a
 [`Diagnosis`](@ref) without asking the resolver anything further.
@@ -148,6 +156,63 @@ struct Availability{P,V} <: Fact
 end
 
 """
+    Resolver.Diagnostics.Dependency{P,V}(pkg, versions, dep, offering, allowed)
+
+The fact that some versions of `pkg` need `dep`, and which versions of it they
+will take:
+
+  * `versions` — the versions of `pkg` this fact speaks for: a run of what the
+    package offers, best first. Every one of them depends on `dep` and takes
+    the same versions of it, and they are versions this query admits, so the
+    fact is about the choice the resolve actually had.
+  * `offering` — every version of `dep` the resolve could have chosen, in the
+    order `dep` lists them.
+  * `allowed` — per version of the offering, whether `versions` admit it.
+    Nothing of the query is in this: it is what `pkg` says about `dep`. It is
+    `nothing` where no bound of `pkg`'s is what the conflict turns on — a step
+    on the way to the package that has nothing left, or a `dep` the query has
+    left nothing of, which every bound would starve alike — and then the fact
+    says only that `dep` is needed, which is all it is there to say.
+
+The direction is a claim, not a convention. A registry records compatibility
+symmetrically, so which side declared a bound is not generally recoverable, and
+this fact is stated only where the registry does record `pkg` as depending on
+`dep`. Where it does not, all that can be said is that the two do not go
+together, which is an
+[`Incompatibility`](@ref Resolver.Diagnostics.Incompatibility).
+"""
+struct Dependency{P,V} <: Fact
+    pkg      :: P
+    versions :: Vector{V}
+    dep      :: P
+    offering :: Vector{V}
+    allowed  :: Union{Nothing,Vector{Bool}}
+end
+
+"""
+    Resolver.Diagnostics.Incompatibility{P,V}(pkg, versions, other, offering, allowed)
+
+The fact that some versions of `pkg` go with only some versions of `other`,
+with nothing said about which of the two declared it. The fields are
+[`Dependency`](@ref Resolver.Diagnostics.Dependency)'s: `versions` is a run of
+`pkg`'s versions this query admits that all agree about `other`, and `allowed`
+says, per version of `other`'s `offering`, whether they admit it.
+
+A registry records compatibility symmetrically — that these two versions
+cannot be installed together, not that one of them said so — so this is what
+is left to say when the versions it speaks for do not depend on the package it
+speaks about: there is no side to put the bound on, and it puts it on neither.
+Reading it the other way round is just as true.
+"""
+struct Incompatibility{P,V} <: Fact
+    pkg      :: P
+    versions :: Vector{V}
+    other    :: P
+    offering :: Vector{V}
+    allowed  :: Vector{Bool}
+end
+
+"""
     Resolver.Diagnostics.unavailable(fact::Availability) :: Bool
 
 Whether the fact leaves its package with no version at all — every version it
@@ -180,6 +245,20 @@ Base.hash(a::Action, h::UInt) = hash(a.pkg, hash(a.kind, hash(:Action, h)))
 
 Base.:(==)(a::Requirement, b::Requirement) = a.pkg == b.pkg
 Base.hash(a::Requirement, h::UInt) = hash(a.pkg, hash(:Requirement, h))
+
+Base.:(==)(a::Dependency, b::Dependency) =
+    a.pkg == b.pkg && a.versions == b.versions && a.dep == b.dep &&
+    a.offering == b.offering && a.allowed == b.allowed
+Base.hash(a::Dependency, h::UInt) =
+    hash(a.allowed, hash(a.offering, hash(a.dep,
+        hash(a.versions, hash(a.pkg, hash(:Dependency, h))))))
+
+Base.:(==)(a::Incompatibility, b::Incompatibility) =
+    a.pkg == b.pkg && a.versions == b.versions && a.other == b.other &&
+    a.offering == b.offering && a.allowed == b.allowed
+Base.hash(a::Incompatibility, h::UInt) =
+    hash(a.allowed, hash(a.offering, hash(a.other,
+        hash(a.versions, hash(a.pkg, hash(:Incompatibility, h))))))
 
 Base.:(==)(a::Availability, b::Availability) =
     a.pkg == b.pkg && a.members == b.members && a.excluded == b.excluded
@@ -326,6 +405,53 @@ function availability_phrase(f::Availability)
     return isempty(clauses) ? head : "$head: $(join(clauses, ", "))"
 end
 
+# The versions a mask picks out of a package's offering, as an English list of
+# ranges. Packages list their versions best first, so a run reads low to high;
+# a run is a run of the offering, so a range never spans a version the mask
+# leaves out.
+function offering_phrase(offering::Vector, allowed::Vector{Bool})
+    parts = String[]
+    i = 1
+    while i ≤ length(allowed)
+        if allowed[i]
+            j = i
+            while j < length(allowed) && allowed[j+1]
+                j += 1
+            end
+            push!(parts, range_phrase(offering, i, j))
+            i = j
+        end
+        i += 1
+    end
+    return join(parts, ", ")
+end
+
+# What a relation is about. The versions are named whatever they are: they are
+# the versions this query left standing, so leaving them out would let the
+# sentence be read as one about the package rather than about the choice the
+# resolve had — and a version range is shorter than saying so.
+relation_subject(f) =
+    "$(f.pkg) $(range_phrase(f.versions, 1, length(f.versions)))"
+
+# a dependency as one line, with the bound where there is one to state
+function dependency_phrase(f::Dependency)
+    subject = relation_subject(f)
+    (f.allowed === nothing || all(f.allowed)) &&
+        return "$subject requires $(f.dep)"
+    any(f.allowed) || return "$subject requires $(f.dep) at no version of it"
+    return "$subject requires $(f.dep) at " *
+        offering_phrase(f.offering, f.allowed)
+end
+
+# An incompatibility as one line. Nothing here says which package's compat
+# entry it came from, because nothing in the universe does
+function incompatibility_phrase(f::Incompatibility)
+    subject = relation_subject(f)
+    any(f.allowed) || return "$subject works with no version of $(f.other)"
+    return "$subject works with $(f.other) only at " *
+        offering_phrase(f.offering, f.allowed)
+end
+
 # print `text` filled to `width` columns, `lead` before the first line and
 # `rest` before every later one
 function print_wrapped(io::IO, text::AbstractString, lead::String, rest::String;
@@ -348,6 +474,19 @@ function print_wrapped(io::IO, text::AbstractString, lead::String, rest::String;
     end
     println(io)
 end
+
+# a fact as the line the report prints for it; the requirement is the one kind
+# with no versions in it, so it is the caller's to print
+fact_phrase(f::Availability)    = availability_phrase(f)
+fact_phrase(f::Dependency)      = dependency_phrase(f)
+fact_phrase(f::Incompatibility) = incompatibility_phrase(f)
+
+# the packages a fact speaks about, in the order it names them: what a report
+# shows versions of is what its facts are about
+fact_packages(f::Requirement)     = (f.pkg,)
+fact_packages(f::Availability)    = (f.pkg,)
+fact_packages(f::Dependency)      = (f.pkg, f.dep)
+fact_packages(f::Incompatibility) = (f.pkg, f.other)
 
 count_phrase(n::Int, one::String, many::String) =
     n == 0 ? "no $many" : n == 1 ? "1 $one" : "$n $many"
@@ -394,13 +533,11 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis{P,V}) where {P,V}
         for f in c.chain
             f isa Requirement ?
                 println(io, "  • you require $(f.pkg)") :
-                print_wrapped(io,
-                    availability_phrase(f::Availability), "  • ", "    ")
+                print_wrapped(io, fact_phrase(f), "  • ", "    ")
         end
         # the versions worth showing are the ones this conflict is about
         named = P[]
-        for f in c.chain
-            p = f isa Requirement ? f.pkg : (f::Availability).pkg
+        for f in c.chain, p in fact_packages(f)
             p in named || push!(named, p)
         end
         sort!(named)
@@ -625,6 +762,332 @@ function with_emptied_packages(body::Function, sat::SAT{P}, vm::VarMap{P}) where
     end
 end
 
+## why one package matters to another
+#
+# A chain says what the query asked for and what its constraints left of the
+# packages, and between the two there is a step it cannot take on its own: that
+# some versions of one package need another, at some versions of it. The user
+# wrote the requirement and wrote the bound; the dependency is the one link in
+# the story they could not have written, and until it is said the report is a
+# pair of facts with nothing between them.
+#
+# It is read off the universe, which records per class which packages that
+# class depends on and which classes of them it admits. What has to be found is
+# *which* steps to say, and that is a walk: start at the conflict's
+# requirements with the versions this query admits of them, follow the
+# dependencies every one of those versions has — the ones no choice of version
+# can avoid — and narrow each package reached by what the packages already
+# reached admit of it. A package the walk leaves with no version is where the
+# story ends, and the steps that got there are the story.
+#
+# The walk answers with a set of versions per package rather than pairing them
+# up, so it says less than the solver does: a package it leaves with nothing
+# really has nothing, and a package it leaves something with may still be
+# unreachable. That is the safe direction. Nothing it emits is a claim about
+# satisfiability — the chain's requirements and availabilities carry that, and
+# the solver checked them — and every fact it does emit is a statement about
+# the registry and this query's constraints that can be read straight back off
+# the universe.
+
+# the classes of `p` this query admits — the ones it left a version in
+admitted_classes(sat::SAT{P}, p::P) where {P} =
+    Bool[!iszero(r) for r in sat.reps[p]]
+
+# where `q` sits in `p`'s dependency columns, or nothing if `p` never needs it
+dep_column(info_p::PkgInfo{P}, q::P) where {P} =
+    (k = searchsortedfirst(info_p.depends, q);
+     k ≤ length(info_p.depends) && info_p.depends[k] == q ? k : nothing)
+
+# does every class in `live` of `p` depend on `q`? Only then is `q` forced by
+# `p`: a class that does without it is a choice the story would have to rule
+# out before it could claim `q` has to be installed
+function forces(info_p::PkgInfo{P}, q::P, live::Vector{Bool}) where {P}
+    k = dep_column(info_p, q)
+    k === nothing && return false
+    return all(!live[c] || info_p.conflicts[c, k] for c in eachindex(live))
+end
+
+# the classes of `q` that some class in `live` of `p` admits. A package the
+# two never interact over is one `p` says nothing about, so all of it is
+# admitted
+function admissible(sat::SAT{P}, p::P, q::P, live::Vector{Bool}) where {P}
+    info_p = sat.info[p]
+    n_q = nclasses(sat.info[q])
+    # the first partner's block of columns starts at offset 0, so whether
+    # there is a block at all is a question about the keys
+    haskey(info_p.interacts, q) || return fill(true, n_q)
+    b = info_p.interacts[q]
+    return Bool[any(live[c] && !info_p.conflicts[c, b+j] for c in eachindex(live))
+                for j = 1:n_q]
+end
+
+# The walk. Every pass reads one snapshot and writes the next, so what a
+# package's set was when it starved is a set the report can quote; taking each
+# package's answer as it comes would leave the story depending on the order the
+# packages were visited in.
+#
+# A pass first extends the forced set — a package every live class of a forced
+# package depends on has to be installed too — and then narrows every forced
+# package by every other forced package's bounds on it, dependency or not,
+# since two packages that are both installed have to agree however the bound
+# got there. Both directions are monotone, so the walk settles; it stops at the
+# first pass that leaves a package with nothing, which is a complete story and
+# the shortest one this walk has.
+#
+# Returns the snapshot the last pass read, the package each was first forced
+# by, and, per starved package, the classes it had before and the packages
+# whose bounds took them.
+function forced_descent(sat::SAT{P}, reqs::Vector{P}) where {P}
+    live = Dict{P,Vector{Bool}}(p => admitted_classes(sat, p) for p in reqs)
+    parent = Dict{P,P}()
+    forced = copy(reqs)
+    starved = Dict{P,Tuple{Vector{Bool},Vector{P}}}()
+    for _ = 1:length(sat.info)
+        snap = live
+        # to closure, so that a package forced by one forced this pass is
+        # reached this pass too — the narrowing below is what a pass is for,
+        # and it has nothing to say about a package it has not met
+        i = 1
+        while i ≤ length(forced)
+            p = forced[i]
+            i += 1
+            any(snap[p]) || continue
+            for q in sat.info[p].depends
+                haskey(snap, q) && continue
+                forces(sat.info[p], q, snap[p]) || continue
+                push!(forced, q)
+                snap[q] = admitted_classes(sat, q)
+                parent[q] = p
+            end
+        end
+        live = Dict{P,Vector{Bool}}()
+        changed = false
+        for q in forced
+            admits = admitted_classes(sat, q)
+            new = copy(admits)
+            blame = P[]
+            for p in forced
+                (p == q || !any(snap[p])) && continue
+                haskey(sat.info[p].interacts, q) || continue
+                a = admissible(sat, p, q, snap[p])
+                # everything that takes a version this query still admits,
+                # whether or not one is left by the time it is asked. Which of
+                # them the story needs is a question for later, and stopping
+                # at the first would name whichever came up first
+                any(admits[c] && !a[c] for c in eachindex(a)) && push!(blame, p)
+                new .&= a
+            end
+            live[q] = new
+            !any(new) && (starved[q] = (snap[q], blame))
+            new == snap[q] || (changed = true)
+        end
+        isempty(starved) || return snap, parent, starved
+        changed || break
+    end
+    return live, parent, starved
+end
+
+# Do the bounds of `blamed` between them leave `q` nothing? What a story about
+# `q` claims, and what makes each of the packages it names load-bearing
+function starves(sat::SAT{P}, snap::Dict{P,Vector{Bool}}, q::P,
+                 blamed::Vector{P}) where {P}
+    left = admitted_classes(sat, q)
+    for r in blamed
+        left .&= admissible(sat, r, q, snap[r])
+    end
+    return !any(left)
+end
+
+# The fewest of `blame` that still leave `q` nothing, so that a story names no
+# package it could have done without. Dropping is attempted on the packages the
+# query never asked for first, so that what survives is what the user can act
+# on rather than whichever package the walk happened to meet first
+function fewest_blamed(sat::SAT{P}, snap::Dict{P,Vector{Bool}}, q::P,
+                       blame::Vector{P}, reqs::Vector{P}) where {P}
+    keep = copy(blame)
+    order = [P[r for r in blame if r ∉ reqs]; P[r for r in blame if r ∈ reqs]]
+    for r in order
+        rest = P[x for x in keep if x != r]
+        starves(sat, snap, q, rest) && (keep = rest)
+    end
+    return keep
+end
+
+# the forcing steps from a requirement down to `p`, in that order
+function forcing_path(parent::Dict{P,P}, p::P) where {P}
+    path = Tuple{P,P}[]
+    while haskey(parent, p)
+        pushfirst!(path, (parent[p], p))
+        p = parent[p]
+    end
+    return path
+end
+
+# What `pkg` says about `q`, as facts. One fact per set of `pkg`'s live classes
+# that agree about `q`, split again wherever the versions they stand for are
+# not a run of what `pkg` offers — so a fact's versions read as one range and
+# every version in that range says what the fact says. Versions this query
+# forbids are left out: the fact is about the choice the resolve had.
+#
+# `bound` is whether the bound is worth stating at all. On the last step of a
+# story it is the whole point — it is what the query's own constraints have
+# left nothing of. On the steps that lead there it is decoration, and worse
+# than that: versions that agree about needing a package often disagree about
+# which of it they will take, so a step that carried its bound would be a
+# paragraph where a sentence was wanted, and the versions it names are named
+# again as the subject of the next step anyway.
+#
+# Whether the versions a fact speaks for depend on `q` is part of what they
+# have to agree about, because it is what decides which way round the fact may
+# be said. A registry records compatibility symmetrically, so a bound can be
+# attributed to the package that declared the dependency and to no other; the
+# versions that merely have to get along with `q` get the symmetric sentence,
+# which claims nothing about who said so.
+function relation_facts(
+    sat  :: SAT{P,V},
+    prob :: Problem{P},
+    pkg  :: P,
+    live :: Vector{Bool},
+    q    :: P,
+    bound :: Bool,
+) where {P,V}
+    info_p, info_q = sat.info[pkg], sat.info[q]
+    k = dep_column(info_p, q)
+    # a package this query has left nothing of is starved by every bound
+    # alike, so which bound `pkg` declares is not what the story turns on
+    bounded = bound && any(admitted_classes(sat, q))
+    # what a group of classes says about `q`, and the versions it stands for
+    Says = Tuple{Bool,Union{Nothing,Vector{Bool}}}
+    groups = Vector{Pair{Says,Vector{Bool}}}()
+    for c in eachindex(live)
+        live[c] || continue
+        needs_it = k !== nothing && info_p.conflicts[c, k]
+        a = nothing
+        if bounded
+            cs = admissible(sat, pkg, q, Bool[i == c for i in eachindex(live)])
+            a = fill(false, length(info_q.versions))
+            for (j, ok) in enumerate(cs), i in info_q.members[j]
+                a[i] = ok
+            end
+        end
+        key = (needs_it, a)
+        g = findfirst(x -> first(x) == key, groups)
+        g === nothing && (push!(groups, key => fill(false, length(info_p.versions)));
+                          g = length(groups))
+        for i in info_p.members[c]
+            isempty(exclusion_kinds(prob, pkg, info_p.versions[i])) &&
+                (last(groups[g])[i] = true)
+        end
+    end
+    facts = Fact[]
+    offering = copy(info_q.versions)
+    for ((needs_it, allowed), mask) in groups
+        # versions that do not need `q`, and have nothing to say about it
+        # either, contribute nothing to the story
+        needs_it || (allowed !== nothing && !all(allowed)) || continue
+        i = 1
+        while i ≤ length(mask)
+            if mask[i]
+                j = i
+                while j < length(mask) && mask[j+1]
+                    j += 1
+                end
+                vers = info_p.versions[i:j]
+                push!(facts, needs_it ?
+                    Dependency{P,V}(pkg, vers, q, offering, allowed) :
+                    Incompatibility{P,V}(pkg, vers, q, offering, allowed))
+                i = j
+            end
+            i += 1
+        end
+    end
+    return facts
+end
+
+# Why the packages a conflict names have anything to do with each other, as
+# facts about the registry. The walk from the conflict's requirements ends at a
+# package with nothing left; the story is the packages whose bounds left it
+# nothing, and the forcing steps that put each of them in the query's way.
+#
+# A step is said in the direction of the dependency where there is one, since
+# that is the only direction a bound can honestly be attributed in. Where a
+# package is starved by one other and depends on it, the same relation reads
+# better the other way about — "this is what these versions need" rather than
+# "this is what those versions leave" — and the walk's own narrowing is what
+# makes the two the same fact.
+#
+# The chain already says which packages the query emptied, so a walk that ends
+# at one of them is telling this conflict's story rather than some other one;
+# that is what `emptied` picks between when several packages starve at once.
+function chain_relations(
+    sat     :: SAT{P,V},
+    prob    :: Problem{P},
+    reqs    :: Vector{P},
+    emptied :: Vector{P},
+) where {P,V}
+    snap, parent, starved = forced_descent(sat, reqs)
+    isempty(starved) && return Fact[]
+
+    # Which story to tell, when the walk leaves several packages with nothing.
+    # Bounds are symmetric, so a package and the one that starves it usually
+    # starve each other, and the choice is which way round to say it: a
+    # requirement is where the story starts rather than where it ends, and a
+    # story about a package this query emptied is a story about this conflict
+    # rather than some other one. Then the shortest, and then by name, so that
+    # a tie does not depend on iteration order.
+    best = nothing
+    for (q, (before, blame)) in starved
+        blamed = fewest_blamed(sat, snap, q, blame, reqs)
+        steps = length(blamed) + length(forcing_path(parent, q)) +
+            sum(r -> length(forcing_path(parent, r)), blamed; init = 0)
+        touches = q ∈ emptied || any(∈(emptied), blamed)
+        key = (q ∈ reqs, !touches, steps, string(q))
+        (best === nothing || key < best[1]) && (best = (key, q, before, blamed))
+    end
+    _, q, before, blamed = best
+    # ... and, of the requirements the fewest left out, the ones that starve
+    # `q` all by themselves. Any one of them is enough to make it a conflict,
+    # so minimality names one and drops the rest — and a reader would fix that
+    # one bound and never learn their own other requirement had been broken
+    # too. This is the same union of minimal reasons the requirements of a
+    # conflict are gathered by. A package the query never asked for earns no
+    # such sentence: it is not something the reader is owed an account of, and
+    # a story that named every one of them would be a list, not a story
+    append!(blamed, P[r for r in starved[q][2] if r ∈ reqs && r ∉ blamed &&
+                      starves(sat, snap, q, P[r])])
+    # ... back in the order the walk met them, which starts with the
+    # requirements in the order the query gave them
+    blamed = P[r for r in starved[q][2] if r ∈ blamed]
+
+    # one relation per package blamed, said the better way round when there is
+    # only one of them: with several, what matters is that their demands do not
+    # overlap, and that is only visible with each stated as a demand on `q`
+    pairs = Tuple{P,Vector{Bool},P}[]
+    for r in blamed
+        length(blamed) == 1 && forces(sat.info[q], r, before) ?
+            push!(pairs, (q, before, r)) :
+            push!(pairs, (r, snap[r], q))
+    end
+    # A package the story speaks of has to be in the query's way to begin with,
+    # and the forcing steps are what put it there. The package a relation is
+    # *about* needs no path of its own when the relation is a dependency on it,
+    # since that is what puts it there; where none of them is, `q` gets a
+    # walk of its own, and nothing is said about it beyond how it got here
+    any(b == q && forces(sat.info[a], q, live) for (a, live, b) in pairs) ||
+        pushfirst!(pairs, (q, before, q))
+    facts = Fact[]
+    said = Set{Tuple{P,P}}((a, b) for (a, _, b) in pairs)
+    for (a, live, b) in pairs
+        for (x, y) in forcing_path(parent, a)
+            (x, y) in said && continue
+            push!(said, (x, y))
+            append!(facts, relation_facts(sat, prob, x, snap[x], y, false))
+        end
+        a == b || append!(facts, relation_facts(sat, prob, a, live, b, true))
+    end
+    return facts
+end
+
 # The story of one conflict: the query's own facts that this conflict's fix is
 # what rescues, and why each of them needs rescuing.
 #
@@ -674,7 +1137,18 @@ function conflict_story(
             push!(avails, availability_fact(sat, prob, p))
         end
     end
-    append!(chain, avails)
+    # the registry's own part of the story goes between the packages it speaks
+    # for and the ones it speaks about, so that the chain reads as a chain:
+    # you asked for this, this is what it needs, this is what you left of it
+    rels = chain_relations(sat, prob, reqs, P[f.pkg for f in avails])
+    subjects = Set{P}(f.pkg for f in rels)
+    for f in avails
+        (f::Availability).pkg in subjects && push!(chain, f)
+    end
+    append!(chain, rels)
+    for f in avails
+        (f::Availability).pkg in subjects || push!(chain, f)
+    end
     return reqs, chain
 end
 

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -156,7 +156,7 @@ struct Availability{P,V} <: Fact
 end
 
 """
-    Resolver.Diagnostics.Dependency{P,V}(pkg, versions, dep, offering, allowed)
+    Resolver.Diagnostics.Dependency{P,V}(pkg, versions, dep, offering, allowed, newest, oldest)
 
 The fact that some versions of `pkg` need `dep`, and which versions of it they
 will take:
@@ -187,10 +187,14 @@ struct Dependency{P,V} <: Fact
     dep      :: P
     offering :: Vector{V}
     allowed  :: Union{Nothing,Vector{Bool}}
+    # whether `versions` reaches the newest / oldest version of `pkg` this
+    # query admits, so the range can be stated as an open bound
+    newest   :: Bool
+    oldest   :: Bool
 end
 
 """
-    Resolver.Diagnostics.Incompatibility{P,V}(pkg, versions, other, offering, allowed)
+    Resolver.Diagnostics.Incompatibility{P,V}(pkg, versions, other, offering, allowed, newest, oldest)
 
 The fact that some versions of `pkg` go with only some versions of `other`,
 with nothing said about which of the two declared it. The fields are
@@ -210,6 +214,8 @@ struct Incompatibility{P,V} <: Fact
     other    :: P
     offering :: Vector{V}
     allowed  :: Vector{Bool}
+    newest   :: Bool
+    oldest   :: Bool
 end
 
 """
@@ -370,8 +376,17 @@ action_phrase(a::Action) =
 
 # a run of a package's versions, compressed: packages list their versions best
 # first, so a run reads low to high
-range_phrase(members, i::Int, j::Int) =
-    i == j ? string(members[i]) : "$(members[j])–$(members[i])"
+# When a run reaches the end of what is on offer, an open bound says so: "≥
+# 1.2.0" tells the reader nothing newer is at issue, where "1.2.0–1.9.3" leaves
+# them wondering what is wrong with 1.9.4. `high`/`low` say whether the run
+# reaches the newest/oldest version there is to reach.
+function range_phrase(members, i::Int, j::Int; high::Bool = false, low::Bool = false)
+    i == j && !(high && low) && return string(members[i])
+    high && low && return "any version"
+    high && return "≥ $(members[j])"
+    low && return "≤ $(members[i])"
+    return "$(members[j])–$(members[i])"
+end
 
 # join a list of phrases into an English list
 function list_phrase(parts::Vector{String})
@@ -396,8 +411,10 @@ function availability_phrase(f::Availability)
         if !isempty(excluded[i])
             by = kinds_phrase(excluded[i])
             push!(clauses, isempty(clauses) ?
-                "$(range_phrase(members, i, j)) excluded by $by" :
-                "$(range_phrase(members, i, j)) by $by")
+                "$(range_phrase(members, i, j; high = i == 1,
+                    low = j == length(members))) excluded by $by" :
+                "$(range_phrase(members, i, j; high = i == 1,
+                    low = j == length(members))) by $by")
         end
         i = j + 1
     end
@@ -418,7 +435,8 @@ function offering_phrase(offering::Vector, allowed::Vector{Bool})
             while j < length(allowed) && allowed[j+1]
                 j += 1
             end
-            push!(parts, range_phrase(offering, i, j))
+            push!(parts, range_phrase(offering, i, j;
+                high = i == 1, low = j == length(allowed)))
             i = j
         end
         i += 1
@@ -430,8 +448,12 @@ end
 # the versions this query left standing, so leaving them out would let the
 # sentence be read as one about the package rather than about the choice the
 # resolve had — and a version range is shorter than saying so.
+# An open bound is stated only at one end: a run reaching *both* ends of what
+# the query admits is still not "any version" — the availability fact just said
+# which versions were taken away — so it is named in full.
 relation_subject(f) =
-    "$(f.pkg) $(range_phrase(f.versions, 1, length(f.versions)))"
+    "$(f.pkg) $(range_phrase(f.versions, 1, length(f.versions);
+        high = f.newest & !f.oldest, low = f.oldest & !f.newest))"
 
 # a dependency as one line, with the bound where there is one to state
 function dependency_phrase(f::Dependency)
@@ -981,6 +1003,12 @@ function relation_facts(
     end
     facts = Fact[]
     offering = copy(info_q.versions)
+    # a run reaching the newest (or oldest) version this query admits can be
+    # stated as an open bound: there is nothing above (or below) it to wonder
+    # about. What the query excludes is said by the availability fact instead.
+    admitted = Bool[isempty(exclusion_kinds(prob, pkg, v)) for v in info_p.versions]
+    hi = something(findfirst(admitted), 1)
+    lo = something(findlast(admitted), length(admitted))
     for ((needs_it, allowed), mask) in groups
         # versions that do not need `q`, and have nothing to say about it
         # either, contribute nothing to the story
@@ -994,8 +1022,10 @@ function relation_facts(
                 end
                 vers = info_p.versions[i:j]
                 push!(facts, needs_it ?
-                    Dependency{P,V}(pkg, vers, q, offering, allowed) :
-                    Incompatibility{P,V}(pkg, vers, q, offering, allowed))
+                    Dependency{P,V}(pkg, vers, q, offering, allowed,
+                        i == hi, j == lo) :
+                    Incompatibility{P,V}(pkg, vers, q, offering, allowed,
+                        i == hi, j == lo))
                 i = j
             end
             i += 1

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -35,7 +35,8 @@ using Resolver: Problem, PkgData, PkgInfo, SAT, Diagnosis, pkg_info, relax,
     with_classes_relaxed, class_exclusions, exclusion_kinds, nclasses,
     sat_assume_var
 using Resolver.Diagnostics: Diagnostics, Conflict, Fix, Action, Fact,
-    Requirement, Availability, unavailable, action_phrase
+    Requirement, Availability, Dependency, Incompatibility, unavailable,
+    action_phrase
 using Resolver.UnsatCores: sat_mcses
 
 using Pkg.Versions: VersionSpec
@@ -64,6 +65,14 @@ fact_literals(sat::SAT{P}, f::Availability{P}) where {P} =
     haskey(sat.vars, f.pkg) ? Int[forbidden_lit(sat, f.pkg, c)
         for c in eachindex(sat.reps[f.pkg]) if iszero(sat.reps[f.pkg][c])] : Int[]
 
+# A dependency and an incompatibility claim none: they say what the registry
+# says, which is not something this query could relax, so there is nothing for
+# the solver to be asked about them and nothing taking one away would give
+# back. What they say is checked against the universe instead, by
+# `relations_are_true` below
+fact_literals(::SAT{P}, ::Dependency{P}) where {P} = Int[]
+fact_literals(::SAT{P}, ::Incompatibility{P}) where {P} = Int[]
+
 conflict_literals(sat::SAT, c::Conflict) =
     reduce(vcat, (fact_literals(sat, f) for f in c.chain); init = Int[])
 
@@ -89,11 +98,16 @@ end
 # Brute force, which is what makes it an oracle; chains are a handful of facts,
 # and one too big to enumerate falls back to the unsatisfiability check alone.
 function chain_is_covered(sat::SAT, c::Conflict)
-    n = length(c.chain)
-    n ≤ 8 || return !sat_assuming(sat, conflict_literals(sat, c))
+    # only the facts that claim literals are enumerated over: the rest say what
+    # the registry says, which no subset of assumptions can turn off, so they
+    # are in every subset and in none of them alike
     lits = [fact_literals(sat, f) for f in c.chain]
+    claim = Int[i for i in eachindex(lits) if !isempty(lits[i])]
+    n = length(claim)
+    n ≤ 8 || return !sat_assuming(sat, conflict_literals(sat, c))
     subset(bits) = reduce(vcat,
-        (lits[i] for i = 1:n if !iszero(bits & (1 << (i-1)))); init = Int[])
+        (lits[claim[i]] for i = 1:n if !iszero(bits & (1 << (i-1))));
+        init = Int[])
     unsat = Bool[!sat_assuming(sat, subset(bits)) for bits = 0:(1 << n) - 1]
     covered = falses(n)
     for bits = 0:(1 << n) - 1
@@ -106,6 +120,103 @@ function chain_is_covered(sat::SAT, c::Conflict)
         end
     end
     return all(covered)
+end
+
+# What one class of `p` says about `q`: whether it depends on it, and which of
+# `q`'s versions it admits. Read straight off the universe's matrices, which is
+# where a relation fact's claim has to be checked — the solver is never asked
+# about a dependency edge or a registry bound, so it has nothing to say here
+function class_relation(sat::SAT{P}, p::P, c::Int, q::P) where {P}
+    info_p, info_q = sat.info[p], sat.info[q]
+    k = findfirst(==(q), info_p.depends)
+    dep = k !== nothing && info_p.conflicts[c, k]
+    allowed = fill(true, length(info_q.versions))
+    if haskey(info_p.interacts, q)
+        b = info_p.interacts[q]
+        for j = 1:nclasses(info_q), i in info_q.members[j]
+            allowed[i] = !info_p.conflicts[c, b + j]
+        end
+    end
+    return dep, allowed
+end
+
+# the versions of `p` a fact speaks for, as indices into what `p` offers
+fact_indices(sat::SAT{P}, p::P, versions) where {P} =
+    Int[findfirst(==(v), sat.info[p].versions) for v in versions]
+
+# Does every relation in the chain say something true of the universe, in the
+# only direction it may be said in?
+#
+#   * a dependency is stated only where the registry has one. `PkgInfo` records
+#     compatibility symmetrically, so a bound cannot be attributed to a package
+#     that merely has one — that is what the other kind is for;
+#   * an incompatibility is stated where the versions it speaks for do not
+#     depend on what it speaks about, so there is no side to put the bound on
+#     and it puts it on neither. Reading it the other way round says the same
+#     thing, since that is what symmetric means;
+#   * the versions it speaks for are versions the query admits, they are a run
+#     of what the package offers, and every one of them says exactly what the
+#     fact says. A fact that averaged over versions that disagree would be a
+#     bound none of them declares.
+function relations_are_true(sat::SAT{P}, prob::Problem{P}, c::Conflict) where {P}
+    for f in c.chain
+        f isa Dependency || f isa Incompatibility || continue
+        p = f.pkg
+        q = f isa Dependency ? f.dep : f.other
+        info_p, info_q = sat.info[p], sat.info[q]
+        @test f.offering == info_q.versions
+        idx = fact_indices(sat, p, f.versions)
+        @test idx == first(idx):last(idx)  # a run of what `p` offers
+        for i in idx
+            v = info_p.versions[i]
+            @test isempty(exclusion_kinds(prob, p, v))
+            dep, allowed = class_relation(sat, p, info_p.classes[i], q)
+            @test dep == (f isa Dependency)
+            f.allowed === nothing || @test allowed == f.allowed
+        end
+        # the other way round: reading an incompatibility from `q`'s side picks
+        # out the same pairs
+        f isa Incompatibility || continue
+        for (j, u) in enumerate(info_q.versions)
+            _, back = class_relation(sat, q, info_q.classes[j], p)
+            @test f.allowed[j] == all(back[i] for i in idx)
+        end
+    end
+end
+
+# A relation with no bound says only that the package is needed. That is
+# enough where something else in the story says what would have done instead —
+# the next step, whose subject is the versions this one would have named, or
+# the relation the story ends on — and enough where the query has left the
+# package nothing at all, since then every bound would be starved alike. It is
+# not enough anywhere else: dropping a bound there would drop the answer
+function bounds_are_stated(sat::SAT{P}, c::Conflict{P}) where {P}
+    rels = Fact[f for f in c.chain
+                if f isa Dependency || f isa Incompatibility]
+    # a package the story goes on from, or that some bound speaks about
+    spoken = Set{P}(f.pkg for f in rels)
+    for f in rels
+        f.allowed === nothing ||
+            push!(spoken, f isa Dependency ? f.dep : f.other)
+    end
+    return all(rels) do f
+        f isa Dependency && f.allowed === nothing || return true
+        return f.dep in spoken || all(iszero, sat.reps[f.dep])
+    end
+end
+
+# Do the relations in a chain hang together — every package one speaks of
+# either something the conflict requires, or something an earlier relation
+# already brought in? A relation about packages nothing else in the story
+# mentions would be true and beside the point
+function relations_connect(c::Conflict{P}) where {P}
+    reached = Set{P}(c.reqs)
+    for f in c.chain
+        f isa Dependency || f isa Incompatibility || continue
+        f.pkg in reached || return false
+        push!(reached, f isa Dependency ? f.dep : f.other)
+    end
+    return true
 end
 
 # the withdrawal a set of actions asks for, read off here rather than taken
@@ -228,6 +339,14 @@ function check_diagnosis(data, prob::Problem{P}; order = nothing,
                 # among its own facts cover every one of them
                 @test chain_is_covered(sat, c)
             end
+        end
+
+        # the registry's own facts say what the registry says, in a direction
+        # it licenses, about packages the rest of the story reaches
+        for c in d.conflicts
+            relations_are_true(sat, prob, c)
+            @test relations_connect(c)
+            @test bounds_are_stated(sat, c)
         end
 
         # availability facts say what the problem says about the versions, class
@@ -366,6 +485,34 @@ const larger_repair = Dict(
     :G => PkgData([:v2, :v1], DEPS_NONE, COMP_NONE),
 )
 
+# :A's versions disagree about :C: a3 wants c3, the older two want c2. A bound
+# leaving only c1 breaks all of them, and for different reasons — so a story
+# that gave one bound for the package would be giving one none of its versions
+# declares
+const varied_bound = Dict(
+    :A => PkgData([:a3, :a2, :a1],
+        Dict(:a3 => [:C], :a2 => [:C], :a1 => [:C]),
+        Dict(:a3 => Dict(:C => [:c3]), :a2 => Dict(:C => [:c2]),
+             :a1 => Dict(:C => [:c2]))),
+    :C => PkgData([:c3, :c2, :c1], DEPS_NONE, COMP_NONE),
+)
+
+# :A needs :B needs :C, and the bound is on :C. Nothing relates :A to :C, so a
+# story drawn only from the packages the chain names would have nothing to say
+const two_hops = Dict(
+    :A => PkgData([:a1], Dict(:a1 => [:B]), COMP_NONE),
+    :B => PkgData([:b1], Dict(:b1 => [:C]), Dict(:b1 => Dict(:C => [:c2]))),
+    :C => PkgData([:c2, :c1], DEPS_NONE, COMP_NONE),
+)
+
+# :P names :W in its compat and does not depend on it — a weak dependency,
+# which is a bound with no edge behind it. :S is what pulls :W in
+const weak_bound = Dict(
+    :P => PkgData([:p1], DEPS_NONE, Dict(:p1 => Dict(:W => [:w1]))),
+    :S => PkgData([:s1], Dict(:s1 => [:W]), COMP_NONE),
+    :W => PkgData([:w2, :w1], DEPS_NONE, COMP_NONE),
+)
+
 # four requirements whose disagreements form a path — :C with :B, :B with :A,
 # :A with :D — so the cheapest repairs are {A,B}, {A,C} and {B,D}, which is
 # three of them and therefore not a product of anything
@@ -432,10 +579,14 @@ end
     @test length(d.conflicts) == 1
     c = only(d.conflicts)
     @test c.reqs == [:A]
+    # the middle fact is the one the user did not write: :A needs :B, and no
+    # bound of :A's is what the story turns on, since the query has left :B
+    # with nothing whatever :A would have taken
     @test c.chain == Fact[Requirement(:A),
+        Dependency{Symbol,Symbol}(:A, [:v1], :B, [:w3, :w2, :w1], nothing),
         Availability{Symbol,Symbol}(:B, [:w3, :w2, :w1],
             [[:compat, :pin], [:compat], [:pin]])]
-    @test unavailable(c.chain[2])
+    @test unavailable(c.chain[3])
     # the cheapest version to give back costs one kind, so that is the fix —
     # and not requiring :A is the other
     @test [fix.actions for fix in c.fixes] ==
@@ -453,7 +604,11 @@ end
         :P => PkgData([:p2, :p1], DEPS_NONE, COMP_NONE),
     )
     d = check_diagnosis(data, Problem([:R]; compat = Dict(:P => [:p1])))
-    f = d.conflicts[1].chain[2]::Availability
+    # here there is a bound to state: :P has a version left, just not one
+    # :R will take
+    @test d.conflicts[1].chain[2] ==
+        Dependency{Symbol,Symbol}(:R, [:r1], :P, [:p2, :p1], [true, false])
+    f = d.conflicts[1].chain[3]::Availability
     @test f.pkg == :P
     @test f.members == [:p2, :p1]
     @test f.excluded == [[:compat], Symbol[]]
@@ -463,6 +618,7 @@ end
 
         Conflict 1: R cannot be satisfied.
           • you require R
+          • R r1 requires P at p2
           • P: p2 excluded by your compat
           Fix it by any one of:
             1. relax your compat on P
@@ -471,12 +627,86 @@ end
         """
 end
 
+@testset "diagnosis: a bound that differs across versions" begin
+    # :C has a version left, and every version of :A wants a different one it
+    # has not got. What each of them wants is a fact about that version, so
+    # the story states it once per version that agrees
+    d = check_diagnosis(varied_bound, Problem([:A]; compat = Dict(:C => [:c1])))
+    c = only(d.conflicts)
+    @test c.chain == Fact[Requirement(:A),
+        Dependency{Symbol,Symbol}(:A, [:a3], :C, [:c3, :c2, :c1],
+            [true, false, false]),
+        Dependency{Symbol,Symbol}(:A, [:a2, :a1], :C, [:c3, :c2, :c1],
+            [false, true, false]),
+        Availability{Symbol,Symbol}(:C, [:c3, :c2, :c1],
+            [[:compat], [:compat], Symbol[]])]
+    @test sprint(show, MIME("text/plain"), d) == """
+        Unsatisfiable — 1 conflict:
+
+        Conflict 1: A cannot be satisfied.
+          • you require A
+          • A a3 requires C at c3
+          • A a1–a2 requires C at c2
+          • C: c2–c3 excluded by your compat
+          Fix it by any one of:
+            1. relax your compat on C
+               → allows: A a3, C c3
+            2. drop requirement A
+        """
+end
+
+@testset "diagnosis: a story that spans more than one hop" begin
+    # the query names :A and :C, and it is :B in between that explains them
+    d = check_diagnosis(two_hops, Problem([:A]; compat = Dict(:C => [:c1])))
+    c = only(d.conflicts)
+    # the step to :B says only that :B is needed. What :A will take of it is
+    # not what the query left nothing of, and the versions it would name are
+    # the subject of the next step anyway
+    @test c.chain == Fact[Requirement(:A),
+        Dependency{Symbol,Symbol}(:A, [:a1], :B, [:b1], nothing),
+        Dependency{Symbol,Symbol}(:B, [:b1], :C, [:c2, :c1], [true, false]),
+        Availability{Symbol,Symbol}(:C, [:c2, :c1], [[:compat], Symbol[]])]
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("A a1 requires B\n", report)
+    @test occursin("B b1 requires C at c2\n", report)
+    # ... and :B is not something the query said anything about: the middle of
+    # the story is the part only the registry knows
+    @test :B ∉ [f.pkg for f in c.chain
+                if f isa Requirement || f isa Availability]
+end
+
+@testset "diagnosis: a bound with no dependency behind it" begin
+    # :P's bound on :W is a weak dependency: a compat entry with no edge. The
+    # universe records compatibility symmetrically, so which of the two
+    # declared it is not recoverable — and saying ":P requires :W" would be
+    # attributing a bound to a package that does not even depend on the other
+    prob = Problem([:P, :S]; compat = Dict(:W => [:w2]))
+    d = check_diagnosis(weak_bound, prob)
+    c = only(d.conflicts)
+    @test c.chain == Fact[Requirement(:P), Requirement(:S),
+        Dependency{Symbol,Symbol}(:S, [:s1], :W, [:w2, :w1], nothing),
+        Incompatibility{Symbol,Symbol}(:P, [:p1], :W, [:w2, :w1],
+            [false, true]),
+        Availability{Symbol,Symbol}(:W, [:w2, :w1], [Symbol[], [:compat]])]
+    # the only dependency stated is the one the registry has
+    @test [(f.pkg, f.dep) for f in c.chain if f isa Dependency] == [(:S, :W)]
+    @test !any(f isa Dependency && (f.pkg == :P || f.dep == :P) for f in c.chain)
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("S s1 requires W\n", report)
+    @test occursin("P p1 works with W only at w1\n", report)
+    @test !occursin("P p1 requires", report)
+    # ... and it really is a weak dependency: :P on its own installs no :W, so
+    # nothing about it can be a dependency of :P
+    sol = resolve(weak_bound, [:P])
+    @test sol !== nothing && !haskey(sol, :W)
+end
+
 @testset "diagnosis: any kind is a constraint like any other" begin
     prob = Problem([:A];
         prerelease = (p, v) -> p === :B && v !== :w1,
         yanked     = (p, v) -> p === :B && v === :w1)
     d = check_diagnosis(needs_dep, prob)
-    f = d.conflicts[1].chain[2]::Availability
+    f = d.conflicts[1].chain[3]::Availability
     @test f.excluded == [[:prerelease], [:prerelease], [:yanked]]
     # one kind is enough to give the package back, and the best version it
     # would give back costs the prerelease one
@@ -594,6 +824,8 @@ end
     @test c.chain == Fact[Requirement(:A), Requirement(:B),
         Availability{Symbol,Symbol}(:A, [:a2, :a1], [Symbol[], [:compat]]),
         Availability{Symbol,Symbol}(:B, [:b2, :b1], [Symbol[], [:compat]]),
+        Dependency{Symbol,Symbol}(:A, [:a2], :C, [:c2, :c1], [true, false]),
+        Dependency{Symbol,Symbol}(:B, [:b2], :C, [:c2, :c1], [true, false]),
         Availability{Symbol,Symbol}(:C, [:c2, :c1], [[:compat], Symbol[]])]
     @test [fix.actions for fix in c.fixes] == [[Action(:compat, :C)]]
     @test only(c.fixes).solution == Dict(:A => :a2, :B => :b2, :C => :c2)
@@ -608,6 +840,10 @@ end
     @test occursin("you require A", report)
     @test occursin("you require B", report)
     @test occursin("A and B cannot both be satisfied", report)
+    # both of them need :C at the version the bound took, and naming one of
+    # them would leave the other's failure unexplained
+    @test occursin("A a2 requires C at c2", report)
+    @test occursin("B b2 requires C at c2", report)
     @test occursin("The only fix: relax your compat on C", report)
     # the witness names both of them too
     @test occursin("→ allows: A a2, B b2, C c2", report)
@@ -717,7 +953,9 @@ end
 @testset "diagnosis: the report" begin
     # each conflict carries its own menu, and the menus do not multiply: two
     # menus of two, not one of four. There is no closing sentence — every
-    # combination of them is a repair and there are no others
+    # combination of them is a repair and there are no others. The versions
+    # shown are of every package the conflict names, :C and :G included: they
+    # are named because the story is about them
     d = resolve(two_conflicts, Problem([:A, :B, :E, :F]))
     @test sprint(show, MIME("text/plain"), d) == """
         Unsatisfiable — 2 conflicts, each of which must be fixed:
@@ -725,20 +963,24 @@ end
         Conflict 1: A and B cannot both be satisfied.
           • you require A
           • you require B
+          • A v1 requires C at v1
+          • B v1 requires C at v2
           Fix it by any one of:
             1. drop requirement A
-               → allows: B v1
+               → allows: B v1, C v2
             2. drop requirement B
-               → allows: A v1
+               → allows: A v1, C v1
 
         Conflict 2: E and F cannot both be satisfied.
           • you require E
           • you require F
+          • E v1 requires G at v1
+          • F v1 requires G at v2
           Fix it by any one of:
             1. drop requirement E
-               → allows: F v1
+               → allows: F v1, G v2
             2. drop requirement F
-               → allows: E v1
+               → allows: E v1, G v1
         """
     # the one-line summary counts the ways of repairing the whole query
     @test sprint(show, d) == "Diagnosis: 2 conflicts, 4 fixes"
@@ -751,6 +993,7 @@ end
 
         Conflict 1: A cannot be satisfied.
           • you require A
+          • A v1 requires B
           • no version of B is available: w3 excluded by your compat and your pin, w2
             by your compat, w1 by your pin
           Fix it by any one of:
@@ -861,7 +1104,55 @@ end
         @test fix.solution["DataFrames"] ∈ VersionSpec("1")
         @test haskey(fix.solution, "PrettyTables")
     end
+    # the middle of the story: that DataFrames is what needs PrettyTables, and
+    # which versions of it do. No bound is stated, since the query has left
+    # PrettyTables with nothing whatever DataFrames would have taken
+    f = only(x for x in c.chain if x isa Dependency)
+    @test f.pkg == "DataFrames" && f.dep == "PrettyTables"
+    @test f.allowed === nothing
+    @test all(v -> v ∈ VersionSpec("1"), f.versions)
     report = sprint(show, MIME("text/plain"), d)
     @test occursin("no version of PrettyTables is available", report)
     @test occursin("relax your compat on PrettyTables", report)
+    @test occursin(
+        "DataFrames $(f.versions[end])–$(f.versions[1]) requires PrettyTables\n",
+        report)
+
+    # ... and a query that leaves PrettyTables something DataFrames will not
+    # take is where the bound itself is the story
+    prob = Problem(["DataFrames"];
+        compat = Dict("DataFrames" => VersionSpec("1.4 - 1.7"),
+                      "PrettyTables" => VersionSpec("1")))
+    d = check_diagnosis(rp, prob)
+    @test d isa Diagnosis{String,VersionNumber}
+    f = only(x for x in only(d.conflicts).chain if x isa Dependency)
+    @test f.pkg == "DataFrames" && f.dep == "PrettyTables"
+    @test all(v -> v ∈ VersionSpec("1.4 - 1.7"), f.versions)
+    # what it will take is PrettyTables 2, which is what the bound rules out
+    @test all(v ∈ VersionSpec("2") for (v, ok) in zip(f.offering, f.allowed) if ok)
+    @test any(f.allowed)
+    @test occursin("requires PrettyTables at ",
+        sprint(show, MIME("text/plain"), d))
+
+    # a bound that differs across the depending package's versions, on real
+    # data: Plots has wanted a different RecipesBase over the years, and a
+    # query holding it at 1 and RecipesBase at 0.4 is stopped by all of them
+    prob = Problem(["Plots"];
+        compat = Dict("Plots" => VersionSpec("1"),
+                      "RecipesBase" => VersionSpec("0.4")))
+    d = check_diagnosis(rp, prob)
+    @test d isa Diagnosis{String,VersionNumber}
+    deps = Dependency{String,VersionNumber}[f for f in only(d.conflicts).chain
+                                            if f isa Dependency]
+    @test all(f -> f.pkg == "Plots" && f.dep == "RecipesBase", deps)
+    # several of them, because the versions of Plots disagree — and what they
+    # disagree about is exactly what makes them several
+    @test length(deps) > 1
+    @test allunique(f.allowed for f in deps)
+    # each speaks for its own versions, and between them they run newest to
+    # oldest over the versions of Plots the query admits
+    spoken = vcat((f.versions for f in deps)...)
+    @test allunique(spoken)
+    @test issorted(spoken; rev = true)
+    @test all(v -> v ∈ VersionSpec("1"), spoken)
 end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -583,7 +583,7 @@ end
     # bound of :A's is what the story turns on, since the query has left :B
     # with nothing whatever :A would have taken
     @test c.chain == Fact[Requirement(:A),
-        Dependency{Symbol,Symbol}(:A, [:v1], :B, [:w3, :w2, :w1], nothing),
+        Dependency{Symbol,Symbol}(:A, [:v1], :B, [:w3, :w2, :w1], nothing, true, true),
         Availability{Symbol,Symbol}(:B, [:w3, :w2, :w1],
             [[:compat, :pin], [:compat], [:pin]])]
     @test unavailable(c.chain[3])
@@ -607,7 +607,7 @@ end
     # here there is a bound to state: :P has a version left, just not one
     # :R will take
     @test d.conflicts[1].chain[2] ==
-        Dependency{Symbol,Symbol}(:R, [:r1], :P, [:p2, :p1], [true, false])
+        Dependency{Symbol,Symbol}(:R, [:r1], :P, [:p2, :p1], [true, false], true, true)
     f = d.conflicts[1].chain[3]::Availability
     @test f.pkg == :P
     @test f.members == [:p2, :p1]
@@ -635,9 +635,9 @@ end
     c = only(d.conflicts)
     @test c.chain == Fact[Requirement(:A),
         Dependency{Symbol,Symbol}(:A, [:a3], :C, [:c3, :c2, :c1],
-            [true, false, false]),
+            [true, false, false], true, false),
         Dependency{Symbol,Symbol}(:A, [:a2, :a1], :C, [:c3, :c2, :c1],
-            [false, true, false]),
+            [false, true, false], false, true),
         Availability{Symbol,Symbol}(:C, [:c3, :c2, :c1],
             [[:compat], [:compat], Symbol[]])]
     @test sprint(show, MIME("text/plain"), d) == """
@@ -646,8 +646,8 @@ end
         Conflict 1: A cannot be satisfied.
           • you require A
           • A a3 requires C at c3
-          • A a1–a2 requires C at c2
-          • C: c2–c3 excluded by your compat
+          • A ≤ a2 requires C at c2
+          • C: ≥ c2 excluded by your compat
           Fix it by any one of:
             1. relax your compat on C
                → allows: A a3, C c3
@@ -663,8 +663,8 @@ end
     # not what the query left nothing of, and the versions it would name are
     # the subject of the next step anyway
     @test c.chain == Fact[Requirement(:A),
-        Dependency{Symbol,Symbol}(:A, [:a1], :B, [:b1], nothing),
-        Dependency{Symbol,Symbol}(:B, [:b1], :C, [:c2, :c1], [true, false]),
+        Dependency{Symbol,Symbol}(:A, [:a1], :B, [:b1], nothing, true, true),
+        Dependency{Symbol,Symbol}(:B, [:b1], :C, [:c2, :c1], [true, false], true, true),
         Availability{Symbol,Symbol}(:C, [:c2, :c1], [[:compat], Symbol[]])]
     report = sprint(show, MIME("text/plain"), d)
     @test occursin("A a1 requires B\n", report)
@@ -684,9 +684,9 @@ end
     d = check_diagnosis(weak_bound, prob)
     c = only(d.conflicts)
     @test c.chain == Fact[Requirement(:P), Requirement(:S),
-        Dependency{Symbol,Symbol}(:S, [:s1], :W, [:w2, :w1], nothing),
+        Dependency{Symbol,Symbol}(:S, [:s1], :W, [:w2, :w1], nothing, true, true),
         Incompatibility{Symbol,Symbol}(:P, [:p1], :W, [:w2, :w1],
-            [false, true]),
+            [false, true], true, true),
         Availability{Symbol,Symbol}(:W, [:w2, :w1], [Symbol[], [:compat]])]
     # the only dependency stated is the one the registry has
     @test [(f.pkg, f.dep) for f in c.chain if f isa Dependency] == [(:S, :W)]
@@ -824,8 +824,8 @@ end
     @test c.chain == Fact[Requirement(:A), Requirement(:B),
         Availability{Symbol,Symbol}(:A, [:a2, :a1], [Symbol[], [:compat]]),
         Availability{Symbol,Symbol}(:B, [:b2, :b1], [Symbol[], [:compat]]),
-        Dependency{Symbol,Symbol}(:A, [:a2], :C, [:c2, :c1], [true, false]),
-        Dependency{Symbol,Symbol}(:B, [:b2], :C, [:c2, :c1], [true, false]),
+        Dependency{Symbol,Symbol}(:A, [:a2], :C, [:c2, :c1], [true, false], true, true),
+        Dependency{Symbol,Symbol}(:B, [:b2], :C, [:c2, :c1], [true, false], true, true),
         Availability{Symbol,Symbol}(:C, [:c2, :c1], [[:compat], Symbol[]])]
     @test [fix.actions for fix in c.fixes] == [[Action(:compat, :C)]]
     @test only(c.fixes).solution == Dict(:A => :a2, :B => :b2, :C => :c2)


### PR DESCRIPTION
Closes #85. **Stacked on #84** — based on `diagnose-factored-fixes`, so review that first and merge this after.

A conflict's chain could say what was required and what was unavailable, but never why the second mattered to the first:

```
Conflict 2: Plots cannot be satisfied.
  • you require Plots
  • no version of RecipesBase is available: 0.4.0–1.3.4 excluded by your compat
```

Nothing said Plots depends on RecipesBase. That link is the one thing a reader cannot reconstruct — they wrote the requirement and they wrote the bound; they did not write the dependency.

## What it looks like now

Four hops, each stated:

```
• you require Zygote
• Zygote: ≤ 0.6.77 excluded by your compat
• Zygote 0.7.5–0.7.12 requires ChainRules
• ChainRules ≥ 1.72.2 requires StructArrays
• StructArrays ≥ 0.6.11 requires Tables
• Tables ≥ 1.2.0 requires TableTraits at ≥ 0.4.1
• TableTraits: ≥ 0.4.0 excluded by your compat
```

And a case where the contradiction is the point:

```
• Optim: ≤ 2.1.0 excluded by your compat
• Optim 2.2.0–2.2.2 requires LineSearches at ≥ 7.7.0
• Optim 2.2.0–2.2.2 requires NaNMath
• NaNMath 0.3.3–0.3.7 works with LineSearches only at ≤ 7.1.1
```

## Two new facts, and why there are two

`Dependency` says "requires", and is emitted **only** where the registry records the depending package as depending on the other. `Incompatibility` says "works with … only at", and attributes the bound to neither side.

That split is load-bearing. `PkgInfo` records compatibility **symmetrically** (#63, item 1), so which side's `Project.toml` declared a bound is not recoverable. Saying "NaNMath requires LineSearches at …" when NaNMath merely conflicts with it would blame the wrong package, and no test would catch it. They are separate types so a caller rendering its own report cannot use the directed wording for a symmetric relation by forgetting a flag.

## Open bounds

A range whose top is the newest version there is says nothing by naming it, so it is stated as `≥ x`. The Optim case above is what this buys: `≥ 7.7.0` against `≤ 7.1.1` shows the contradiction at a glance where `7.7.0–7.7.1` against `7.0.1–7.1.1` did not.

An open bound is stated at **one end only**. A run reaching both ends of what the query admits is still not "any version" — the availability fact just said which versions were taken away — so it is named in full. Constrained packages keep explicit ranges; the packages the query said nothing about get open ones.

## Design decisions

- **Multi-hop, not just direct edges.** A forced descent: start at the requirements with the versions the query admits, follow only dependencies every live version has, narrow each package by what the already-reached packages admit. A direct-edge-only rule leaves 36% of real conflicts with nothing to say; the walk finds a story for 96 of 99 conflicts across two sweeps.
- **A varying bound is never unioned.** "Plots 1.0.6–1.41.7 requires RecipesBase at 1.0.0–1.3.4" reads as though 1.41.7 works with 1.0.0, which is false. One line per run of versions that agree.
- **Only the relation about the starved package carries its bound.** Bounds on every hop produced a 14-line wall on a lockstep pin.
- **The version range is always named**, never "(all versions)" and never bare: a fix may offer to relax your bound on the depending package, and `relax your compat on DataFrames → DataFrames 0.21.8` lands on a version that does not require PrettyTables at all.

## Testing

New oracles run on every diagnosis in the sweeps: each relation is checked against the universe (offering, admitted version runs, per-version `(depends, allowed)`), incompatibilities are read from both sides and must agree, every subject must be a requirement or already reached, and a bound may be dropped only where the story goes on from that package.

Each new test was verified to fail when the thing it tests is broken — forcing every relation to claim a dependency fails 6 assertions; unioning bound groups fails 5; dropping the forcing-path facts, skipping the union-of-reasons add-back, and mis-stating the last step's bound each fail their own.

Full suite green on 1.12.6 and nightly 1.14.0-DEV; docs build clean.

## Also worth knowing

`PkgInfo.interacts` uses offset `0` for the first partner's block, so `get(interacts, q, 0)` reads a real interaction as none — which is exactly the case for a package with no dependencies of its own, i.e. every weak-dependency bound.

Two limits, disclosed rather than hidden: the descent stops at the first pass that starves anything, so a conflict needing joint reasoning past that gets no story (3 of 99); and where several packages starve at once the choice of which to tell is a preference order, not forced.

🤖 Reviewed and pushed with [Claude Code](https://claude.com/claude-code)