### PR TITLE
Make a conflict read as a syllogism

### DIFF
--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -711,9 +711,11 @@ end
         # by name, since a uuid is not what the reader knows the package as
         @test occursin("cannot be satisfied", msg)
         @test occursin("you require LinearAlgebra", msg)
-        @test occursin("no version of LinearAlgebra is available", msg)
+        # "left", not "available": the registry has versions of it, and the
+        # query's own compat is what took every one of them away
+        @test occursin("no version of LinearAlgebra is left", msg)
         # (the report is filled to a line width, so the clause may be broken)
-        @test occursin("excluded by", msg)
+        @test occursin("by your compat", msg)
         @test occursin("Fix it by any one of:", msg)
         @test occursin("relax your compat on LinearAlgebra", msg)
         @test !occursin(string(LINEAR_ALGEBRA), msg)

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -142,7 +142,6 @@ see why the package could not supply what the conflict needed.
     `:pin` for a pin at another version, and its own name for each other kind
     whose predicate holds. A member with no kind against it is one this query
     admits.
-
 The whole of the offering is here, so what the fact leaves the resolver is what
 it does not exclude: the package is
 [unavailable](@ref Resolver.Diagnostics.unavailable) exactly when every member
@@ -395,12 +394,50 @@ function list_phrase(parts::Vector{String})
     return join(parts[1:end-1], ", ") * " and " * parts[end]
 end
 
-# An availability fact as one line. The fact runs over the package's whole
-# version list, so every maximal run of versions excluded by the same kinds is a
-# range and gets one clause, and the runs it admits are simply not mentioned;
-# the clauses after the first drop "excluded", as an English list of them would.
+# An availability fact as one line, stated positively: what the query leaves,
+# not what it took. The negative form made the reader compute a complement
+# against a version list they do not have -- "≤ 0.6.77 excluded" gives the next
+# line's "0.7.5" only to someone who knows what exists in between -- and the
+# positive form is the same set the next line is about.
+#
+# The kinds are still named, since "your compat" is the part the user can act
+# on, and a run of versions the query admits is what survives them.
 function availability_phrase(f::Availability)
     members, excluded = f.members, f.excluded
+    unavailable(f) && return isempty(members) ?
+        "no version of $(f.pkg) is available" :
+        "no version of $(f.pkg) is left: " *
+            join(exclusion_clauses(members, excluded), ", ")
+    # every maximal run the query admits, as a range
+    parts = String[]
+    i = 1
+    while i ≤ length(members)
+        if isempty(excluded[i])
+            j = i
+            while j < length(members) && isempty(excluded[j+1])
+                j += 1
+            end
+            push!(parts, range_phrase(members, i, j;
+                high = i == 1, low = j == length(members)))
+            i = j
+        end
+        i += 1
+    end
+    kinds = unique!(reduce(vcat, excluded; init = Symbol[]))
+    left = list_phrase(parts)
+    # What is left is credited to the query's constraints only when they are
+    # the whole reason it is what it is. Where redundancy elimination took
+    # versions too, the range is still what the resolve had to choose between,
+    # but saying the compat left it there would be a claim about the compat
+    # that is not true of it alone
+    isempty(kinds) && return "$(f.pkg) can be $left"
+    return "$(kinds_phrase(kinds)) leaves $(f.pkg) at $left"
+end
+
+# the excluded runs, as the negative clauses the unavailable case still needs:
+# there is no surviving range to name, so what took each version away is all
+# there is to say
+function exclusion_clauses(members, excluded)
     clauses = String[]
     i = 1
     while i ≤ length(members)
@@ -408,18 +445,12 @@ function availability_phrase(f::Availability)
         while j < length(members) && excluded[j+1] == excluded[i]
             j += 1
         end
-        if !isempty(excluded[i])
-            by = kinds_phrase(excluded[i])
-            push!(clauses, isempty(clauses) ?
-                "$(range_phrase(members, i, j; high = open_high(i, j, members),
-                    low = open_low(i, j, members))) excluded by $by" :
-                "$(range_phrase(members, i, j; high = open_high(i, j, members),
-                    low = open_low(i, j, members))) by $by")
-        end
+        isempty(excluded[i]) || push!(clauses,
+            "$(range_phrase(members, i, j; high = open_high(i, j, members),
+                low = open_low(i, j, members))) by $(kinds_phrase(excluded[i]))")
         i = j + 1
     end
-    head = unavailable(f) ? "no version of $(f.pkg) is available" : string(f.pkg)
-    return isempty(clauses) ? head : "$head: $(join(clauses, ", "))"
+    return clauses
 end
 
 # The versions a mask picks out of a package's offering, as an English list of
@@ -756,10 +787,29 @@ end
 # taking every class at once is what lets the fact say which versions the query
 # leaves standing as well as which it takes away, and a package is one thing to
 # say a sentence about however many of its classes the story needed.
-availability_fact(sat::SAT{P,V}, prob::Problem{P}, p::P) where {P,V} =
-    Availability{P,V}(p, copy(sat.info[p].versions),
-        Vector{Symbol}[exclusion_kinds(prob, p, v)
-                       for v in sat.info[p].versions])
+function availability_fact(sat::SAT{P,V}, prob::Problem{P}, p::P) where {P,V}
+    info_p = sat.info[p]
+    # Shadows belong in this fact and nowhere else. They are versions
+    # redundancy elimination took of its own accord, so a fact built from what
+    # survives would say the query leaves less than it does -- and the whole
+    # point of stating what is left is that the user can act on it. Whatever
+    # excludes the class excludes everything it shadows, so a chain that rules
+    # the class out rules them out too, and each one's own kinds are a question
+    # for the problem rather than for the class hosting it.
+    #
+    # The order is the version type's, not the provider's. A package lists its
+    # versions best first, which is a claim about preference and is the
+    # provider's to make; a range is read low to high, which is a claim about
+    # order and is the type's. They coincide for version numbers and need not
+    # in general, and it is the second one a report wants.
+    members = copy(info_p.versions)
+    for sh in info_p.shadows
+        append!(members, sh)
+    end
+    sort!(members; rev = true)
+    return Availability{P,V}(p, members,
+        Vector{Symbol}[exclusion_kinds(prob, p, v) for v in members])
+end
 
 # One assumable literal per package this query emptied something of, and the
 # packages they stand for, in package-name order.
@@ -1117,7 +1167,13 @@ function chain_relations(
         for (x, y) in forcing_path(parent, a)
             (x, y) in said && continue
             push!(said, (x, y))
-            append!(facts, relation_facts(sat, prob, x, snap[x], y, false))
+            # with the bound: the next step's subject is the run this one
+            # leaves, so a step that keeps its bound to itself makes that run
+            # appear from nowhere. Where there is no bound to state -- either
+            # because `pkg` declares none, or because the query has left `y`
+            # nothing and every bound would starve it alike -- `relation_facts`
+            # says only that `y` is needed, which is what it said before
+            append!(facts, relation_facts(sat, prob, x, snap[x], y, true))
         end
         a == b || append!(facts, relation_facts(sat, prob, a, live, b, true))
     end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -355,13 +355,25 @@ function check_diagnosis(data, prob::Problem{P}; order = nothing,
             f isa Availability || continue
             if haskey(sat.info, f.pkg)
                 info_p = sat.info[f.pkg]
-                @test f.members == info_p.versions
+                # the fact speaks for every version the query had to choose
+                # between: what survives, plus what redundancy elimination
+                # shadowed, in the version type's own order rather than the
+                # provider's preference order
+                V = eltype(info_p.versions)
+                @test f.members == sort!(vcat(copy(info_p.versions),
+                    reduce(vcat, info_p.shadows; init = V[])); rev = true)
+                @test allunique(f.members)
                 @test f.excluded ==
                     [exclusion_kinds(prob, f.pkg, v) for v in f.members]
+                # a class's own versions carry the class's exclusions, wherever
+                # the fact's ordering puts them -- shadows sit between them, so
+                # this is a lookup by version and not by position any more
+                at = Dict(v => i for (i, v) in enumerate(f.members))
                 for k = 1:nclasses(info_p)
-                    ex = class_exclusions(prob, f.pkg, info_p, k)
-                    @test [f.members[i] for i in info_p.members[k]] == first.(ex)
-                    @test [f.excluded[i] for i in info_p.members[k]] == last.(ex)
+                    for (v, kinds) in class_exclusions(prob, f.pkg, info_p, k)
+                        @test haskey(at, v)
+                        @test f.excluded[at[v]] == kinds
+                    end
                 end
                 # a package with a version left over is not unavailable
                 @test unavailable(f) == all(iszero, sat.reps[f.pkg])
@@ -619,7 +631,7 @@ end
         Conflict 1: R cannot be satisfied.
           • you require R
           • R r1 requires P at p2
-          • P: p2 excluded by your compat
+          • your compat leaves P at p1
           Fix it by any one of:
             1. relax your compat on P
                → allows: P p2, R r1
@@ -647,7 +659,7 @@ end
           • you require A
           • A a3 requires C at c3
           • A ≤ a2 requires C at c2
-          • C: ≥ c2 excluded by your compat
+          • your compat leaves C at c1
           Fix it by any one of:
             1. relax your compat on C
                → allows: A a3, C c3
@@ -663,7 +675,7 @@ end
     # not what the query left nothing of, and the versions it would name are
     # the subject of the next step anyway
     @test c.chain == Fact[Requirement(:A),
-        Dependency{Symbol,Symbol}(:A, [:a1], :B, [:b1], nothing, true, true),
+        Dependency{Symbol,Symbol}(:A, [:a1], :B, [:b1], [true], true, true),
         Dependency{Symbol,Symbol}(:B, [:b1], :C, [:c2, :c1], [true, false], true, true),
         Availability{Symbol,Symbol}(:C, [:c2, :c1], [[:compat], Symbol[]])]
     report = sprint(show, MIME("text/plain"), d)
@@ -684,7 +696,7 @@ end
     d = check_diagnosis(weak_bound, prob)
     c = only(d.conflicts)
     @test c.chain == Fact[Requirement(:P), Requirement(:S),
-        Dependency{Symbol,Symbol}(:S, [:s1], :W, [:w2, :w1], nothing, true, true),
+        Dependency{Symbol,Symbol}(:S, [:s1], :W, [:w2, :w1], [true, true], true, true),
         Incompatibility{Symbol,Symbol}(:P, [:p1], :W, [:w2, :w1],
             [false, true], true, true),
         Availability{Symbol,Symbol}(:W, [:w2, :w1], [Symbol[], [:compat]])]
@@ -994,8 +1006,8 @@ end
         Conflict 1: A cannot be satisfied.
           • you require A
           • A v1 requires B
-          • no version of B is available: w3 excluded by your compat and your pin, w2
-            by your compat, w1 by your pin
+          • no version of B is left: w3 by your compat and your pin, w2 by your
+            compat, w1 by your pin
           Fix it by any one of:
             1. relax your compat on B
                → allows: A v1, B w2
@@ -1112,7 +1124,9 @@ end
     @test f.allowed === nothing
     @test all(v -> v ∈ VersionSpec("1"), f.versions)
     report = sprint(show, MIME("text/plain"), d)
-    @test occursin("no version of PrettyTables is available", report)
+    # "left", not "available": the registry has versions of it, and the
+    # query's own compat is what took every one of them away
+    @test occursin("no version of PrettyTables is left", report)
     @test occursin("relax your compat on PrettyTables", report)
     @test occursin(
         "DataFrames $(f.versions[end])–$(f.versions[1]) requires PrettyTables\n",


### PR DESCRIPTION
Closes #89.

A chain stated its facts and left the reader to connect them. Two things made
that harder than it needed to be.

**Availability facts said what was taken, not what is left.** The next line's
subject then had to be worked out as a complement against a version list the
reader does not have. The worst case the old form produced:

```
• Tables: ≥ 1.0.0 excluded by your compat, ≤ 0.1.19 by your compat
```

— two clauses both crediting the compat, and the band that actually survives
(`0.2.x`) never named at all. It now states the survivor, which is the same set
the rest of the story is about.

**Forcing-path steps suppressed their bounds**, which is what made each range
appear from nowhere. `chain_relations` passed `bound = false` on the steps that
walk toward the starved package, so a line said "Zygote 0.7.12 requires
ChainRules" while the *next* line's subject was `ChainRules ≥ 1.72.2` — a range
that is exactly what Zygote's bound leaves, from a step that declined to say so.
(Zygote 0.7.12's registry compat on ChainRules really is `1.72.2 - 1`; the bound
was there all along.)

Together, on the example from #89:

```
  • you require Zygote                              • you require Zygote
  • Zygote: ≤ 0.7.11 excluded by your compat        • your compat leaves Zygote at 0.7.12
  • Zygote 0.7.12 requires ChainRules          →    • Zygote 0.7.12 requires ChainRules at ≥ 1.72.2
  • ChainRules ≥ 1.72.2 requires StructArrays       • ChainRules ≥ 1.72.2 requires StructArrays at ≥ 0.6.11
  • StructArrays ≥ 0.6.20 requires Tables           • StructArrays ≥ 0.6.20 requires Tables at ≥ 1.2.0
  • Tables ≥ 1.2.0 requires TableTraits at ≥ 0.4.1  • Tables ≥ 1.2.0 requires TableTraits at ≥ 0.4.1
  • TableTraits: ≥ 0.4.0 excluded by your compat    • your compat leaves TableTraits at ≤ 0.3.1
```

## What #88 bought

Saying "your compat leaves X at …" truthfully needs the versions redundancy
elimination removed of its own accord — otherwise the range is what the
*resolve* had left, not what the query admits, and that is not a claim to make
about the user's compat. Those versions are the classes' shadows, which #88
kept, and they go back into the fact here.

They are ordered by the version type rather than by the provider. A package
lists its versions best first, which is a claim about preference; a range is
read low to high, which is a claim about order. The two coincide for version
numbers and need not in general, and it is the second one a report wants. The
cost is that a class's versions no longer sit at the positions its member
indices name — shadows fall between them — so the availability invariants in
`check_diagnosis` became lookups by version instead of by position.

Still not accounted for: versions dropped as uninstallable or unreachable are
absent too, and nothing records them, so the attribution is exact only up to
those.

## Also

A package the query emptied entirely now reads "no version of X is **left**"
rather than "is available". The registry has versions of it; the query took
them. "Available" is still what a package with nothing in the registry gets.

## Not addressed

Two things surfaced while rendering real conflicts, both filed separately
rather than folded in here:

- Where a line's conclusion is not subsumed by the next line's subject, a
  branch is going unexplained — in the chain above, `StructArrays ≥ 0.6.11`
  narrows to `≥ 0.6.20` with nothing said about `0.6.11–0.6.19`.
- #95, a chain naming a package the rest of it never mentions.

Verified against real registry conflicts (Zygote/TableTraits, DataFrames/Tables,
Flux/Zygote, Plots/RecipesBase, CSV/Parsers) as well as the synthetic fixtures.
Full local suite green: problem, satisfiable, classes, class_space, unsat_cores,
relaxation, diagnostics.

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code).
