### PR TITLE
Drop sat_disjoint_muses

### DIFF
--- a/src/UnsatCores.jl
+++ b/src/UnsatCores.jl
@@ -1,24 +1,22 @@
 """
     Resolver.UnsatCores
 
-Minimal explanations of unsatisfiability, over assumption literals: three
+Minimal explanations of unsatisfiability, over assumption literals: two
 questions about a `SAT` instance and an ordered collection of literals the
 caller could assume. `sat_mus` returns a minimal subset of them that is
 unsatisfiable already — drop any one of its literals and the rest is
-satisfiable. `sat_disjoint_muses` splits the collection into independent
-such conflicts, none sharing a literal with another. `sat_mcses` enumerates
-the minimal repairs: every subset whose removal makes everything else
-satisfiable. Answers come back as subsequences of the collection they were asked
+satisfiable. `sat_mcses` enumerates the minimal repairs: every subset whose
+removal makes everything else satisfiable. Answers come back as subsequences of the collection they were asked
 about, and the order it is given in is the caller's only knob: conflicts avoid
 the literals at the front, repairs take the ones at the back.
 
 For the diagnostics machinery, whose relaxations are assumption literals rather
-than packages. These three names are this module's API; `Resolver` itself
+than packages. These two names are this module's API; `Resolver` itself
 exports none of them.
 """
 module UnsatCores
 
-export sat_mus, sat_disjoint_muses, sat_mcses
+export sat_mus, sat_mcses
 
 using ..Resolver: SAT, PicoSAT, sat_assume_var, sat_solve
 
@@ -180,35 +178,6 @@ function mus_shrink_linear(sat::SAT, core::Vector{Int})
         end
     end
     return Int[core[i] for i in eachindex(core) if keep[i]]
-end
-
-"""
-    sat_disjoint_muses(sat, lits) -> Vector{Vector{Int}}
-
-A cover of `lits` by pairwise disjoint minimal unsatisfiable subsets: repeatedly
-extract a MUS and remove it from the candidates until what remains is
-satisfiable. Each returned vector satisfies the `sat_mus` contract, no literal
-appears in two of them, and `lits` minus their union is satisfiable.
-
-Empty when `sat` is satisfiable assuming all of `lits` (and also when `sat` is
-unsatisfiable on its own — see `sat_mus`).
-
-Note that this is *not* an enumeration of all MUSes: MUSes overlap in general,
-and which disjoint ones are found depends on the candidate order and on the
-solver's state, exactly as for `sat_mus`. Cost: one `sat_mus` call per returned
-MUS, plus one to discover that the rest is satisfiable.
-"""
-function sat_disjoint_muses(sat::SAT, lits::AbstractVector{<:Integer})
-    rest = collect(Int, lits)
-    @assert allunique(rest)
-    muses = Vector{Int}[]
-    while true
-        mus = sat_mus(sat, rest)
-        isempty(mus) && break
-        push!(muses, mus)
-        setdiff!(rest, mus) # order-preserving
-    end
-    return muses
 end
 
 ## one repair: the pair the enumeration is built out of

--- a/test/unsat_cores.jl
+++ b/test/unsat_cores.jl
@@ -123,7 +123,6 @@ end
 # the checks below for which answers are state-independent and which aren't.
 transcript(sat::SAT, L::Vector{Int}) = (
     mus   = sat_mus(sat, L),
-    cover = sat_disjoint_muses(sat, L),
     mss   = sat_mss(sat, L),
     mcs   = sat_mcs(sat, L),
     mcses = sat_mcses(sat, L),
@@ -148,16 +147,6 @@ function check_mus_mcs(sat::SAT, info, sols, cands::Vector{Cand})
 
     t = transcript(sat, L)
     check_is_mus(t.mus)
-
-    # the disjoint cover: each a MUS, pairwise disjoint, remainder satisfiable
-    @test all_sat == isempty(t.cover)
-    covered = Int[]
-    for m in t.cover
-        check_is_mus(m)
-        append!(covered, m)
-    end
-    @test allunique(covered)
-    @test oracle_sat(sols, pick(setdiff(L, covered)))
 
     # an MSS is satisfiable and admits no further candidate
     @test t.mss !== nothing
@@ -271,7 +260,7 @@ const no_conflict_data = Dict(
 )
 
 @testset "unsat cores: the API is the submodule's export list" begin
-    api = [:sat_mus, :sat_disjoint_muses, :sat_mcses]
+    api = [:sat_mus, :sat_mcses]
     @test Set(names(Resolver.UnsatCores)) == Set([:UnsatCores; api])
     # the machinery underneath — including the single-repair pair the enumeration
     # is built out of — is defined but stays inside
@@ -283,10 +272,11 @@ const no_conflict_data = Dict(
     # and `Resolver` re-exports none of it
     @test isempty(intersect(names(Resolver), api))
     # nothing survives of what was dropped: the package-keyed conveniences and
-    # their package/literal translation, the union of a cover, and the `_lits`
+    # their package/literal translation, the disjoint cover, and the `_lits`
     # suffix that only existed to keep the conveniences from colliding
     for gone in (:sat_mus_union, :sat_pkg_lits, :sat_lit_pkgs, :sat_mus_lits,
-                 :sat_disjoint_muses_lits, :sat_mus_union_lits, :sat_mss_lits,
+                 :sat_disjoint_muses, :sat_disjoint_muses_lits,
+                 :sat_mus_union_lits, :sat_mss_lits,
                  :sat_mcs_lits, :sat_mcses_lits)
         @test !isdefined(Resolver.UnsatCores, gone)
         @test !isdefined(Resolver, gone)
@@ -323,7 +313,6 @@ end
             Set([Set([:A]), Set([:B])])
         # requiring neither A nor B is fine, so there is nothing to report
         @test isempty(ask(sat_mus, [:C, :D]))
-        @test isempty(sat_disjoint_muses(sat, pkg_lits(sat, [:C, :D])))
         @test ask(sat_mss, [:C, :D]) == [:C, :D]
         @test isempty(ask(sat_mcs, [:C, :D]))
         @test sat_mcses(sat, pkg_lits(sat, [:C, :D])) == [Int[]]
@@ -339,13 +328,10 @@ end
         pkgs = [:A, :B, :C, :E, :F, :G]
         L = pkg_lits(sat, pkgs)
         names_of(sub) = pkg_names(sat, pkgs, sub)
-        # a single conflict covers one of them -- which one is up to the solver's
-        # failed-assumption core -- while the disjoint cover finds both
+        # a single conflict covers one of them -- which one is up to the
+        # solver's failed-assumption core
         @test Set(names_of(sat_mus(sat, L))) ∈
             (Set([:A, :B]), Set([:E, :F]))
-        cover = sat_disjoint_muses(sat, L)
-        @test Set(Set(names_of(m)) for m in cover) ==
-            Set([Set([:A, :B]), Set([:E, :F])])
         # repairing needs one package from each conflict: 2 × 2 = 4 ways
         mcses = sat_mcses(sat, L)
         @test length(mcses) == 4
@@ -375,7 +361,6 @@ end
             sat_add_var(sat, -x); sat_add(sat)
             @test !sat_solve(sat)
             @test isempty(sat_mus(sat, L))
-            @test isempty(sat_disjoint_muses(sat, L))
             @test isempty(sat_mcses(sat, L))
             # white-box: no repair exists, and the pair says so rather than
             # inventing an empty one
@@ -384,7 +369,6 @@ end
         end
         # popping the contradiction restores the instance
         @test sat_solve(sat)
-        @test sat_mus(sat, L) == first(sat_disjoint_muses(sat, L))
     finally
         finalize(sat)
     end
@@ -395,7 +379,6 @@ end
     sat = SAT(info)
     try
         @test isempty(sat_mus(sat, Int[]))
-        @test isempty(sat_disjoint_muses(sat, Int[]))
         @test sat_mcses(sat, Int[]) == [Int[]]
         @test sat_mss(sat, Int[]) == Int[] # white-box
         @test sat_mcs(sat, Int[]) == Int[] # white-box


### PR DESCRIPTION
`sat_disjoint_muses` manufactured disjointness rather than finding it. Each
round deleted the previous MUS's literals from the candidate pool before
asking for the next core, so the sets it returned came back pairwise disjoint
by construction — whether or not the underlying conflicts were actually
independent.

Three separate measurements over registry data showed it overstating
independence, and the diagnosis code that used to lean on it now enumerates
minimal correction sets instead, which answers "what are the independent
conflicts, and how do I fix each" directly rather than by proxy. Nothing calls
it any more.

That leaves `UnsatCores` with two honest questions — one core (`sat_mus`), all
repairs (`sat_mcses`) — and the module docstring updated to match. Tests drop
the `t.cover` invariant block and the six call sites; `:sat_disjoint_muses`
joins the "these names no longer exist" assertion list alongside the
already-removed `:sat_disjoint_muses_lits`.

No behavior change — the function had no remaining callers outside its own
tests.

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code).
