### PR TITLE
Make @alldeps mean both halves (#102)

### DIFF
--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -47,6 +47,10 @@ Wherever <pkgs> appears you can specify a comma-separated list of:
   * @deps for packages in the [deps] section of Project.toml
   * @weakdeps for packages in the [weakdeps] section of Project.toml
   * @alldeps for packages in both the [deps] and [weakdeps] sections
+
+Weak dependencies are not required by default, so a selector naming one
+only triggers on a resolve that pulls it in through --extra-deps, or
+through some other package that depends on it.
 """
 
 parse_opts!(ARGS, split("""
@@ -287,12 +291,10 @@ project_compat[JULIA_UUID] = julia_versions
 function parse_packages(str::AbstractString)
     pkgs = UUID[]
     for item in split(str, ',')
-        if item in ("@deps", "@alldeps")
-            union!(pkgs, project_deps)
-            continue
-        end
-        if item in ("@weakdeps", "@alldeps")
-            union!(pkgs, project_weakdeps)
+        # @alldeps is both halves, so neither branch may return early on it
+        if item in ("@deps", "@weakdeps", "@alldeps")
+            item in ("@deps", "@alldeps") && union!(pkgs, project_deps)
+            item in ("@weakdeps", "@alldeps") && union!(pkgs, project_weakdeps)
             continue
         end
         uuid = tryparse(UUID, item)
@@ -305,7 +307,8 @@ function parse_packages(str::AbstractString)
                 uuid = only(uuids)
             end
         end
-        uuid isa UUID || usage("Invalid value for --prioritize: $item")
+        # any option taking <pkgs> lands here, so do not name one of them
+        uuid isa UUID || usage("Invalid package selector: $item")
         uuid ∉ pkgs && push!(pkgs, uuid)
     end
     return pkgs

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -118,16 +118,23 @@ const RESOLVE_JL = normpath(joinpath(@__DIR__, "..", "resolve.jl"))
 const BIN_PROJECT = normpath(joinpath(@__DIR__, ".."))
 
 function resolve_versions(
-    compat :: AbstractString,
-    flags  :: Vector{String} = String[];
-    deps   :: Vector{Pair{String,UUID}} = ["JSON" => JSON],
-    err    :: IOBuffer = IOBuffer(), # the script's stderr, for tests that read it
+    compat   :: AbstractString,
+    flags    :: Vector{String} = String[];
+    deps     :: Vector{Pair{String,UUID}} = ["JSON" => JSON],
+    weakdeps :: Vector{Pair{String,UUID}} = Pair{String,UUID}[],
+    err      :: IOBuffer = IOBuffer(), # the script's stderr, for tests that read it
 )
     dir = mktempdir()
     open(joinpath(dir, "Project.toml"), "w") do io
         println(io, "[deps]")
         for (name, uuid) in deps
             println(io, "$name = \"$uuid\"")
+        end
+        if !isempty(weakdeps)
+            println(io, "\n[weakdeps]")
+            for (name, uuid) in weakdeps
+                println(io, "$name = \"$uuid\"")
+            end
         end
         isempty(compat) && return
         println(io, "\n[compat]")
@@ -314,6 +321,33 @@ end
         @test Resolver.resolve(info, prob; order) == Resolver.resolve(baked, prob)
         @test Resolver.resolve(info, prob; order)[JULIA_UUID] <
               Resolver.resolve(info, prob)[JULIA_UUID]
+    end
+
+    # `@alldeps` is the union of [deps] and [weakdeps], in every option that
+    # takes a package selector and not only the ordering ones.
+    #
+    # Stated as an identity against naming both halves, rather than against
+    # version numbers the registry will move. The identity holds just as well
+    # when the selector ignores the weak dependencies altogether, so the
+    # inequality has to say that they moved.
+    @testset "@alldeps covers the weak dependencies" begin
+        deps = ["JSON" => JSON]
+        weakdeps = ["Compat" => COMPAT]
+        resolve(flags) = resolve_versions("", flags; deps, weakdeps)
+        pull_in = "--extra-deps=@weakdeps"
+        via_alldeps = resolve(["--min=@alldeps", pull_in])
+        via_halves = resolve(["--min=@deps", "--min=@weakdeps", pull_in])
+        via_deps = resolve(["--min=@deps", pull_in])
+        @test !isnothing(via_alldeps)
+        @test via_alldeps == via_halves
+        # the weak dep is in the graph either way, and only the union moves it
+        @test haskey(via_deps, COMPAT)
+        @test via_alldeps[COMPAT] < via_deps[COMPAT]
+        # ... while the strong deps are minimized either way
+        @test via_alldeps[JSON] == via_deps[JSON]
+        # as a requirement set too, where the difference is whether the weak
+        # dependency is resolved at all rather than at which version
+        @test haskey(resolve(["--extra-deps=@alldeps"]), COMPAT)
     end
 
     # Prerelease admission is a query constraint, not a property of the package


### PR DESCRIPTION
Fixes #102.

@Tom-Finke's diagnosis was exactly right: `parse_packages` matches `@alldeps` in the `@deps` branch and `continue`s, so the `@weakdeps` branch it also matches is never reached.

## It is wider than the ordering options

`parse_packages` backs *every* option that takes `<pkgs>`, so `@alldeps` was a plain synonym for `@deps` throughout — not just in `--min`. The case that bites hardest isn't an ordering option at all:

| | before | after |
|---|---|---|
| `--extra-deps=@alldeps` | weak deps not pulled in **at all** | pulled in |
| `--min=@alldeps` | weak deps left at their default maximum | minimized |

For `--extra-deps` the difference is *whether* a package is resolved rather than which version of it — a silently smaller dependency graph.

## Answering the two questions

**1. Should `@alldeps` expand to `[deps] ∪ [weakdeps]`?** Yes — the help text has said so since the selectors were introduced, so the text is right and the code was wrong. Both branches now run for `@alldeps`, with one `continue` covering all three selectors.

**2. Is `--min=@weakdeps` meaningful without `--extra-deps=@weakdeps`?** It isn't a special case. Ordering options are preferences over whatever gets resolved, so naming an unresolved package is inert — the same for a weak dependency as for any unrelated package. It's not dead by rule either: if some other package in the graph depends on it, it gets resolved and the preference applies. But weak dependencies are the one place where "named but not required" is the *default* state, which is where people will trip, so the help text now says it:

> Weak dependencies are not required by default, so a selector naming one only bites on a resolve that pulls it in — through `--extra-deps`, or through some other package that depends on it.

## Testing

The regression test states the fix as an identity — naming the union does what naming both halves does — rather than pinning version numbers the registry will move under. On its own that would prove nothing, since *agreeing* is precisely what the bug did, so it is paired with an inequality showing the weak dependency actually moved.

Negative control, with only the control flow reverted and the test left in place: 3 of the 6 assertions fail, `Compat` stuck at 3.47.0 where the fix gives 1.0.0. Suite is 180/180.

## One drive-by, easy to drop

The parser reported bad input as `Invalid value for --prioritize` whatever option it came from — which is every option taking `<pkgs>`. It now says `Invalid package selector`. Separable from the fix if you'd rather not carry it.

---

Patches authored interactively with [Claude Code](https://claude.com/claude-code).
