### PR TITLE
Name a repeated conflict by what tells it apart

### DIFF
--- a/docs/src/theory/unsat-explanation.md
+++ b/docs/src/theory/unsat-explanation.md
@@ -976,9 +976,13 @@ Rules, not preferences — each guards a truth-condition or an attribution:
   too much ("cannot be satisfied" is false absolutely, true only under the
   unstated *given the rest*) or spell the context out at absurd length; the
   bare form is as clear, shorter, and never wrong. The one sentence heading
-  that survives is the absolute truth: "no version of X is available." The
-  checkers still premise every requirement the conflict answers for: what
-  shrinks is the sentence, not the claim set.
+  that survives is the absolute truth: "no version of X is available." Where
+  two conflicts share a root requirement their headings would read as one
+  conflict said twice, so each is extended with the package it contradicts
+  at — the package its own lines name and the others' do not, taken where
+  the chain closes — which leaves the heading a true bare list and stops it
+  reading as a duplicate. The checkers still premise every requirement the
+  conflict answers for: what shrinks is the sentence, not the claim set.
 * **Blocked fixes answer for actions, one sentence each.** For every
   tempting action — named by the conflict's lines or heading, in no fix of
   the cover — the section prints its solve-decided verdict (Section 7): an

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -1633,12 +1633,77 @@ heading_reqs(c::Conflict) = c.reqs
 # sentence that survives is the absolute truth: a requirement whose package the
 # universe holds nothing of has no argument to make, and what became of it is
 # the whole of what there is to say.
-function conflict_heading(c::Conflict)
+function conflict_heading(c::Conflict, also = nothing)
     rs = heading_reqs(c)
     isempty(c.lines) && length(rs) == 1 &&
         return "no version of $(only(rs)) is available."
     isempty(rs) && return "the requirements"
-    return join_and(String[string(r) for r in rs])
+    parts = String[string(r) for r in rs]
+    also === nothing || push!(parts, string(also))
+    return join_and(parts)
+end
+
+# The packages a conflict's lines name, in the order the lines name them.
+function line_packages(c::Conflict{P,V}) where {P,V}
+    ps = P[]
+    for l in c.lines, p in packages(l.clause)
+        p in ps || push!(ps, p)
+    end
+    return ps
+end
+
+# Which package tells this conflict apart from the others its heading collides
+# with: one its own lines name and `common` — the packages every one of them
+# names — does not, or nothing where its lines say nothing the others do not.
+# Among several, the package the chain closes against — the last query fact the
+# page states, read off the chain itself rather than guessed at — since that is
+# where this conflict contradicts, and so the difference the reader is being
+# pointed at rather than a name picked off a list. Failing that the meet's
+# pivot, which is what a page that states no query fact argues about. A
+# requirement the heading already names is never the answer.
+function distinguishing_package(c::Conflict{P,V}, common::Set{P}) where {P,V}
+    cands = P[p for p in line_packages(c) if p ∉ common && p ∉ c.reqs]
+    isempty(cands) && return nothing
+    for p in Iterators.reverse(chain_closers(c))
+        p in cands && return p
+    end
+    for l in Iterators.reverse(c.lines)
+        l.pivot in cands && return l.pivot
+    end
+    return cands[1]
+end
+
+# The packages the page states the query's own facts about, in the order it
+# states them — the chain's own walk, asked and not printed.
+chain_closers(c::Conflict{P,V}) where {P,V} =
+    print_chain(devnull, c, Line{P}[l for l in c.lines if l.given],
+                Line{P}[l for l in c.lines if !l.given],
+                p -> c.versions[p], string)
+
+# Two conflicts rooted in the same requirements print the same bare list, and a
+# heading repeated reads as one conflict said twice rather than as two separate
+# problems with one requirement in common. So a colliding heading is extended
+# with the package that conflict contradicts at: still a bare list, still
+# claiming nothing, and now naming what makes it its own conflict. A heading
+# nothing collides with is untouched, and where the lines overlap entirely
+# there is nothing to add — the conflict's number is the whole of the
+# difference. Presentation only: what the conflict answers for is `reqs`, which
+# this does not touch.
+function heading_extras(cs::Vector{Conflict{P,V}}) where {P,V}
+    extras = Dict{Int,P}()
+    groups = Dict{String,Vector{Int}}()
+    for (i, c) in enumerate(cs)
+        push!(get!(Vector{Int}, groups, conflict_heading(c)), i)
+    end
+    for is in values(groups)
+        length(is) > 1 || continue
+        common = reduce(intersect, (Set{P}(line_packages(cs[i])) for i in is))
+        for i in is
+            p = distinguishing_package(cs[i], common)
+            p === nothing || (extras[i] = p)
+        end
+    end
+    return extras
 end
 
 # Which of the query's kinds took versions of `p` away, and what they left.
@@ -1881,6 +1946,9 @@ end
 # statement that would still need two packages introduced brings its own, the
 # facts it rests on printing above it. A meet of three or more sides is that
 # case twice over, and prints whole.
+#
+# Answers with the packages it stated the query's own facts about, in the order
+# it stated them: the last of them is the fact the chain closed against.
 function print_chain(io::IO, c::Conflict{P,V}, given::Vector{Line{P}},
                      derived::Vector{Line{P}}, vers, names) where {P,V}
     order, con, extra, loose = given_facts(c, given)
@@ -1891,11 +1959,14 @@ function print_chain(io::IO, c::Conflict{P,V}, given::Vector{Line{P}},
     told = Set{P}()
     acc = Dict{P,Lit}()
 
+    closers = P[]
     function tell(p::P)
         p in told && return
         push!(told, p)
-        haskey(con, p) &&
+        if haskey(con, p)
             print_wrapped(io, constraint_phrase(c, p, con[p]), "  • ", "    ")
+            push!(closers, p)
+        end
         for l in get(extra, p, Line{P}[])
             print_wrapped(io, line_phrase(l, vers, names), "  • ", "    ")
         end
@@ -1945,6 +2016,7 @@ function print_chain(io::IO, c::Conflict{P,V}, given::Vector{Line{P}},
     for l in loose
         print_wrapped(io, line_phrase(l, vers, names), "  • ", "    ")
     end
+    return closers
 end
 
 # What the fix gets you, of the packages the page speaks of: the reader sees the
@@ -1990,12 +2062,15 @@ One conflict's page: its heading (where it is numbered), the lines that prove
 it, the menu that settles it, and the verdict on each action the page makes
 tempting and no fix takes. `others` is what the whole diagnosis knows about
 the repairs its menus do not reach, which is what a menu of one is entitled to
-say about itself.
+say about itself. `also` is a package to name in the heading beside the
+requirements, which a page whose heading would otherwise repeat another's is
+given (`heading_extras`).
 """
 function print_conflict(io::IO, c::Conflict{P,V}, index = nothing;
-                        others::Symbol = :some, alone::Bool = true) where {P,V}
+                        others::Symbol = :some, alone::Bool = true,
+                        also = nothing) where {P,V}
     index === nothing ||
-        println(io, "Conflict ", index, ": ", conflict_heading(c))
+        println(io, "Conflict ", index, ": ", conflict_heading(c, also))
     vers(p) = c.versions[p]
     names(p) = string(p)
     print_chain(io, c, Line{P}[l for l in c.lines if l.given],
@@ -2169,9 +2244,11 @@ function Base.show(io::IO, ::MIME"text/plain", d::Diagnosis)
     # residue is empty.
     n > 1 && isempty(d.residue) && print(io, ", each of which must be fixed")
     println(io, ":")
+    extras = heading_extras(d.conflicts)
     for (i, c) in enumerate(d.conflicts)
         println(io)
-        print_conflict(io, c, i; others = d.others, alone = isempty(d.residue))
+        print_conflict(io, c, i; others = d.others, alone = isempty(d.residue),
+                       also = get(extras, i, nothing))
     end
     if !isempty(d.residue)
         println(io)

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -1373,6 +1373,49 @@ end
 end
 
 
+# A heading is the requirements its conflict answers for, so two conflicts
+# rooted in the same requirement print the same one -- which reads as one
+# conflict said twice rather than as two problems sharing a root. Where
+# headings collide, each is extended with the package that conflict closes
+# against; a heading nothing collides with is untouched, and conflicts whose
+# lines say the same thing leave the number to do the whole of the telling.
+# Built by hand, since what is under test is the rendering and not the
+# analysis that found the conflicts.
+@testset "diagnosis: a repeated heading names what tells the two apart" begin
+    P, V = String, Int
+    VS = Dict(p => [1, 2] for p in ("A", "B", "C", "D", "E"))
+    dep(p, q) = Clauses.clause([p => literal(2, [1], true; absent = true),
+                                q => literal(2, [1])])
+    bound(q) = Clauses.clause([q => literal(2, [2]; absent = true)])
+    # `p 1 requires q 1`, and the user's compat on q contradicting it
+    conflict(p, q) = Conflict{P,V}(P[p],
+        Line{P}[Line{P}(dep(p, q), P[], false, 1, nothing),
+                Line{P}(bound(q), P[], true)],
+        VS, Dict{P,Vector{Vector{Symbol}}}(q => [[:compat]]), Fix{P,V}[])
+    page(cs...) = replace(sprint(show, MIME("text/plain"),
+                                 Diagnosis(Conflict{P,V}[cs...], :none)),
+                          r"\n\s+" => " ")
+
+    # two conflicts about A closing at different packages: each heading names
+    # the package that conflict contradicts at, and neither names the other's
+    out = page(conflict("A", "B"), conflict("A", "C"), conflict("D", "E"))
+    @test occursin("Conflict 1: A and B • A 1 requires B 1", out)
+    @test occursin("Conflict 2: A and C • A 1 requires C 1", out)
+    # ... and the conflict nothing collides with keeps its bare heading
+    @test occursin("Conflict 3: D • D 1 requires E 1", out)
+
+    # a heading with nothing to collide with is untouched, same packages or no
+    @test occursin("Conflict 1: A • A 1 requires B 1",
+                   page(conflict("A", "B")))
+
+    # two conflicts whose lines say the same thing have nothing to add: the
+    # number is the whole of the difference
+    same = page(conflict("A", "B"), conflict("A", "B"))
+    @test occursin("Conflict 1: A • A 1 requires B 1", same)
+    @test occursin("Conflict 2: A • A 1 requires B 1", same)
+    @test !occursin("A and B", same)
+end
+
 @testset "diagnosis: the report" begin
     # each conflict carries its own menu, and the menus do not multiply: two
     # menus of two, not one of four. There is no closing sentence — every


### PR DESCRIPTION
Fixes a presentation defect in the unsatisfiable-resolve reports: when one required package is the root of several *independent* conflicts, they all printed the identical heading — "Conflict 4: Cairo_jll" and "Conflict 6: Cairo_jll" — which reads as one conflict said twice rather than two separate problems sharing a requirement. In a corpus of 57 hard real-world "upgrade the whole environment" queries this happened in 20 cases.

## The fix

A colliding heading is extended with **the package that conflict contradicts at** — among the packages its own lines name, minus those every conflict in the collision names and minus its requirements, the one the chain closes against (read off the chain's own walk, so the reader's eye stops on that same line), with the meet's pivot and then line order as fallbacks. Still the bare-list form, still true. Decided at render time only: a heading with no collision is byte-identical to before, and `Conflict.reqs` is untouched.

Makie's headings, before:

```
Conflict 1: FreeTypeAbstraction
Conflict 2: Makie
Conflict 3: Animations
Conflict 4: Cairo_jll
Conflict 5: ImageIO
Conflict 6: Cairo_jll
Conflict 7: FFMPEG_jll
```

and after:

```
Conflict 1: FreeTypeAbstraction
Conflict 2: Makie
Conflict 3: Animations
Conflict 4: Cairo_jll and GettextRuntime_jll
Conflict 5: ImageIO
Conflict 6: Cairo_jll and Libffi_jll
Conflict 7: FFMPEG_jll
```

The two stanzas that collided, as they now read — each is a different argument, and the heading now says at what:

```
Conflict 4: Cairo_jll and GettextRuntime_jll
  • Cairo_jll requires Glib_jll
  • your compat leaves Glib_jll 2.88.3+0
  • Glib_jll ≥2.84.3+0 requires GettextRuntime_jll 0.22.4+0
  • your compat leaves GettextRuntime_jll 1.0.0+0
  Fix it by any one of:
    1. relax your compat on GettextRuntime_jll
       → allows: Cairo_jll 1.18.7+0, GettextRuntime_jll 0.22.4+0, Glib_jll
         2.88.3+0
    2. relax your compat on Glib_jll
       → allows: Cairo_jll 1.18.7+0, GettextRuntime_jll 1.0.0+0, Glib_jll
         2.84.0+0
  Blocked fixes:
    • relaxing your compat on Cairo_jll does not help.
    • dropping requirement GettextRuntime_jll does not help.
    • dropping requirement Cairo_jll or dropping requirement Glib_jll would
      only help if you do both and also relaxed your compat on EarCut_jll,
      relaxed your compat on FixedPointNumbers, relaxed your compat on
      Giflib_jll, dropped requirement FFMPEG_jll, dropped requirement
      HarfBuzz_jll, dropped requirement Makie and dropped requirement
      libass_jll.

Conflict 6: Cairo_jll and Libffi_jll
  • Cairo_jll requires Libffi_jll ≤3.2.2+2, 3.4.7+0 (through Glib_jll)
  • your compat leaves Libffi_jll 3.5.2+0
  One fix: relax your compat on Libffi_jll
    → allows: Cairo_jll 1.18.7+0, Libffi_jll 3.4.7+0
  Blocked fixes:
    • relaxing your compat on Cairo_jll does not help.
    • dropping requirement Libffi_jll does not help.
    • dropping requirement Cairo_jll would not help unless you also relaxed
      your compat on EarCut_jll, relaxed your compat on FixedPointNumbers,
      relaxed your compat on Giflib_jll, dropped requirement FFMPEG_jll,
      dropped requirement Glib_jll, dropped requirement HarfBuzz_jll, dropped
      requirement Makie and dropped requirement libass_jll.
```

## Evidence

Over the hard corpus — **every report, before and after, is in this gist: https://gist.github.com/StefanKarpinski/af717e40b3457450bfc316612d46f925** (`changed.md` has the 20 changed cases side by side) — **20 of 57 reports had a repeated heading before and none do after**, and a diff of every report shows *only* heading lines changed. Full suite green; new unit test covers the collision, the non-colliding neighbour, and the fully-overlapping fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hyi2aKkUnkd9HA2hS9YChk
