### PR TITLE
End a conflict's story where its own facts are

### DIFF
--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -1118,16 +1118,25 @@ function chain_relations(
     # Bounds are symmetric, so a package and the one that starves it usually
     # starve each other, and the choice is which way round to say it: a
     # requirement is where the story starts rather than where it ends, and a
-    # story about a package this query emptied is a story about this conflict
-    # rather than some other one. Then the shortest, and then by name, so that
-    # a tie does not depend on iteration order.
+    # walk that *ends* at one of the packages the chain says the query emptied
+    # is telling this conflict's story rather than some other one. Then the
+    # shortest, and then by name, so that a tie does not depend on iteration
+    # order.
+    #
+    # Where it ends is the whole of that question: the chain states one
+    # availability fact per emptied package it names, and the last of them is
+    # what the walk arrives at. A walk that merely *starts* at one — which any
+    # walk does whenever the query has emptied something of a requirement —
+    # says nothing about which package it is about to leave with nothing, so
+    # taking that for a story about this conflict lets it end on a package no
+    # availability fact of this chain speaks of, and leaves the fact that does
+    # not fit stated with nothing in the chain to connect it to.
     best = nothing
     for (q, (before, blame)) in starved
         blamed = fewest_blamed(sat, snap, q, blame, reqs)
         steps = length(blamed) + length(forcing_path(parent, q)) +
             sum(r -> length(forcing_path(parent, r)), blamed; init = 0)
-        touches = q ∈ emptied || any(∈(emptied), blamed)
-        key = (q ∈ reqs, !touches, steps, string(q))
+        key = (q ∈ reqs, q ∉ emptied, steps, string(q))
         (best === nothing || key < best[1]) && (best = (key, q, before, blamed))
     end
     _, q, before, blamed = best

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -540,6 +540,21 @@ const conflict_path = Dict(
     :R => PkgData([:r2, :r1], DEPS_NONE, COMP_NONE),
 )
 
+# Two conflicts at once, the second of them squeezed twice over: :B needs :U at
+# a version the query has taken away, and :E needs :Z at one and :T at another,
+# reaching :T through :M. Either of :E's squeezes explains it by itself, so the
+# smallest explanation names one of them — and the walk from :E meets the other
+# on its way there
+const two_squeezes = Dict(
+    :B => PkgData([:b1], Dict(:b1 => [:U]), Dict(:b1 => Dict(:U => [:u2]))),
+    :E => PkgData([:e2, :e1], Dict(:e1 => [:M, :Z]),
+        Dict(:e1 => Dict(:Z => [:z2]))),
+    :M => PkgData([:m1], Dict(:m1 => [:T]), Dict(:m1 => Dict(:T => [:t2]))),
+    :T => PkgData([:t2, :t1], DEPS_NONE, COMP_NONE),
+    :U => PkgData([:u2, :u1], DEPS_NONE, COMP_NONE),
+    :Z => PkgData([:z2, :z1], DEPS_NONE, COMP_NONE),
+)
+
 @testset "diagnosis: independent conflicts come out separately" begin
     prob = Problem([:A, :B, :E, :F])
     d = check_diagnosis(two_conflicts, prob)
@@ -859,6 +874,39 @@ end
     @test occursin("The only fix: relax your compat on C", report)
     # the witness names both of them too
     @test occursin("→ allows: A a2, B b2, C c2", report)
+end
+
+@testset "diagnosis: a story ends where its own facts are" begin
+    # :E is squeezed by :Z one hop away and by :T two hops away, and the
+    # smallest explanation of it names :T. The walk has to end there too: a
+    # story that stopped at :Z would state a dependency on a package it then
+    # says nothing about, and :T's bound would arrive with nothing in the chain
+    # to connect it to — this conflict wearing another one's fact
+    prob = Problem([:B, :E];
+        compat = Dict(:E => [:e1], :T => [:t1], :U => [:u1], :Z => [:z1]))
+    d = check_diagnosis(two_squeezes, prob)
+    @test length(d.conflicts) == 2
+    c = only(x for x in d.conflicts if x.reqs == [:E])
+    @test c.chain == Fact[Requirement(:E),
+        Availability{Symbol,Symbol}(:E, [:e2, :e1], [[:compat], Symbol[]]),
+        Dependency{Symbol,Symbol}(:E, [:e1], :M, [:m1], [true], true, true),
+        Dependency{Symbol,Symbol}(:M, [:m1], :T, [:t2, :t1],
+            [true, false], true, true),
+        Availability{Symbol,Symbol}(:T, [:t2, :t1], [[:compat], Symbol[]])]
+    # ... which is to say that every package the chain says the query emptied
+    # is one the chain's own relations reach
+    reached = Set{Symbol}(c.reqs)
+    for f in c.chain
+        f isa Dependency && push!(reached, f.pkg, f.dep)
+    end
+    @test all(f -> !(f isa Availability) || f.pkg in reached, c.chain)
+    # :Z is no part of this story, so the report does not mention it
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("E e1 requires M\n", report)
+    @test occursin("M m1 requires T at t2\n", report)
+    @test !occursin("Z", report)
+    @test [fix.actions for fix in c.fixes] ==
+        [[Action(:compat, :E)], [Action(:drop, :E)]]
 end
 
 @testset "diagnosis: cheapest repairs that are not a product" begin


### PR DESCRIPTION
Closes #95.

A conflict's chain could state an availability fact for a package the rest of it
never mentions, and the fix menu for that conflict looked wrong as a result.

## The cause

The relations in a story come from a walk that ends at a package the query left
with nothing, and several packages can starve at once. Which one to end at was
decided by:

```julia
touches = q ∈ emptied || any(∈(emptied), blamed)
key = (q ∈ reqs, !touches, steps, string(q))
```

The `blamed` disjunct is the bug. A walk *starting* at a package whose classes
the query emptied blames that package for the starvation, so `touches` is true
for **every** starved package as soon as the query has constrained a
requirement — which is exactly what a squeezed requirement is. The tie then
fell through to `steps`, and a story about Flux could end at Zygote, whose
availability the chain does not state, while Tables, whose availability it does
state, was left with no relation naming it and got appended to the end of the
chain by `conflict_story`'s trailing loop.

The comment above the function already said the rule was about where a walk
*ends*. The code did not implement it. The fix is to decide it by that and
nothing else:

```julia
key = (q ∈ reqs, q ∉ emptied, steps, string(q))
```

## On the issue's predicted output

#95 predicted the chain should end on Zygote's availability and offer "relax
your compat on Zygote". **That prediction was wrong**, and this PR deliberately
does not produce it. Flux is squeezed twice over — `Flux → MLCore → Tables` is
unsatisfiable on its own, independently of Zygote — so the chain correctly ends
on Tables, by way of the hops that reach it.

The menu is right too. Enumerating every smallest repair for the reproducer
gives six, all of size two, and `larger_repair_exists` is false, so these are
all of them:

```
{drop DataFrames, drop Flux}          {drop Flux, relax DataFrames}
{drop DataFrames, relax Flux}         {drop Flux, relax Tables}
{relax DataFrames, relax Flux}        {relax Tables, relax Zygote}
```

Exactly one contains a Zygote action, and it also contains Tables — so
`{relax DataFrames, relax Zygote}` is not a repair, and relaxing Zygote settles
Flux only when conflict 1 is settled by relaxing Tables rather than by its
default fix. No single relaxation settles Flux there, which is why the menu is
the single `drop requirement Flux`. That is `factor_repairs` doing its job on a
family that does not factor, not `conflict_story` losing an option.

## Test

The single-conflict fixtures cannot catch this — there is only ever one emptied
package to choose between. The new `two_squeezes` fixture has two conflicts,
the second squeezed both one hop away and two, so the smallest explanation
names one squeeze while the walk passes the other on its way there. It asserts
the exact chain, the report text, the menu, and the general invariant that
every availability fact's package is reached by the chain's own relations.

Verified failing without the fix (5 assertions) and passing with it.

## Known follow-up

Two pre-existing shapes still put an availability fact in a chain that does not
reach it, both different from this one and neither fixed here: a required
package whose versions die for different reasons, and a walk that stops one hop
short of the package that starved it. The latter needs a design change to
`forced_descent`, not a tie-break.

Full local suite green, including `bin/test/runtests.jl` (175/175).

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code).
