### PR TITLE
Keep dominated versions beside the class that dominates them

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,6 +34,8 @@ Resolver.PkgInfo
 Resolver.pkg_info
 Resolver.version_classes
 Resolver.class_members
+Resolver.no_shadows
+Resolver.collapse_shadows
 Resolver.collapse_classes!
 Resolver.Universe
 Resolver.prepare_pkg_info

--- a/docs/src/theory/layered.md
+++ b/docs/src/theory/layered.md
@@ -248,6 +248,42 @@ reach-filtered problem), so by Theorem 4 again the fully filtered problem
 has the same layered answer. **The implementation's answer is the raw
 layered solution.**
 
+## Shadows: what a deletion leaves behind
+
+Theorem 6 says the answer does not need ``q@j``. It does not say a *report*
+does not need it. A reader asking why the resolver would not take ``q@j`` is
+owed the reason, and the reason lives in a different version — ``q@i`` — so a
+pointer to it has to be kept or the deletion becomes unaccountable.
+
+`mark_necessary!` keeps one: when it deletes ``q@j`` it records ``q@j`` in the
+**shadow list** of the class ``q@i`` that dominated it (`PkgInfo.shadows`, one
+list per class, alongside `members`). Nothing else about the universe changes.
+The shadow lists are in no matrix, no clause names them, and no model contains
+one, so every theorem above reads the same before and after: the sets of
+classes, rows and columns the proofs quantify over are exactly the sets they
+were. Shadowing is a deletion that writes down its reason, not a deletion
+avoided.
+
+What the record is good for is fixed by the same subset that licensed the
+deletion. Every constraint of ``q@i`` is a constraint of ``q@j``, so:
+
+- **whatever rules out ``q@i`` rules out ``q@j``.** A statement of the form
+  "these versions are excluded, for this reason" is true of a class's shadows
+  whenever it is true of the class.
+- **a stated bound does not carry over.** ``q@j`` may bound a dependency more
+  tightly than ``q@i`` does — that is a superset, and it is the ordinary case
+  — so "``q@i`` requires ``r`` at ``1.2``" may be simply false of ``q@j``. The
+  implication runs one way only.
+
+A shadow list belongs to a class and lives exactly as long as it does: a class
+deleted for being unreachable or uninstallable takes its shadows with it. That
+loses a report nothing, because a shadow of such a class would have gone the
+same way on its own account — it depends on whatever made the class
+uninstallable, and its ``\mathrm{key}_\emptyset`` is worse than the class's,
+so no walk that stopped before the class reaches past it — and because both of
+those deletions are already explained by the chain being printed. Domination is
+the one deletion whose reason is somewhere else.
+
 ## Iterating the filter
 
 It is natural to ask whether a single reachability pass followed by a

--- a/docs/src/theory/relaxation.md
+++ b/docs/src/theory/relaxation.md
@@ -158,6 +158,12 @@ the fact Lemma 2's discussion shows a relaxation can reverse.
     *feasible* class, so it would have pinned ``c_1`` or better, not
     ``c_2``. Contradiction. ∎
 
+A struck class is not thereby forgotten: `mark_necessary!` records its members
+in the shadow list of ``c_1``, which is what lets a diagnosis account for them
+— see [Shadows](layered.md#Shadows:-what-a-deletion-leaves-behind) on the
+previous page. The record is a side table; Theorem A quantifies over the same
+classes either way.
+
 !!! warning "Side condition"
     The domination test ignores conflicts whose partner class is absent from
     the universe. That exemption is sound only when evaluated against the

--- a/src/FilterPkgs.jl
+++ b/src/FilterPkgs.jl
@@ -384,8 +384,8 @@ function copy_ranked!(
         if perm === nothing
             info′[p] = PkgInfo(
                 copy(info_p.versions), copy(info_p.classes),
-                copy(info_p.members), copy(info_p.depends),
-                copy(info_p.interacts), X′)
+                copy(info_p.members), copy(info_p.shadows),
+                copy(info_p.depends), copy(info_p.interacts), X′)
             reps′[p] = copy(reps[p])
         else
             # the partition follows the classes: class `r` of the new layout is
@@ -393,8 +393,8 @@ function copy_ranked!(
             inv = invperm(perm)
             info′[p] = PkgInfo(
                 copy(info_p.versions), Int[inv[i] for i in info_p.classes],
-                info_p.members[perm], copy(info_p.depends),
-                copy(info_p.interacts), X′)
+                info_p.members[perm], info_p.shadows[perm],
+                copy(info_p.depends), copy(info_p.interacts), X′)
             reps′[p] = reps[p][perm]
         end
     end
@@ -893,6 +893,8 @@ function mark_necessary!(
     D = UInt64[]        # per-class domination candidate masks
     T = UInt64[]        # mask of classes still tracked by the sweep
     R = Int[]           # redundant indices vector
+    dom = Int[]         # per class, the class that dominates it (0: none)
+    F = Bool[]          # per class, whether its shadow list is ours to grow
     # scratch: suffix masks of the classes
     # ordered by key_∅, so "the classes whose best possible rank is worse than
     # t" is one mask lookup
@@ -1085,8 +1087,13 @@ function mark_necessary!(
                 end
             end
         end
-        # union of all candidate sets = the dominated classes
+        # union of all candidate sets = the dominated classes, and along with
+        # it the class each one is dominated by: the classes are visited in
+        # ascending order, so the first to claim a class is the best one that
+        # can, and the claim is what a report will attribute the deletion to
         fill!(T, UInt64(0)) # reuse as the union accumulator
+        resize!(dom, m)
+        fill!(dom, 0)
         @inbounds for w = 1:W
             c = A[w]
             while !iszero(c)
@@ -1094,7 +1101,13 @@ function mark_necessary!(
                 c &= c - 1
                 o = (i - 1) * W
                 for w′ = 1:W
+                    fresh = D[o + w′] & ~T[w′]
                     T[w′] |= D[o + w′]
+                    while !iszero(fresh)
+                        j = ((w′ - 1) << 6) + trailing_zeros(fresh) + 1
+                        fresh &= fresh - 1
+                        dom[j] = i
+                    end
                 end
             end
         end
@@ -1107,6 +1120,37 @@ function mark_necessary!(
             end
         end
         isempty(R) && continue
+        # follow each claim to a class that survives the round. Transitivity
+        # says it already is one — a dominator of the claimant would have
+        # claimed first, so the claimant is undominated — but what a shadow
+        # list needs is a host that is really still here, and a comparison per
+        # deletion is cheaper than resting on the argument
+        for j in R
+            d = dom[j]
+            while !iszero(dom[d])
+                d = dom[d]
+            end
+            dom[j] = d
+        end
+        # hand each deleted class's versions, and whatever it was already
+        # shadowing, to the class that dominates it. the lists are replaced
+        # rather than grown in place: `copy_ranked!` shares them with the
+        # artifact it copied, which must not learn about this query
+        sh = info_p.shadows
+        vers = info_p.versions
+        mem = info_p.members
+        resize!(F, m)
+        fill!(F, false)
+        nosh = V[] # one empty list for every class on its way out
+        for j in R
+            d = dom[j]
+            F[d] || (sh[d] = copy(sh[d]); F[d] = true)
+            for k in mem[j]
+                push!(sh[d], vers[k])
+            end
+            append!(sh[d], sh[j])
+            sh[j] = nosh
+        end
         # deactivate redundant classes
         X[R, end] .= false
         for (q, b, c) in partners[p]
@@ -1173,6 +1217,7 @@ function drop_unmarked!(
         V = info_p.versions
         C = info_p.classes
         M = info_p.members
+        S = info_p.shadows
         D = info_p.depends
         T = info_p.interacts
         X = info_p.conflicts
@@ -1214,11 +1259,16 @@ function drop_unmarked!(
         V′ = V[keep]
         C′ = Vector{Int}(undef, length(V′))
         M′ = Vector{Vector{Int}}(undef, m′)
+        S′ = similar(S, m′)
         i′ = 0
         for i = 1:m
             I[i] || continue
             i′ += 1
             M′[i′] = mem = Int[index[j] for j in M[i]]
+            # a surviving class keeps what it shadows; a deleted one's shadows
+            # went to its dominator when `mark_necessary!` deleted it, and are
+            # simply gone when another pass did
+            S′[i′] = S[i]
             for j in mem
                 C′[j] = i′
             end
@@ -1296,7 +1346,7 @@ function drop_unmarked!(
         X′[1:m′, end] .= true  # kept classes are active
         X′[m′+1, 1:b′] .= true # kept columns are active
         # assign new struct into info
-        info[p] = PkgInfo(V′, C′, M′, D′, T′, X′)
+        info[p] = PkgInfo(V′, C′, M′, S′, D′, T′, X′)
     end
     return info
 end
@@ -1311,6 +1361,8 @@ function check_info_structure(
             info_p.classes[j] == i ||
                 return :members, p, p
         end
+        length(info_p.shadows) == nclasses(info_p) ||
+            return :shadows, p, p
         size(info_p.conflicts, 1) == padded_rows(nclasses(info_p)) ||
             return :rows, p, p
         for q in info_p.depends

--- a/src/PkgInfo.jl
+++ b/src/PkgInfo.jl
@@ -12,6 +12,9 @@ apart — and the partition saying which versions those are is carried with it.
     the matrix row version `i` belongs to; `members[c]` is class `c`'s version
     indices, ascending. Both are stored because both directions are hot;
     anything that drops or renumbers classes rebuilds them together.
+  * `shadows` — per class, the versions redundancy elimination removed *because
+    of* that class, as values rather than indices, since they are no longer in
+    `versions`. See below.
   * `depends` — the packages some class depends on, sorted; one matrix column
     each, in that order.
   * `interacts` — per partner package, the offset of its block of *class*
@@ -43,11 +46,35 @@ Deactivation never implies deletion: an emptied class keeps its row, its
 column in every partner, and its dependency columns. Keeping the two bits apart
 is what makes that possible, and BitKernels.jl's header spells out why one bit
 could not do both jobs.
+
+## Shadows
+
+`members[c]` and `shadows[c]` are both "versions class `c` speaks for", and
+they are deliberately not the same list. A member is *indistinguishable* from
+the class: it shares the row, so every statement the row makes is true of it. A
+shadowed version is one `mark_necessary!` deleted because `c` has a **subset**
+of its constraints — so what `c` rules out, the shadow is ruled out by too, but
+the shadow may be constrained in ways `c` is not. Folding the two together
+would put a version under a row that does not describe it, and would break the
+moment a constraint excludes `c` while admitting the version it shadows.
+
+So the safe reading of a shadow is one-directional: **whatever excludes the
+class excludes everything it shadows**, and nothing more. A stated bound is not
+one of those things — "class `c` requires `q` at `1.2`" may be false of a
+shadow, which can want `q` more narrowly still.
+
+Shadows exist to be reported, not resolved over: they are in no matrix, no SAT
+clause names them, and no solution contains one. A class that leaves the
+universe for any other reason — uninstallable, unreachable — takes its shadows
+with it. That costs a report nothing: a shadow of such a class would have left
+for the same reason on its own, and unlike domination that reason is already
+somewhere a report can say it.
 """
 struct PkgInfo{P,V}
     versions  :: Vector{V}
     classes   :: Vector{Int}
     members   :: Vector{Vector{Int}}
+    shadows   :: Vector{Vector{V}}
     depends   :: Vector{P}
     interacts :: Dict{P, Int}
     conflicts :: BitMatrix
@@ -60,7 +87,18 @@ PkgInfo(
     interacts :: Dict{P,Int},
     conflicts :: BitMatrix,
 ) where {P,V} = PkgInfo{P,V}(versions, classes, class_members(classes),
-    depends, interacts, conflicts)
+    no_shadows(V, maximum(classes; init = 0)), depends, interacts, conflicts)
+
+"""
+    no_shadows(V, m) :: Vector{Vector{V}}
+
+`m` classes that shadow nothing, at the cost of a single empty vector: every
+entry aliases the same one. That is safe only because a shadow list is
+*replaced* rather than appended to — the one place that grows one copies it
+first — and the saving is worth the discipline, since most classes shadow
+nothing and a registry-scale universe has tens of thousands of them.
+"""
+no_shadows(::Type{V}, m::Int) where {V} = fill(V[], m)
 
 # the number of classes — i.e. of rows of the conflicts matrix
 nclasses(info::PkgInfo) = length(info.members)
@@ -80,10 +118,37 @@ function class_members(classes::Vector{Int}, m::Int = maximum(classes; init = 0)
     return members
 end
 
+"""
+    collapse_shadows(shadows, classes, members, m) :: Vector{Vector{V}}
+
+The shadow lists of a coarser partition: the new class a set of old ones merge
+into shadows everything they shadowed. `classes` and `m` describe the new
+partition, `members` and `shadows` the old one.
+
+`pkg_info` collapses before anything has shadowed anything, so in practice this
+copies empties; it exists so that merging classes is not a special case that
+has to remember shadows separately.
+"""
+function collapse_shadows(
+    shadows :: Vector{Vector{V}},
+    classes :: Vector{Int},
+    members :: Vector{Vector{Int}},
+    m       :: Int,
+) where {V}
+    sh = no_shadows(V, m)
+    for (i, s) in enumerate(shadows)
+        isempty(s) && continue
+        c = classes[first(members[i])]
+        sh[c] = isempty(sh[c]) ? copy(s) : vcat(sh[c], s)
+    end
+    return sh
+end
+
 # `members` is the inverse of `classes`, so it is not compared
 function Base.:(==)(a::PkgInfo, b::PkgInfo)
     a.versions  == b.versions  &&
     a.classes   == b.classes   &&
+    a.shadows   == b.shadows   &&
     a.depends   == b.depends   &&
     a.interacts == b.interacts &&
     a.conflicts == b.conflicts
@@ -233,6 +298,7 @@ function collapse_classes!(info::Dict{P,PkgInfo{P,V}}) where {P,V}
             length(mem[q]) == length(info[q].versions)
             for q in keys(info_p.interacts))
             info[p] = PkgInfo{P,V}(info_p.versions, cls[p], mem_p,
+                collapse_shadows(info_p.shadows, cls[p], info_p.members, m),
                 info_p.depends, info_p.interacts, info_p.conflicts)
             continue
         end
@@ -247,6 +313,7 @@ function collapse_classes!(info::Dict{P,PkgInfo{P,V}}) where {P,V}
         end
         rows = Int[first(mem_c) for mem_c in mem_p]
         info[p] = PkgInfo{P,V}(info_p.versions, cls[p], mem_p,
+            collapse_shadows(info_p.shadows, cls[p], info_p.members, m),
             info_p.depends, interacts,
             gather_conflicts(info_p.conflicts, rows, cols))
     end
@@ -597,7 +664,7 @@ function pkg_info(
         m = nver[pi]
         info[pkgs[pi]] = PkgInfo{P,V}(
             datas[pi].versions, collect(1:m), [[i] for i = 1:m],
-            D, T, mats[pi])
+            no_shadows(V, m), D, T, mats[pi])
     end
 
     # the T1 preprocessing: the installability prune, then the partition. Both

--- a/src/PkgInfoFiles.jl
+++ b/src/PkgInfoFiles.jl
@@ -18,6 +18,15 @@ function save_pkg_info_file(
             # be in the file: without it there is no saying which version a row
             # stands for
             write_ints(io, d.classes)
+            # a filtered artifact carries the versions redundancy elimination
+            # removed, attached to the class that made them removable. They are
+            # not in `versions` any more, so they are written as values
+            write_int(io, count(!isempty, d.shadows))
+            for (c, sh) in enumerate(d.shadows)
+                isempty(sh) && continue
+                write_int(io, c)
+                write_vals(io, sh)
+            end
             write_vals(io, pm, d.depends)
             write_vals(io, pm, sort!(collect(keys(d.interacts))))
             write_bits(io, d.conflicts)
@@ -45,11 +54,18 @@ function load_pkg_info_file(
         for p in pv
             versions  = read_vals(io, V)
             classes   = read_ints(io)
+            m         = maximum(classes; init = 0)
+            shadows   = no_shadows(V, m)
+            for _ = 1:read_int(io, Int)
+                c = read_int(io, Int)
+                shadows[c] = read_vals(io, V)
+            end
             depends   = read_vals(io, pv)
             interacts = read_vals(io, pv)
-            conflicts = read_bits(io, padded_rows(maximum(classes; init = 0)))
+            conflicts = read_bits(io, padded_rows(m))
             interacts = Dict{P, Int}(q => 0 for q in interacts)
-            info[p] = PkgInfo(versions, classes, depends, interacts, conflicts)
+            info[p] = PkgInfo{P,V}(versions, classes, class_members(classes, m),
+                shadows, depends, interacts, conflicts)
         end
         # compute interacts dict values: one column block per partner *class*
         for (p, d) in info
@@ -65,7 +81,7 @@ end
 
 ## bespoke de/serialization functions ##
 
-const magic = "\xfa\x7d\xe1\0Resolver.jl PkgInfo File\0v3\0"
+const magic = "\xfa\x7d\xe1\0Resolver.jl PkgInfo File\0v4\0"
 
 function write_magic(io::IO)
     write(io, magic)

--- a/test/class_space.jl
+++ b/test/class_space.jl
@@ -19,8 +19,8 @@
 
 using Resolver: PkgData, PkgInfo, Problem, SAT, PicoSAT, pkg_info, nclasses,
     rank_pkg_info, prepare_pkg_info, filter_pkg_info!, deactivations,
-    mark_installable!, mark_necessary!, class_ranking, finalize,
-    sat_assume, sat_pop, is_satisfiable, sat_solve
+    mark_installable!, mark_necessary!, drop_unmarked!, class_ranking,
+    finalize, sat_assume, sat_pop, is_satisfiable, sat_solve
 
 const NODEPS = Dict{Symbol,Vector{Symbol}}()
 const NOCOMP = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
@@ -367,4 +367,161 @@ end
     finally
         finalize(sat)
     end
+end
+
+# the versions a universe can still name but no longer offers
+shadowed(univ, p) = Set(v for sh in univ.info[p].shadows for v in sh)
+
+# the redundancy pass on its own, and the classes it struck: everything the
+# installability prune took is subtracted, so what is left is exactly the
+# deletions that owe an explanation
+function redundancy_delta(info, prob)
+    univ = rank_pkg_info(info, prob)
+    mark_installable!(univ.info)
+    before = struck(univ)
+    mark_necessary!(univ.info, deactivations(univ), univ.ranks)
+    return univ, setdiff(struck(univ), before)
+end
+
+@testset "shadows: a deleted version keeps a place to be named from" begin
+    # :P's four versions are four classes — {:Q}, {:Q,:R}, {:S}, {:S,:R} — and
+    # two of them dominate: :v4's row is a subset of :v3's, :v2's of :v1's. The
+    # two survivors are not comparable to each other, so each has to keep its
+    # own deletion rather than the universe keeping one pile of them
+    data = Dict(
+        :P => PkgData([:v4, :v3, :v2, :v1],
+            Dict(:v4 => [:Q], :v3 => [:Q, :R],
+                 :v2 => [:S], :v1 => [:S, :R]), NOCOMP),
+        :Q => PkgData([:w1], NODEPS, NOCOMP),
+        :R => PkgData([:w1], NODEPS, NOCOMP),
+        :S => PkgData([:w1], NODEPS, NOCOMP),
+    )
+    info = pkg_info(data, [:P]; filter = false)
+    @test nclasses(info[:P]) == 4
+    univ, _ = redundancy_delta(info, Problem([:P]))
+    drop_unmarked!(univ)
+
+    # what survives, and what each survivor speaks for
+    @test univ.info[:P].versions == [:v4, :v2]
+    @test univ.info[:P].members == [[1], [2]]
+    @test univ.info[:P].shadows == [[:v3], [:v1]]
+    # every version is accounted for: offered or shadowed, never lost
+    @test Set(univ.info[:P].versions) ∪ shadowed(univ, :P) ==
+          Set(data[:P].versions)
+
+    # the whole filter then walks past :v2's class — nothing requires :S — and
+    # the shadow goes with it, which is what shadowing a *class* means
+    full = prepare_pkg_info(info, Problem([:P]))
+    @test full.info[:P].versions == [:v4]
+    @test full.info[:P].shadows == [[:v3]]
+    # the artifact is left alone: a universe shares its shadow lists with the
+    # artifact it was copied from, so growing one has to replace it, and a
+    # second resolve over the same artifact has to see the same universe
+    @test prepare_pkg_info(info, Problem([:P])).info == full.info
+    # ... and the answer is the one it was before any of this
+    @test resolve(data, [:P]) == Dict(:P => :v4, :Q => :w1)
+
+    # a chain lands on the class that survives it, not on the nearest one:
+    # :v3 dominates :v2, but :v4 dominates both
+    data = Dict(
+        :P => PkgData([:v4, :v3, :v2, :v1],
+            Dict(:v3 => [:Q], :v2 => [:Q, :R], :v1 => [:Q, :R, :S]), NOCOMP),
+        :Q => PkgData([:w1], NODEPS, NOCOMP),
+        :R => PkgData([:w1], NODEPS, NOCOMP),
+        :S => PkgData([:w1], NODEPS, NOCOMP),
+    )
+    univ = prepare_pkg_info(pkg_info(data, [:P]; filter = false),
+                            Problem([:P]))
+    @test univ.info[:P].versions == [:v4]
+    @test univ.info[:P].shadows == [[:v3, :v2, :v1]]
+    @test resolve(data, [:P]) == Dict(:P => :v4)
+end
+
+@testset "shadows: a shadow is not a member" begin
+    # :v1 needs :Q and :v2 does not, so :v2's class dominates :v1's and, with
+    # nothing constraining :P, :v1 is deleted and shadowed by it.
+    data = Dict(
+        :P => PkgData([:v2, :v1], Dict(:v1 => [:Q]), NOCOMP),
+        :Q => PkgData([:w1], NODEPS, NOCOMP),
+    )
+    info = pkg_info(data, [:P]; filter = false)
+    free = prepare_pkg_info(info, Problem([:P]))
+    @test free.info[:P].versions == [:v2]
+    @test free.info[:P].shadows == [[:v1]]
+    @test !haskey(free.info, :Q) # nothing surviving pulls it in
+
+    # Now pin :P to the shadowed version. Were the shadow a *member* of the
+    # class that shadows it, the class would simply stand at :v1 — and the
+    # class's row says nothing about :Q, so the answer would leave :Q out and
+    # be wrong. A shadow is not a member: the pin empties the dominating class,
+    # an emptied class dominates nothing, and :v1's own class — with its own
+    # row, and its own dependency — is there to be selected.
+    prob = Problem([:P]; pin = Dict(:P => :v1))
+    univ = prepare_pkg_info(info, prob)
+    @test univ.info[:P].versions == [:v2, :v1]
+    @test univ.info[:P].members == [[1], [2]]
+    @test all(isempty, univ.info[:P].shadows)
+    @test univ.reps[:P] == [0, 2] # the dominator is the emptied one
+    @test resolve(data, prob) == Dict(:P => :v1, :Q => :w1)
+    test_bake_equivalence(data, prob)
+end
+
+@testset "shadows: swept" begin
+    Random.seed!(rand(RandomDevice(), UInt64))
+    # Two properties of the shadow lists over the tiny grids with random
+    # constraints on top.
+    #
+    # First, they account for the redundancy pass exactly: every version that
+    # pass deleted is named by some surviving class, and no other version is.
+    # The grids give the installability prune nothing to do — every package has
+    # versions and every dependency names one of them — which is what makes the
+    # accounting exact rather than an inclusion, so that is asserted too.
+    #
+    # Second, the claim the lists exist to support: the class a version is
+    # shadowed by has a *subset* of its constraints. That is what makes "this
+    # class is ruled out" carry over to everything it shadows, and it is
+    # checked here against the raw data rather than against the matrix the
+    # pass read, so a bug in the row test cannot hide in both.
+    found = 0
+    for (m, n) in ((2, 2), (2, 3), (3, 2), (3, 3), (2, 4), (4, 2), (2, 5))
+        make_deps, make_comp, data, d, c = tiny_data_makers(m, n)
+        for _ = 1:25
+            fill_data!(m, n, make_deps(randbits(d)), make_comp(randbits(c)), data)
+            reqs = collect(make_reqs(rand(1:2^m-1)))
+            info = pkg_info(data, keys(data); filter = false)
+            for _ = 1:4
+                compat, pin = random_constraints(m, n)
+                prob = Problem(reqs; compat, pin)
+                univ, delta = redundancy_delta(info, prob)
+                pruned = Dict(p => Set(ip.versions[i]
+                        for cl = 1:nclasses(ip) if !ip.conflicts[cl, end]
+                        for i in ip.members[cl])
+                    for (p, ip) in univ.info)
+                gone = Dict{Any,Set}()
+                for (p, vs) in delta
+                    union!(get!(() -> Set(), gone, p), vs)
+                    setdiff!(pruned[p], vs)
+                end
+                drop_unmarked!(univ)
+                for (p, ip) in univ.info
+                    sh = shadowed(univ, p)
+                    @test isempty(pruned[p])
+                    @test sh == get(() -> Set(), gone, p)
+                    found += length(sh)
+                    # the subset claim, read off the raw data
+                    for cl = 1:nclasses(ip), v in ip.shadows[cl]
+                        r = ip.versions[first(ip.members[cl])]
+                        @test Set(lookup(data[p].depends, r, ())) ⊆
+                              Set(lookup(data[p].depends, v, ()))
+                        for (q, iq) in univ.info, w in iq.versions
+                            forbids(u) = ref_forbids(data, p, u, q, w) ||
+                                         ref_forbids(data, q, w, p, u)
+                            forbids(r) && @test forbids(v)
+                        end
+                    end
+                end
+            end
+        end
+    end
+    @test found > 0 # the sweep really did find some
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,7 +167,8 @@ using Resolver: PkgData
     @test_throws ArgumentError("Required package MissingReq is not available in the package data") resolve(data, [:MissingReq])
 end
 
-using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file, nclasses
+using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file, nclasses,
+    filter_pkg_info!
 @testset "pkg info files" begin
     # the file carries the partition, since the matrix is built over it rather
     # than the other way round: a loaded artifact must be equal to the saved
@@ -213,6 +214,24 @@ using Resolver: pkg_info, save_pkg_info_file, load_pkg_info_file, nclasses
         Problem([:A]; compat = Dict(:B => [:v2])),
         Problem([:A, :B]; pin = Dict(:B => :v1)),
     ])
+
+    # a fully filtered artifact also carries the versions redundancy
+    # elimination removed, attached to the class that made them removable.
+    # They are not in `versions` any more, so the file has to say so itself
+    fdata = Dict(
+        :A => PkgData([:v2, :v1], Dict(:v1 => [:B]),
+                      Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()),
+        :B => PkgData([:v1], Dict{Symbol,Vector{Symbol}}(),
+                      Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()),
+    )
+    finfo = filter_pkg_info!(pkg_info(fdata, [:A]), [:A]).info
+    @test finfo[:A].versions == [:v2]
+    @test finfo[:A].shadows == [[:v1]]
+    path = save_pkg_info_file(finfo)
+    back = load_pkg_info_file(path)
+    @test back == finfo
+    @test back[:A].shadows == [[:v1]]
+    rm(path)
 end
 
 @testset "zero-version packages" begin


### PR DESCRIPTION
Closes #88. Unblocks #89.

Redundancy elimination deleted dominated versions outright, so a report could not account for them. `Problem(["Zygote","TableTraits"]; compat = ...)` gave:

```
• Zygote: ≤ 0.6.77 excluded by your compat
• Zygote 0.7.5–0.7.12 requires ChainRules
```

Zygote 0.7.0–0.7.4 exist and your compat admits them; the resolver removed them and nothing could say so. Worse, it made the clearer positive phrasing *false* — "with your compat, Zygote can only be 0.7.5–0.7.12" is not true of the compat, which allows 0.7.0–0.7.12.

Now a deleted class hands its versions to the class that dominated it. `PkgInfo` gains `shadows :: Vector{Vector{V}}` beside `members`, rebuilt wherever `members` is.

## Why this is sound

The rule in `layered.md` already says it: redundancy deletes `q@j` only when a better `q@i` has a **subset** of its constraints. Subset means any reason `q@i` cannot be chosen also rules out `q@j` — so the dominator's explanation covers everything it shadows. Shadowing is not a deletion: the classes, rows and columns the proofs quantify over are unchanged, so no theorem restates. `layered.md` gains a section saying that, and what a shadow licenses in both directions — the exclusion carries over, a **stated bound does not**, since a shadowed version's constraints are a superset and may bound more tightly.

## The answer does not change

The deletion set is computed by untouched code; the new work happens after it exists. Differentially, base vs branch:

| check | scope | result |
|---|---|---|
| whole registry | `prepare_pkg_info` over **14,195** packages — versions, classes, depends, interacts, conflicts, reps | identical (6.8 MB digest, byte for byte) |
| registry queries | 12 problems, universes *and* answers | identical |
| random problems | **10,800** constrained, 6,450 of them UNSAT | identical |
| in-suite oracles | 30,126 bake-equivalence, 21,300 ordering-vs-baked, 61,153 brute-force | all pass |

Relaxation stability holds: `test/relaxation_stable.jl` green on both Julia versions, plus three standalone runs with fresh seeds.

## Cost

Whole registry, `prepare_pkg_info` over 14,195 packages, three alternating rounds:

| | base | branch |
|---|---|---|
| time | 5.82 s | 6.07 s (+4.3%) |
| universe memory | 40.8 MiB | 46.7 MiB (+14.5%) |
| T1 artifact | 66.9 MiB | 68.9 MiB (+3.0%) |

17,173 of 55,828 surviving classes shadow something; 60,507 shadowed versions. Per-query time is within a few percent.

## Representation choices

- **Version values, not indices.** `drop_unmarked!` renumbers survivors immediately after the pass that creates shadows, so indices would be invalidated on the spot.
- **Not folded into the class.** A class means indistinguishable and shares a matrix row; shadowed versions carry extra constraints. There is a test for the fold, and a sabotage confirming it is caught.
- **Copy-on-write over a shared empty**, so a class that shadows nothing costs 8 bytes rather than a vector header — and `prepare_pkg_info` cannot write through into the T1 artifact it copied.
- **File format `v3` → `v4`**: `filter_pkg_info!` output is saveable and would otherwise lose the lists silently.

## Testing

Six sabotages, each applied, run and reverted, each caught: mis-attributing every deletion to the first class; skipping the rehoming loop; letting a deactivated class dominate (which returns a `Diagnosis` where a solution exists); discarding shadows on renumber; not writing them to the file; and folding them into `members`/`classes` — the representation #88 warns against, caught with the exact wrong shape.

Full suite green on 1.12.6 (1,242,244 assertions) and nightly 1.14.0-DEV (1,242,765); docs build clean.

## Three things #88 got wrong

1. **The "constraint excludes the dominator but admits a shadow" case cannot arise on the resolve path** — a query-emptied class is excluded from the domination test on both sides, so the constraint that would expose the fold prevents the shadowing upstream. The test demonstrates the real version: the same version is a shadow under one query and a class of its own under another.
2. Shadows had to be values, not indices (above).
3. The file format had to change (above).

The "possible second payoff" — feeding shadows back to allow reordering — is deliberately not attempted: it changes answers by construction and is a different change.

🤖 Reviewed and pushed with [Claude Code](https://claude.com/claude-code)