### PR TITLE
Bound the scan for a package's chosen class

### DIFF
--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -465,16 +465,17 @@ const is_unsatisfiable = !is_satisfiable
 function each_solution_index(f::Function, sat::SAT)
     for (p, v_p) in sat.vars
         PicoSAT.deref(sat.pico, v_p) < 0 && continue
-        i = 1
-        while true
-            if PicoSAT.deref(sat.pico, v_p + i) > 0
-                # guaranteed to happen by SAT construction:
-                # v_p => v_p + i for some i = 1:n_p
-                f(p, i)
-                break
-            end
-            i += 1
+        c = 0
+        for i = 1:nclasses(sat.info[p])
+            PicoSAT.deref(sat.pico, v_p + i) > 0 || continue
+            c = i
+            break
         end
+        @assert c != 0 """
+            $p is installed with no class chosen, which `v_p => ⋁ᵢ p@i` forbids:
+            the last solve must have returned satisfiable, with no clauses added
+            since."""
+        f(p, c)
     end
 end
 

--- a/test/satisfiable.jl
+++ b/test/satisfiable.jl
@@ -194,3 +194,37 @@ end
         end
     end
 end
+
+# The scan in `each_solution_index` restates `sat_variables`' layout, and the
+# prefix-ladder variables sit immediately after a package's class block -- so
+# if the two drift apart it reports a class the package has not got, silently:
+# only `solution` ever indexes `reps` with what it yields.
+@testset "each_solution_index: the scan stays inside its package's block" begin
+    none_d = Dict{Symbol,Vector{Symbol}}()
+    none_c = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
+    cases = [
+        # three classes, so a ladder is laid right after them
+        Dict(:A => Resolver.PkgData([:a1], Dict(:a1 => [:B]), none_c),
+             :B => Resolver.PkgData([:b3, :b2, :b1],
+                 Dict(:b3 => [:C], :b2 => Symbol[], :b1 => Symbol[]), none_c),
+             :C => Resolver.PkgData([:c1], none_d, none_c)) => [:A],
+        # one class, so no ladder at all
+        Dict(:A => Resolver.PkgData([:a1], none_d, none_c)) => [:A],
+    ]
+    for (data, reqs) in cases
+        prob = Resolver.Problem(reqs)
+        sat = SAT(prepare_pkg_info(pkg_info(data, prob), prob))
+        @test Resolver.sat_solve(sat)
+        seen = Dict{Symbol,Int}()
+        Resolver.each_solution_index(sat) do p, i
+            @test 1 ≤ i ≤ Resolver.nclasses(sat.info[p])
+            @test !haskey(seen, p)
+            seen[p] = i
+        end
+        sol = Resolver.solution(sat)
+        @test Set(keys(sol)) == Set(keys(seen))
+        for (p, v) in sol
+            @test v == sat.info[p].versions[sat.reps[p][seen[p]]]
+        end
+    end
+end


### PR DESCRIPTION
Closes #92.

`each_solution_index` walked a package's class variables with `while true`,
resting on the clause `p ⇒ ⋁ᵢ p@i` to stop it:

```julia
i = 1
while true
    if PicoSAT.deref(sat.pico, v_p + i) > 0
        # guaranteed to happen by SAT construction:
        # v_p => v_p + i for some i = 1:n_p
        f(p, i)
        break
    end
    i += 1
end
```

The clause is added for every package, so the loop is not wrong today. What it
has is no enforcement of the bound it assumes, and the worst available failure
mode if that ever stops holding. `sat_variables` lays a package's classes at
`v_p+1 : v_p+n_p` and puts the prefix-ladder variables immediately after, so a
scan that outruns the block reads a variable belonging to something else and
reports a class the package has not got — and past the last variable
`picosat_deref` is bounds-checked and answers `0` rather than erroring, so the
loop never stops at all. A resolve would hang: no stack trace, no message,
nothing to bisect.

Now it scans `1:nclasses(sat.info[p])` and raises if no class is true, naming
the package.

## No answer changes

Measured rather than assumed: over 400 satisfiable random instances (1151
package variables), `deref` never returned `0` for a package variable — which
matters because the guard skips only `deref < 0`, so an unassigned variable
would fall through into the scan — and no yielded index ever left its package's
range. Both suites pass unchanged.

## About the test

The test is about the layout arithmetic, not the assertion. An instance
violating the constructor's own invariant is not constructible through the
public API — `SAT` always adds the clause, and it is not in a frame anything can
pop — so there is no honest way to make the new error fire, and per the issue I
have not contrived one.

What can be pinned down is that the scan reads the right variables. `v_p + i` is
`sat_variables`' layout written out a second time, and if the two drifted apart
the symptom would be silent: `extract_solution!` just stores the index, and only
`solution` ever indexes `reps` with it. The new testset checks that every index
is one of the package's own, that each installed package gets exactly one, and
that the versions `solution` derives agree — over a fixture with three classes
(so a ladder is laid immediately after the block) and one with a single class
(so there is no ladder at all).

Verified it has teeth by mutation: changing the scan to `v_p + i + 1` produces
20 failures, and the new `error` fires rather than the loop hanging.

Full local suite green, including `bin/test/runtests.jl` (175/175).

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code).
