### PR TITLE
Dedup identical ManifestEntry values across registries

### DIFF
--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -595,6 +595,13 @@ struct ManifestEntry
     weakdeps :: Dict{String,UUID}
 end
 
+# Value-based equality/hash so identical entries from multiple registries dedup in Set
+Base.:(==)(a::ManifestEntry, b::ManifestEntry) =
+    a.name == b.name && a.version == b.version && a.tree_hash == b.tree_hash &&
+    a.deps == b.deps && a.weakdeps == b.weakdeps
+Base.hash(a::ManifestEntry, h::UInt) =
+    hash((a.name, a.version, a.tree_hash, a.deps, a.weakdeps), h)
+
 # On Julia >= 1.14 the registry parser yields a package's dependencies as a
 # `Set{UUID}` rather than a `Dict{String,UUID}`; the manifest still needs them
 # keyed by name, so reconstruct the mapping from a uuid -> name table covering


### PR DESCRIPTION
When the same package version is served by more than one installed registry (for us: a private registry that mirrors a package also present in another private registry), `bin/resolve.jl` collects one `ManifestEntry` per registry into a `Set{ManifestEntry}` and errors if the set has more than one element:

```
Package DyadData [cab12561-e36c-4498-ae70-c9a5e79fef2a]: version 2.0.0 resolved but has multiple conflicting definitions
```

The entries are identical by value (same name, version, tree hash, deps and weakdeps), but `ManifestEntry` is a plain struct with `Dict` fields, so `==`/`hash` fall back to identity and the set never dedups them.

This defines value-based `==` and `hash` for `ManifestEntry`, so identical entries collapse to one and the manifest is written. Entries that genuinely differ (different tree hash or dependency set) still produce the error.

No test added: the `bin/test` suite runs against the installed General registry only, and reproducing this needs two registries that both carry the same version. Happy to add one if you have a preferred way to set that up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
