### PR TITLE
Fix stale stdlib snapshot, and notice the next one (#103)

### DIFF
--- a/.github/workflows/stdlibs.yml
+++ b/.github/workflows/stdlibs.yml
@@ -1,0 +1,75 @@
+# Check bin/'s pinned stdlib snapshot against every Julia it claims to support.
+#
+# bin/ pins HistoricalStdlibVersions, whose data is a snapshot of what each
+# Julia release bundles. A pin left behind by new Julia releases keeps
+# resolving -- it just resolves against a Julia that never existed, and the
+# wrong answer is shaped exactly like a real conflict (issue #103). The suite in
+# ci.yml runs this same check, but only under the Julia it runs on, so the older
+# manifests would go unchecked. This job covers the rest of the range.
+#
+# It also instantiates each manifest before checking it, so a manifest that no
+# longer resolves on its own Julia fails here too.
+#
+# Only released Julias: bin/check_stdlibs.jl skips prereleases, since a
+# development build and the snapshot's stanza for it are two different points on
+# a moving branch and disagree for no reason anyone could fix.
+name: stdlibs
+on:
+  pull_request:
+    paths:
+      - 'bin/**'
+      - '.github/workflows/stdlibs.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'bin/**'
+      - '.github/workflows/stdlibs.yml'
+  # the pin can go stale with nothing here changing, so also check on a timer
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+jobs:
+  snapshot:
+    name: Julia ${{ matrix.version }} stdlib snapshot
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Every minor bin/Project.toml's `julia` compat admits. Spelled out
+        # rather than derived: it changes about once a year, and the
+        # `manifests` job below fails when a released Julia is missing from
+        # bin/, which is the same moment this list needs a new entry.
+        version: ['1.9', '1.10', '1.11', '1.12']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+      - name: Instantiate bin/
+        run: julia --project=bin -e 'using Pkg; Pkg.instantiate()'
+      - name: Check the stdlib snapshot
+        run: julia --project=bin bin/check_stdlibs.jl
+
+  # A Julia minor with no manifest of its own does not fail -- it falls back to
+  # another Julia's pins -- so nothing above would notice a new release going
+  # unsupported. This is the only check here that depends on what Julia has
+  # shipped rather than on what is installed, so it runs once, on latest.
+  manifests:
+    name: A manifest per released Julia
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+      - name: Instantiate bin/
+        run: julia --project=bin -e 'using Pkg; Pkg.instantiate()'
+      # bin/julia_versions.json is a committed cache refreshed when it is over
+      # an hour old, and a fresh checkout looks new -- so the committed copy
+      # would be used however stale it is, which is exactly what this job must
+      # not trust. Age it to force the refetch.
+      - name: Force a fresh Julia release list
+        run: touch -d '@0' bin/julia_versions.json
+      - name: Check for missing manifests
+        run: julia --project=bin bin/update_manifests.jl --check

--- a/bin/Manifest-v1.10.toml
+++ b/bin/Manifest-v1.10.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.9"
+julia_version = "1.10.11"
 manifest_format = "2.0"
-project_hash = "7742b17646627b575a16722e2b83574215cd1ad3"
+project_hash = "77fe9f78fab46b624d21a7dbf39b5b2c5be8ac9b"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -38,15 +38,21 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.7.0"
+version = "1.8.0"
 
 [[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "88352712893ec50bee3680605891eaf0e9ed6368"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.4"
+version = "1.8.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -85,24 +91,21 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
-
-[[deps.Mmap]]
-uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "2.28.1010+0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2025.12.2"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
 [[deps.Parsers]]
-deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+deps = ["Dates", "PrecompileTools"]
+git-tree-sha1 = "663e8b48b789916221e0765393b289ca6c88f24e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.3"
+version = "3.0.0"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -117,9 +120,9 @@ version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.3"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -137,7 +140,7 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 deps = ["Serialization", "libpicosat_jll"]
 path = ".."
 uuid = "ecd60e94-5748-11e9-04dc-1fe0f95e4121"
-version = "0.1.0"
+version = "0.2.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -148,6 +151,22 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.5"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -173,9 +192,9 @@ version = "1.2.13+1"
 
 [[deps.libpicosat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d9c92caf140928a90515bc20ea4d8d319fe4ca9f"
+git-tree-sha1 = "cbda9296ecfdf9d9805a512845471d584e5fbb75"
 uuid = "6b231c3b-13f8-5ced-86ae-8860c7f75d86"
-version = "965.0.0+0"
+version = "965.0.2+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -185,4 +204,4 @@ version = "1.52.0+1"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.6.1+0"

--- a/bin/Manifest-v1.10.toml
+++ b/bin/Manifest-v1.10.toml
@@ -27,10 +27,10 @@ version = "1.6.0"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.HistoricalStdlibVersions]]
-deps = ["Pkg"]
-git-tree-sha1 = "7e72d0ce251105cebeab1e156977af2346cbe558"
+deps = ["Pkg", "PrecompileTools"]
+git-tree-sha1 = "e2c444d79d406f80f316b779761eef0cf17fc137"
 uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
-version = "2.0.2"
+version = "2.0.7"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]

--- a/bin/Manifest-v1.11.toml
+++ b/bin/Manifest-v1.11.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.5"
+julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "7742b17646627b575a16722e2b83574215cd1ad3"
+project_hash = "d0273994dbd7c6962a4a015bbb47318ba699fafb"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -38,15 +38,21 @@ version = "2.0.7"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.7.0"
+version = "1.8.0"
 
 [[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "88352712893ec50bee3680605891eaf0e9ed6368"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.4"
+version = "1.8.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -91,10 +97,6 @@ deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.6+0"
 
-[[deps.Mmap]]
-uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-version = "1.11.0"
-
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2023.12.12"
@@ -104,10 +106,10 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
 [[deps.Parsers]]
-deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+deps = ["Dates", "PrecompileTools"]
+git-tree-sha1 = "663e8b48b789916221e0765393b289ca6c88f24e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.3"
+version = "3.0.0"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -128,9 +130,9 @@ version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.3"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -146,7 +148,7 @@ version = "1.11.0"
 deps = ["Serialization", "libpicosat_jll"]
 path = ".."
 uuid = "ecd60e94-5748-11e9-04dc-1fe0f95e4121"
-version = "0.1.0"
+version = "0.2.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -155,6 +157,22 @@ version = "0.7.0"
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 version = "1.11.0"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.5"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -182,9 +200,9 @@ version = "1.2.13+1"
 
 [[deps.libpicosat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d9c92caf140928a90515bc20ea4d8d319fe4ca9f"
+git-tree-sha1 = "cbda9296ecfdf9d9805a512845471d584e5fbb75"
 uuid = "6b231c3b-13f8-5ced-86ae-8860c7f75d86"
-version = "965.0.0+0"
+version = "965.0.2+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/bin/Manifest-v1.11.toml
+++ b/bin/Manifest-v1.11.toml
@@ -31,10 +31,10 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 version = "1.11.0"
 
 [[deps.HistoricalStdlibVersions]]
-deps = ["Pkg"]
-git-tree-sha1 = "7e72d0ce251105cebeab1e156977af2346cbe558"
+deps = ["Pkg", "PrecompileTools"]
+git-tree-sha1 = "e2c444d79d406f80f316b779761eef0cf17fc137"
 uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
-version = "2.0.2"
+version = "2.0.7"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]

--- a/bin/Manifest-v1.12.toml
+++ b/bin/Manifest-v1.12.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.0-beta3"
+julia_version = "1.12.7"
 manifest_format = "2.0"
 project_hash = "1a7459ec991893a00bd614db909bf08acd681ebe"
 
@@ -16,6 +16,11 @@ version = "1.11.0"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
 
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.1+2"
+
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -24,7 +29,7 @@ version = "1.11.0"
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -38,15 +43,21 @@ version = "2.0.7"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.7.0"
+version = "1.8.0"
 
 [[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "88352712893ec50bee3680605891eaf0e9ed6368"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.4"
+version = "1.8.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
@@ -61,7 +72,7 @@ version = "0.6.4"
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.11.1+1"
+version = "8.15.0+0"
 
 [[deps.LibGit2]]
 deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
@@ -91,13 +102,9 @@ deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
-[[deps.Mmap]]
-uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-version = "1.11.0"
-
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.2.25"
+version = "2025.11.4"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -106,18 +113,18 @@ version = "1.3.0"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.0+0"
+version = "3.5.6+0"
 
 [[deps.Parsers]]
-deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+deps = ["Dates", "PrecompileTools"]
+git-tree-sha1 = "663e8b48b789916221e0765393b289ca6c88f24e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.3"
+version = "3.0.0"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.12.0"
+version = "1.12.1"
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
@@ -127,15 +134,15 @@ version = "1.12.0"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "516f18f048a195409d6e072acf879a9f017d3900"
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.3.2"
+version = "1.3.4"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.3"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -151,7 +158,7 @@ version = "1.11.0"
 deps = ["Serialization", "libpicosat_jll"]
 path = ".."
 uuid = "ecd60e94-5748-11e9-04dc-1fe0f95e4121"
-version = "0.1.0"
+version = "0.2.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -160,6 +167,22 @@ version = "0.7.0"
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 version = "1.11.0"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.5"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
@@ -191,9 +214,9 @@ version = "1.3.1+2"
 
 [[deps.libpicosat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d9c92caf140928a90515bc20ea4d8d319fe4ca9f"
+git-tree-sha1 = "cbda9296ecfdf9d9805a512845471d584e5fbb75"
 uuid = "6b231c3b-13f8-5ced-86ae-8860c7f75d86"
-version = "965.0.0+0"
+version = "965.0.2+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -201,6 +224,6 @@ uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.5.0+2"
+version = "17.7.0+0"

--- a/bin/Manifest-v1.12.toml
+++ b/bin/Manifest-v1.12.toml
@@ -31,10 +31,10 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 version = "1.11.0"
 
 [[deps.HistoricalStdlibVersions]]
-deps = ["Pkg"]
-git-tree-sha1 = "7e72d0ce251105cebeab1e156977af2346cbe558"
+deps = ["Pkg", "PrecompileTools"]
+git-tree-sha1 = "e2c444d79d406f80f316b779761eef0cf17fc137"
 uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
-version = "2.0.2"
+version = "2.0.7"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]

--- a/bin/Manifest-v1.9.toml
+++ b/bin/Manifest-v1.9.toml
@@ -38,15 +38,21 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.7.0"
+version = "1.8.0"
 
 [[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "c7345ab1a7ca4dc8a02c9f6510da0d9857bbe513"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.4"
+version = "1.7.1"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -82,9 +88,6 @@ deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+0"
 
-[[deps.Mmap]]
-uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2022.10.11"
@@ -95,9 +98,9 @@ version = "1.2.0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+git-tree-sha1 = "ba0dc8a8a67cacac4842631f960c046e4e563675"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.3"
+version = "2.8.8"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -112,9 +115,9 @@ version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.3"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -132,7 +135,7 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 deps = ["Serialization", "libpicosat_jll"]
 path = ".."
 uuid = "ecd60e94-5748-11e9-04dc-1fe0f95e4121"
-version = "0.1.0"
+version = "0.2.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -143,6 +146,22 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.5"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -168,9 +187,9 @@ version = "1.2.13+0"
 
 [[deps.libpicosat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d9c92caf140928a90515bc20ea4d8d319fe4ca9f"
+git-tree-sha1 = "cbda9296ecfdf9d9805a512845471d584e5fbb75"
 uuid = "6b231c3b-13f8-5ced-86ae-8860c7f75d86"
-version = "965.0.0+0"
+version = "965.0.2+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/bin/Manifest-v1.9.toml
+++ b/bin/Manifest-v1.9.toml
@@ -27,10 +27,10 @@ version = "1.6.0"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.HistoricalStdlibVersions]]
-deps = ["Pkg"]
-git-tree-sha1 = "7e72d0ce251105cebeab1e156977af2346cbe558"
+deps = ["Pkg", "PrecompileTools"]
+git-tree-sha1 = "e2c444d79d406f80f316b779761eef0cf17fc137"
 uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
-version = "2.0.2"
+version = "2.0.7"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -2,7 +2,7 @@ module Registries
 
 export registry_provider, package_info, bundled_versions,
     prerelease_exclusion, yanked_versions, is_registered, is_bundled,
-    UPGRADABLE_STDLIBS_UUIDS
+    stdlib_snapshot, host_stdlibs, UPGRADABLE_STDLIBS_UUIDS
 
 import Base: UUID
 import HistoricalStdlibVersions: STDLIBS_BY_VERSION, UNREGISTERED_STDLIBS, StdlibInfo
@@ -110,6 +110,40 @@ filter!(JULIA_VERSIONS) do v
     end
 end
 
+## the stdlib snapshot
+#
+# HistoricalStdlibVersions records what each Julia release bundles, but only as
+# stanzas at the versions where the set *changed*, so the stanza describing a
+# Julia is the newest one at or below it. Prerelease and build parts are
+# stripped first: a stanza is a statement about a patch release, and a
+# prerelease of it bundles what it will bundle.
+function stdlib_snapshot(julia_ver::VersionNumber)
+    stanza = UNREGISTERED_STDLIBS
+    for (v, this_stdlibs) in STDLIBS_BY_VERSION
+        v > Base.thispatch(julia_ver) && break
+        stanza = this_stdlibs
+    end
+    return stanza
+end
+
+# What the *running* Julia bundles, read out of its own stdlib directory --
+# ground truth, as against `stdlib_snapshot`'s recollection of it. Every stdlib
+# ships the Project.toml it was built from, `version` and all. This is the only
+# thing here that looks at the host rather than a target Julia; it exists so the
+# snapshot can be checked against a Julia that is actually present (see
+# bin/check_stdlibs.jl), which is what keeps a stale pin from going unnoticed.
+function host_stdlibs()
+    bundled = Dict{UUID,VersionNumber}()
+    for dir in readdir(Sys.STDLIB; join = true)
+        file = joinpath(dir, "Project.toml")
+        isfile(file) || continue
+        project = Pkg.TOML.parsefile(file)
+        haskey(project, "uuid") && haskey(project, "version") || continue
+        bundled[UUID(project["uuid"])] = VersionNumber(project["version"])
+    end
+    return bundled
+end
+
 ## extracting the dependency graph from registries
 
 # The canonical version order: newest first. It is a property of the registry
@@ -167,11 +201,7 @@ function julia_and_stdlib_versions(
     stdlibs = Dict{UUID,Dict{VersionNumber,StdlibInfo}}()
     bundlers = Dict{UUID,Dict{VersionNumber,VersionSpec}}()
     for julia_ver in julia_vers
-        last_stdlibs = UNREGISTERED_STDLIBS
-        for (v, this_stdlibs) in STDLIBS_BY_VERSION
-            v > Base.thispatch(julia_ver) && break
-            last_stdlibs = this_stdlibs
-        end
+        last_stdlibs = stdlib_snapshot(julia_ver)
         for (uuid, stdlib_info) in last_stdlibs
             stdlib_ver = something(stdlib_info.version, julia_ver)
             deps_u = get!(()->valtype(stdlibs)(), stdlibs, uuid)
@@ -386,12 +416,7 @@ function registry_provider(
             union!(vers, JULIA_VERSIONS)
             for v in vers
                 deps[v] = valtype(deps)()
-                # find relevant stdlibs stanza
-                last_stdlibs = UNREGISTERED_STDLIBS
-                for (v′, this_stdlibs) in STDLIBS_BY_VERSION
-                    v′ > Base.thispatch(v) && break
-                    last_stdlibs = this_stdlibs
-                end
+                last_stdlibs = stdlib_snapshot(v)
                 # pin every stdlib this Julia bundles to its bundled version
                 # -- except the upgradable ones, which Julia bundles without
                 # pinning: for those the registry versions compete with the

--- a/bin/check_stdlibs.jl
+++ b/bin/check_stdlibs.jl
@@ -1,0 +1,79 @@
+#!/usr/bin/env julia
+#
+# Check the pinned stdlib snapshot against the Julia running this script.
+#
+#     julia --project=bin bin/check_stdlibs.jl
+#
+# `bin/` pins HistoricalStdlibVersions in its manifests, and that package is a
+# snapshot: it records what each Julia release bundles. A pin left behind by new
+# Julia releases does not fail loudly, it answers wrongly -- a release newer than
+# the pin is not missing from the data, it is described by an older stanza. So
+# the resolver reports confidently about a Julia that never existed, and the
+# report looks exactly like a real conflict. That is issue #103: the pin sat at
+# 2.0.2, which predates 1.12, so 1.12.x was credited with 1.11's OpenSSL_jll
+# 3.0.15 rather than the 3.5.x it ships, and OpenSSL_CLI_jll would not resolve
+# on it at all.
+#
+# The running Julia carries the answer in its own stdlib directory, so that is
+# what the snapshot is checked against. Note what this does *not* do: it never
+# asks whether a newer HistoricalStdlibVersions exists, so it cannot fail merely
+# because time passed -- only because the pin actually misdescribes a Julia that
+# is present. Keeping the pin current is bin/update_manifests.jl's job.
+#
+# Coverage is one Julia per run, so .github/workflows/stdlibs.yml runs it across
+# the range the bin/ manifests support. Prereleases are skipped: see below.
+# Exits nonzero on drift.
+
+push!(empty!(LOAD_PATH), @__DIR__)
+
+include("Registries.jl")
+
+function check_stdlibs(io::IO = stdout)
+    # Only a released Julia has a settled answer to "what do you bundle". A
+    # development build is a moving target -- `1.14.0-DEV.2617` is master at one
+    # commit, while the snapshot's 1.14.0 stanza is master at another -- so the
+    # two disagree for no reason anybody could fix, and on this machine's
+    # nightly they disagree about eighteen stdlibs. Released versions are also
+    # the only ones the bin/ manifests target, so skipping the rest costs the
+    # check nothing it was meant to catch.
+    if !isempty(VERSION.prerelease)
+        println(io, "julia $VERSION is a prerelease: skipping the stdlib snapshot check")
+        return true
+    end
+    bundled = host_stdlibs()
+    snapshot = stdlib_snapshot(VERSION)
+    names = Dict(uuid => info.name for (uuid, info) in snapshot)
+    # The upgradable stdlibs are absent from the snapshot by design -- Julia
+    # bundles them without pinning them, so registry versions compete with the
+    # bundled one -- and their absence is not staleness.
+    pinned = Dict(uuid => info.version
+                  for (uuid, info) in snapshot
+                  if info.version !== nothing &&
+                     uuid ∉ UPGRADABLE_STDLIBS_UUIDS)
+    absent = sort!([names[uuid] for uuid in setdiff(keys(pinned), keys(bundled))])
+    drifted = sort!([(names[uuid], version, bundled[uuid])
+                     for (uuid, version) in pinned
+                     if haskey(bundled, uuid) && bundled[uuid] != version])
+    println(io, "julia $VERSION: $(length(pinned)) stdlibs pinned by the snapshot, ",
+                "$(length(bundled)) bundled")
+    if isempty(absent) && isempty(drifted)
+        println(io, "the pinned stdlib snapshot describes this Julia")
+        return true
+    end
+    for name in absent
+        println(io, "  missing: $name is pinned by the snapshot but not bundled here")
+    end
+    for (name, claimed, actual) in drifted
+        println(io, "  drifted: $name -- snapshot says $claimed, this Julia ships $actual")
+    end
+    println(io, """
+
+        The stdlib snapshot does not describe julia $VERSION. Refresh the pin:
+
+            julia --project=bin bin/update_manifests.jl
+
+        and commit the bin/Manifest-*.toml changes.""")
+    return false
+end
+
+check_stdlibs() || exit(1)

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -137,10 +137,13 @@ function resolve_versions(
     julia = Base.julia_cmd()[1]
     cmd = `$julia --project=$BIN_PROJECT $RESOLVE_JL $dir --print-versions $flags`
     if !success(pipeline(cmd; stdout = out, stderr = err))
-        # tell "no solution" apart from "the script broke", putting the message
-        # back so a caller that passed `err` in can read it too
-        msg = String(take!(err))
-        print(err, msg)
+        # tell "no solution" apart from "the script broke", leaving the message
+        # in place so a caller that passed `err` in can read it too. Read rather
+        # than take-and-put-back: through Julia 1.10 a buffer that has been a
+        # subprocess's stderr comes back non-writeable, so printing into it
+        # throws where 1.11 and later are fine.
+        seekstart(err)
+        msg = read(err, String)
         # when it broke, say what it said -- the command alone explains nothing
         occursin("Unsatisfiable", msg) || error("failed: $cmd\n$msg")
         return nothing

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -538,6 +538,57 @@ end
         @test !haskey(bundled, JSON) # not a stdlib
     end
 
+    # `bundled_versions` is only as good as the snapshot behind it, and that
+    # snapshot is a pinned dependency of bin/ -- so it goes stale on its own,
+    # without anything here changing. The failure is silent: a Julia release
+    # newer than the pin is not missing from the data, it is *described by an
+    # older stanza*, so the resolver answers confidently about a Julia that
+    # never existed. Issue #103: the pin sat at 2.0.2, which predates 1.12, so
+    # 1.12.x was credited with 1.11's OpenSSL_jll 3.0.15 instead of the 3.5.x
+    # it really ships, and no version of OpenSSL_CLI_jll would resolve on it.
+    #
+    # The running Julia carries the answer in its own stdlib directory, so
+    # check the snapshot against it. Note what this does *not* test: it says
+    # nothing about whether a newer HistoricalStdlibVersions exists, so it
+    # cannot fail merely because time passed -- only because the pin actually
+    # misdescribes a Julia we support. Its coverage is whatever Julia the suite
+    # runs under; .github/workflows/stdlibs.yml sweeps the rest of the range
+    # the bin/ manifests support.
+    #
+    # The upgradable stdlibs are excluded on both sides: Julia bundles them
+    # without pinning them, and the snapshot leaves them out for that reason
+    # (see UPGRADABLE_STDLIBS_UUIDS), so they are absent here by design rather
+    # than by staleness.
+    @testset "the stdlib snapshot describes the running Julia" begin
+        bundled = host_stdlibs()
+        @test length(bundled) > 20 # a plausible stdlib directory at all
+        snapshot = stdlib_snapshot(VERSION)
+        pinned = Dict(uuid => info.version
+                      for (uuid, info) in snapshot
+                      if info.version !== nothing &&
+                         uuid ∉ UPGRADABLE_STDLIBS_UUIDS)
+        # Report by name throughout: a bare uuid says nothing about which
+        # stdlib drifted, and this test's whole job is to name the drift.
+        names = Dict(uuid => info.name for (uuid, info) in snapshot)
+        # every stdlib the snapshot pins here is really bundled here ...
+        absent = sort!([names[uuid] for uuid in setdiff(keys(pinned), keys(bundled))])
+        # ... at the version it claims
+        drifted = sort!(["$(names[uuid]): snapshot $(version), bundled $(bundled[uuid])"
+                         for (uuid, version) in pinned
+                         if haskey(bundled, uuid) && bundled[uuid] != version])
+        # Only on a released Julia. A development build is a moving target --
+        # `1.14.0-DEV.2617` is master at one commit, the snapshot's 1.14.0
+        # stanza is master at another -- so the two disagree over something
+        # nobody could fix, and CI runs this suite on nightly.
+        if isempty(VERSION.prerelease)
+            @test absent == String[]
+            @test drifted == String[]
+        else
+            @test_skip absent == String[]
+            @test_skip drifted == String[]
+        end
+    end
+
     # The Julia universe is not a query parameter either: the provider offers
     # *every* Julia version, along with every stdlib version any of them bundles,
     # and the `--julia` / project bound is an ordinary compat entry on `julia`. The

--- a/bin/update_manifests.jl
+++ b/bin/update_manifests.jl
@@ -1,0 +1,157 @@
+#!/usr/bin/env julia
+#
+# Refresh bin/'s per-Julia manifests against the current registries.
+#
+#     julia bin/update_manifests.jl            refresh every manifest
+#     julia bin/update_manifests.jl --check    report gaps, change nothing
+#
+# bin/ pins its dependencies in one manifest per supported Julia minor, and one
+# of those pins -- HistoricalStdlibVersions -- is a snapshot of what each Julia
+# release bundles. Pins do not rot loudly: they keep resolving, they just start
+# describing a Julia that no longer exists (issue #103). bin/check_stdlibs.jl
+# catches that after the fact; this script is how you fix it, and how you keep
+# it from happening.
+#
+# Each manifest has to be written by the Julia it is for, since it records that
+# Julia's own stdlib versions -- so this drives `julia +X.Y` through juliaup,
+# once per supported minor. Channels that are not installed are reported rather
+# than installed: adding a Julia is your call, not a script's.
+#
+# The supported minors are every released Julia matching bin/Project.toml's
+# `[compat] julia`, taken from the version list Registries.jl already tracks. A
+# minor that has no manifest yet gets one -- that is the other half of staying
+# current, and the half nothing else would notice, since a Julia with no
+# manifest of its own does not fail, it silently falls back to another's.
+#
+# `--check` reports that gap without filling it, which is what CI runs: the
+# check needs a current list of Julia releases, not a current set of pins, so it
+# needs neither juliaup nor the other Julias to be installed.
+
+push!(empty!(LOAD_PATH), @__DIR__)
+
+import Pkg
+
+include("Registries.jl")
+
+const BIN = @__DIR__
+
+# A minor is carried as a VersionNumber so it can be matched against compat,
+# but it names a series, not a release: print it as one.
+series(minor::VersionNumber) = "$(minor.major).$(minor.minor)"
+
+manifest_path(minor::VersionNumber) = joinpath(BIN, "Manifest-v$(series(minor)).toml")
+
+# The Julia minors bin/ supports: released versions only (a prerelease bundles
+# what it will bundle, not what it does), matching the project's own bound.
+function supported_minors()
+    project = Pkg.TOML.parsefile(joinpath(BIN, "Project.toml"))
+    # Project.toml compat is semver syntax ("^1.9"), not registry syntax
+    bound = Pkg.Types.semver_spec(get(get(project, "compat", Dict()), "julia", "*"))
+    minors = Set{VersionNumber}()
+    for v in Registries.JULIA_VERSIONS
+        isempty(v.prerelease) && v in bound || continue
+        push!(minors, VersionNumber(v.major, v.minor))
+    end
+    return sort!(collect(minors))
+end
+
+# Is `julia +X.Y` a channel juliaup can run? Probing beats parsing `juliaup
+# status`, and it is the same question the update itself will ask.
+function channel_available(minor::VersionNumber)
+    channel = "+$(series(minor))"
+    success(pipeline(`julia $channel --version`; stdout = devnull, stderr = devnull))
+end
+
+function update_manifest(minor::VersionNumber)
+    channel = "+$(series(minor))"
+    # the child writes straight to fd 1, so anything still buffered here would
+    # otherwise land after output from a subprocess that ran later
+    flush(stdout)
+    run(`julia $channel --project=$BIN -e "using Pkg; Pkg.update()"`)
+    flush(stdout)
+end
+
+# Which supported minors have no manifest of their own? This is the staleness
+# that no amount of testing catches, because the symptom is a Julia quietly
+# resolving against another Julia's pins rather than anything failing.
+function report_missing(minors::Vector{VersionNumber})
+    absent = filter(m -> !isfile(manifest_path(m)), minors)
+    if isempty(absent)
+        println("every supported Julia minor has a manifest")
+        return true
+    end
+    println("no manifest for: ", join(series.(absent), ", "))
+    println("\nRun bin/update_manifests.jl on a machine with those Julias installed:\n",
+            "    juliaup add ", join(series.(absent), " "), "\n",
+            "    julia bin/update_manifests.jl")
+    # The snapshot matrix in the workflow is spelled out rather than derived, so
+    # a new minor needs adding there too -- and nothing else would say so: the
+    # matrix would keep passing on the versions it does list.
+    println("\nThen add ", join(("'" * series(m) * "'" for m in absent), ", "),
+            " to the `snapshot` matrix in .github/workflows/stdlibs.yml.")
+    return false
+end
+
+function main(args::Vector{String} = ARGS)
+    check_only = "--check" in args
+    isempty(setdiff(args, ["--check"])) ||
+        error("usage: update_manifests.jl [--check]")
+    minors = supported_minors()
+    isempty(minors) && error("no released Julia matches bin/Project.toml's julia compat")
+    println("supported Julia minors: ", join(series.(minors), ", "), "\n")
+    check_only && return report_missing(minors)
+
+    missing_channels, changed, created = VersionNumber[], VersionNumber[], VersionNumber[]
+    for minor in minors
+        path = manifest_path(minor)
+        if !channel_available(minor)
+            push!(missing_channels, minor)
+            println("julia $(series(minor)): channel not installed, skipping")
+            continue
+        end
+        # A Julia with no manifest of its own falls back to Manifest.toml, which
+        # is the 1.9 symlink -- so it would overwrite 1.9's pins with its own.
+        # Giving it an empty manifest first makes it resolve into the right file.
+        is_new = !isfile(path)
+        is_new && touch(path)
+        before = read(path, String)
+        println("\n=== julia $(series(minor)) ===")
+        try
+            update_manifest(minor)
+        catch
+            # an empty file left behind would be committed as a manifest and
+            # then quietly used as one, which is worse than having none
+            is_new && rm(path; force = true)
+            rethrow()
+        end
+        if is_new
+            push!(created, minor)
+        elseif read(path, String) != before
+            push!(changed, minor)
+        end
+    end
+
+    println()
+    # The 1.9 manifest is reached through a symlink, since 1.9 does not
+    # understand version-specific manifest files. Pkg writing through it should
+    # leave the link alone, but a manifest silently turned into a regular file
+    # would strand 1.9 on stale pins, so say so rather than assume.
+    link = joinpath(BIN, "Manifest.toml")
+    ispath(link) && !islink(link) &&
+        println("WARNING: $link is no longer a symlink -- restore it with\n",
+                "    ln -sf Manifest-v1.9.toml $link")
+    isempty(created) || println("created: ", join(("Manifest-v$(series(m)).toml" for m in created), ", "))
+    if isempty(changed)
+        println("all manifests already current")
+    else
+        println("updated: ", join(("Manifest-v$(series(m)).toml" for m in changed), ", "))
+        println("\nReview and commit the changes, and run the bin/ tests:\n",
+                "    julia --project=bin bin/test/runtests.jl")
+    end
+    isempty(missing_channels) ||
+        println("\nNot checked -- these channels are not installed:\n",
+                "    juliaup add ", join(series.(missing_channels), " "))
+    return isempty(missing_channels)
+end
+
+main() || exit(1)


### PR DESCRIPTION
Fixes #103.

## The bug

`bin/`'s manifests pinned `HistoricalStdlibVersions` at 2.0.2, whose data predates Julia 1.12. The resolver therefore believed 1.12.x bundles `OpenSSL_jll` 3.0.15, when 1.12.0 ships 3.5.1 and 1.12.7 ships 3.5.6 — so `OpenSSL_CLI_jll` would not resolve on 1.12 at all. This reached users through [`julia-downgrade-compat`](https://github.com/julia-actions/julia-downgrade-compat), which uses `bin/resolve.jl`.

Both halves of the reported error trace to that one pin, including the half that looked like a separate bug:

> `OpenSSL_CLI_jll 3.5.1+0 requires OpenSSL_jll at ≥ 3.5.7+0`

@Tom-Finke was right that the registry compat is really `~3.5.1`. The chain renders the requirement *after* filtering, and the bogus 3.0.15 pin had removed `OpenSSL_jll` 3.5.1+0 through 3.5.6+0 from the universe, leaving only ≥ 3.5.7+0 standing. Correcting the pin retires both complaints. 2.0.2 was five releases behind, and the same drift misdated eleven other stdlibs on 1.12.

The reported case now resolves as expected — `OpenSSL_CLI_jll` 3.5.1+0 with `OpenSSL_jll` 3.5.6+0 on julia 1.12.7 — identically under 1.9, 1.10, 1.11 and 1.12.

## Noticing it next time

A stale pin does not fail, it answers wrongly: a Julia newer than the pin is not *missing* from the snapshot, it is described by an older stanza. The resolver keeps answering, about a Julia that never existed, and the wrong answer is shaped exactly like a real conflict. Nothing in the suite could tell the difference, because nothing knew the right answer.

The running Julia does — every stdlib ships the `Project.toml` it was built from. Checking the snapshot against `Sys.STDLIB` costs a directory listing and no network. On the pin as it stood it names twelve drifted stdlibs on 1.12, `OpenSSL_jll` among them.

What it deliberately does **not** do is ask whether a newer `HistoricalStdlibVersions` exists. That would be a moving target — red on the package's release schedule rather than on anything in the tree — and a check that fails for reasons the tree cannot fix gets disabled. This one fails only when the pin actually misdescribes a Julia that is present.

Two findings shaped the design:

- **Nightly can never pass it.** The snapshot's `1.14.0` stanza and a nightly build are two points on a moving branch; they disagree about eighteen stdlibs and neither is wrong. CI runs the suite on nightly, so an unguarded testset would have been permanently red. Prereleases are skipped. (1.13.0-rc4 happens to agree with its stanza, but an rc can drift from one through nobody's fault, so the line is drawn at released versions.)
- **A missing manifest doesn't fail, it falls back.** A Julia with no `Manifest-vX.Y.toml` reads `Manifest.toml` — the 1.9 symlink — and would overwrite 1.9's pins with its own. So `--check` reports a released Julia that has no manifest, and `update_manifests.jl` creates one (removing the placeholder again if that Julia fails, since an empty manifest would be committed and then silently used as one).

`.github/workflows/stdlibs.yml` sweeps 1.9–1.12 with the standalone check, instantiating each manifest first, so a manifest that stops resolving on its own Julia fails too. Weekly cron, since both failure modes arrive with time rather than with a commit.

## A pre-existing bug this turned up

The `bin/` suite had never been run on 1.9 or 1.10 — it isn't part of CI, which tests the package suite on release and nightly. It errored 7 times on both. Through Julia 1.10 an `IOBuffer` that has served as a subprocess's stderr comes back non-writeable, so `resolve_versions`'s take-and-put-back threw on exactly the path the unsatisfiable-project tests take. Unrelated to this fix, so it's a separate commit. With it, the suite is 178/178 on all four.

## Commits

| | |
|---|---|
| `ee7f08f` | the fix — `HistoricalStdlibVersions` 2.0.2 → 2.0.7 |
| `f716991` | the pre-existing 1.9/1.10 test-helper bug |
| `b9c769a` | the checks, the refresh script and the workflow |
| `7186372` | the manifest refresh |

**The last commit is separable and I'd suggest reviewing it on its own terms.** Running `update_manifests.jl` produces more than #103 needs: JSON 0.21.4 → 1.8.0 (a rewrite, bringing Parsers 3.0 and StructUtils), plus `libpicosat_jll` 965.0.0+0 → 965.0.2+0 and each host Julia's own stdlib versions. All four Julias pass with it, but a JSON major version and a new SAT binary are worth taking deliberately rather than as freight on a bug fix. Dropping it leaves #103 fixed and the checks working.

## Testing

- `bin/` suite: 178/178 on each of 1.9, 1.10, 1.11, 1.12
- package suite: passes
- both checks have negative controls — the stale 2.0.2 pin produces 12 named drifts on 1.12, and a removed `Manifest-v1.11.toml` produces `no manifest for: 1.11`

One thing left for maintenance: the `snapshot` matrix is spelled out rather than derived, so a new Julia minor needs adding there too. The `--check` failure message says so explicitly, since otherwise the matrix would keep passing on the versions it *does* list — the same silent-failure shape this change exists to avoid.

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code).
