### PR TITLE
Ask upstream for the release that would fix a conflict

### DIFF
--- a/bin/resolve.jl
+++ b/bin/resolve.jl
@@ -553,7 +553,8 @@ function named(d::Resolver.Diagnosis, name::Function)
                 ([[Diagnostics.Action(a.kind, name(a.pkg)) for a in b]
                   for b in bs],
                  [Diagnostics.Action(a.kind, name(a.pkg)) for a in us])
-                for (bs, us) in c.blocks])
+                for (bs, us) in c.blocks],
+            named(c.upstream, name))
          for c in d.conflicts],
         [Diagnostics.Alternative{String,VersionNumber}(
             a.conflicts, a.avoided,
@@ -561,6 +562,13 @@ function named(d::Resolver.Diagnosis, name::Function)
          for a in d.alternatives],
         d.others)
 end
+
+# an upstream fix is two packages, their versions, and a solution
+named(ups::Vector{<:Diagnostics.Upstream}, name::Function) =
+    [Diagnostics.Upstream{String,VersionNumber}(
+        name(u.pkg), u.latest, name(u.dep), u.supports, u.supported,
+        Dict{String,VersionNumber}(name(p) => v for (p, v) in u.solution))
+     for u in ups]
 
 # a fix is actions and a solution, both keyed by package
 named(fixes::Vector{<:Diagnostics.Fix}, name::Function) =
@@ -588,6 +596,11 @@ function package_name(uuid::UUID)
 end
 
 if sol isa Resolver.Diagnosis
+    # ... and what a maintainer could do instead, which is a question about the
+    # registry rather than about this universe: one resolve per candidate, under
+    # the budget the diagnosis keeps for it
+    sol = Diagnostics.upstream_fixes(reg, problem, sol;
+        by = sort_packages_by, order = version_order)
     show(stderr, MIME("text/plain"), named(sol, package_name))
     for note in yanked_notes()
         println(stderr, note)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,10 +18,12 @@ Resolver.Diagnostics.Conflict
 Resolver.Diagnostics.Alternative
 Resolver.Diagnostics.selections
 Resolver.Diagnostics.Fix
+Resolver.Diagnostics.Upstream
 Resolver.Diagnostics.Action
 Resolver.Diagnostics.action_phrase
 Resolver.Diagnostics.Line
 Resolver.Diagnostics.diagnose
+Resolver.Diagnostics.upstream_fixes
 ```
 
 ### The statements a report is made of

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,16 +34,27 @@ Conflict 2: Plots
     2. drop requirement Plots
 ```
 
+Where a conflict turns on a bound only a maintainer can lift, the report says
+that too, as one sendable request:
+
+```
+  Upstream fix: a release of TextEncodeBase supporting DataStructures 0.19.6
+    would fix this; 0.8.3, its latest, supports only 0.18.0–0.18.22.
+    → would allow: DataStructures 0.19.6
+```
+
 Every fix is *verified*: the version list after each one is what a resolve of
-the fixed query actually returns, not a guess. Between them the conflicts
-reach every fix as cheap as the cheapest, so nothing is left over: where a
-group of conflicts that stand or fall together has cheapest fixes that taking
-one entry from each of their menus does not reach, those print after the last
-conflict as the alternatives they are — "Or, to fix without dropping
-requirement Knet:", and then what to do instead. Whatever is outside the page even so is
-confessed: "Costlier fixes also exist." when what was left out gives up more,
-"There are more minimal fixes than are shown." when the search for them was
-cut short. When the menus are the whole of it, the report says nothing at all.
+the fixed query actually returns, not a guess — an upstream one included, whose
+versions come from a resolve against the registry that release would make.
+Between them the conflicts reach every fix as cheap as the cheapest, so nothing
+is left over: where a group of conflicts that stand or fall together has
+cheapest fixes that taking one entry from each of their menus does not reach,
+those print after the last conflict as the alternatives they are — "Or, to fix
+without dropping requirement Knet:", and then what to do instead. Whatever is
+outside the page even so is confessed: "Costlier fixes also exist." when what
+was left out gives up more, "There are more minimal fixes than are shown." when
+the search for them was cut short. When the menus are the whole of it, the
+report says nothing at all.
 
 What "optimal" means, precisely, and why the resolver's aggressive problem
 filtering provably does not change the answer, is worked out in the Theory

--- a/docs/src/theory/unsat-explanation.md
+++ b/docs/src/theory/unsat-explanation.md
@@ -968,6 +968,73 @@ repairs, and the completed cover plus one bounded search per tempting
 action decides them. The walk's remaining duty is the conflicts' own
 stories.
 
+### Upstream fixes
+
+Everything above is what the *user* could change. A conflict's chain ends
+where a registry statement meets one of the user's own facts —
+*BytePairEncoding 0.5.2 requires DataStructures 0.18.0–0.18.22* against
+*your compat leaves DataStructures 0.19.6* — and the registry side is
+something a maintainer could change. The page may say so, under a bar high
+enough that what it says is a single, sendable request: the sentence a user
+would put in an issue, and the page has verified would work.
+
+**A hypothetical release.** For packages `P ≠ Q`, let `P⁺` be `P`'s latest
+version with its compatibility bound on `Q` removed and nothing else changed
+— the same dependencies, the same bounds on every other package, the same
+version number — and write `ℛ[P⁺]` for the registry so modified. This is the
+model of *a release of `P` supporting `Q`*: a maintainer who cut such a
+release would change that one declaration, and a hypothetical that changed
+more would blame more than it can name.
+
+It is modelled in place rather than as a new version number on purpose. A
+new number would carry every other package's bound on `P` along with it, and
+whether some third package admits `0.5.3` where it admitted `0.5.2` is a
+question about version arithmetic the page has no business raising. In
+place, `P⁺` behaves as `P`'s latest in every clause but one.
+
+**Lemma 32 (a repairing release repairs through the bound it drops).**
+Suppose `ℛ ∪ Q` is unsatisfiable and `ℛ[P⁺] ∪ Q` has a model `ι` with `ι(P)`
+the latest version of `P`. Then `ι(Q)` lies outside `P`'s latest bound on `Q`.
+
+*Proof.* The clauses of `ℛ[P⁺] ∪ Q` are those of `ℛ ∪ Q` with the one bound
+removed. If `ι(Q)` satisfied that bound, `ι` would satisfy every clause of
+`ℛ ∪ Q`, the removed one included, and be a model of it. ∎
+
+So a model taking the release is evidence for exactly the sentence the page
+prints: the release helps by admitting a version of `Q` its latest refuses,
+and the witness names that version.
+
+**What qualifies.** A conflict offers an upstream fix for the pair `(P, Q)`
+when all of the following hold.
+
+1. **The bound meets the user's own fact.** `Q` is a package the query
+   narrows — a *your compat leaves Q …* line of this conflict — and `P` is a
+   package the conflict's lines speak of whose latest version carries a
+   bound on `Q` excluding what the user's constraint leaves. A bound
+   contradicted only by *another registry package's* bound is not offered:
+   a sentence that blamed two maintainers would judge which is at fault,
+   and the page judges nothing. One release, one bound, one addressee.
+2. **The blame is current.** The user's constraint on `P`, if any, admits
+   `P`'s latest version. Otherwise a release already exists that the user
+   has excluded, and what helps is on the menu already — *relax your compat
+   on `P`* — not a request upstream.
+3. **It works.** `ℛ[P⁺] ∪ Q′` is satisfiable with `P` at its latest, where
+   `Q′` is the query with every other conflict settled the first way its
+   menu offers — the convention every witness on the page uses. One solve
+   per candidate, and Lemma 32 then says what the solve proved.
+
+Two releases needed at once offer nothing: the bar is a single request, and
+a conflict that needs two is one the page explains and leaves at that. Nor
+does the page suggest a backport — a release in an old series the user is
+held to — since the model is the latest version, and a user held to an old
+series by their own constraint has the menu's fix.
+
+**Budget.** Candidates are few per conflict — pairs of a narrowed package
+and a page package bounding it — and each costs one solve on a modified
+registry. They are tried in an order that puts the pair closing the chain
+first, under a cap on solves per report; what the cap leaves untried is
+recorded on the diagnosis and not announced (Section 11).
+
 ## 8. Verification
 
 What a checker checks, and what it need not.
@@ -1005,6 +1072,12 @@ What a checker checks, and what it need not.
   Theorem 5 answered yes and no unless-entry printed. A reason walk cut
   short is recorded on the diagnosis and not announced on the page (Section
   11).
+* **(V7) Upstream fixes.** For each printed upstream fix `(P, Q)`: its
+  witness has `P` at its latest version and `Q` at a version outside `P`'s
+  latest bound on `Q` (Lemma 32, checked directly rather than trusted); `Q`
+  is narrowed by the query and named by one of the conflict's given lines;
+  the user's constraint on `P`, if any, admits `P`'s latest. Membership
+  tests against the registry's own data; no solver.
 
 **Every check is per-explanation, never against a union.** Where two
 explanations' line-sets are `S₁ ∪ S₂` and `S₂` alone is contradictory, the
@@ -1077,6 +1150,18 @@ Rules, not preferences — each guards a truth-condition or an attribution:
   the chain closes — which leaves the heading a true bare list and stops it
   reading as a duplicate. The checkers still premise every requirement the
   conflict answers for: what shrinks is the sentence, not the claim set.
+* **An upstream fix is one request, verified.** After the blocked fixes,
+  and only where Section 7's three conditions hold, a conflict prints
+  *"Upstream fix: a release of «P» supporting «Q» «q» would fix this; «v»,
+  its latest, supports only «range»."* — `q` the version the witness took,
+  `v` the latest of `P`, and the range what `v`'s bound on `Q` admits,
+  printed as any range on the page is. Under it, *"→ would allow: …"* names
+  the witness on the page's packages other than `P`, whose version is the
+  hypothetical one. Where more than one pair qualifies, at most two print,
+  the pair closing the chain first, as *"Upstream fixes:"* with bullets.
+  Nothing prints for a conflict that fails the bar: the sentence is a
+  request the user can send as it stands, and a page that offered vaguer
+  ones would be training its readers to ignore them.
 * **Blocked fixes answer for actions, one sentence each.** For every
   tempting action — named by the conflict's lines or heading, in no fix of
   the cover — the section prints its solve-decided verdict (Section 7): an
@@ -1223,8 +1308,8 @@ constrains how.
 
 ## 11. Boundaries and honesty
 
-Three enumerations in this design can be cut short, and each is accounted
-for — two by a sentence on the page, one by a record on the diagnosis;
+Four enumerations in this design can be cut short, and each is accounted
+for — two by a sentence on the page, two by a record on the diagnosis;
 nothing else in the design is allowed to be incomplete.
 
 1. **The reason walk** (Theorem 13) is exponential. Truncation costs
@@ -1241,6 +1326,11 @@ nothing else in the design is allowed to be incomplete.
    oracle query (Theorem 5) and its answer sets the wording; *exploring*
    those larger repairs is out of scope by design, and the report says they
    exist without pretending to enumerate them.
+4. **Upstream probes** (Section 7) are one solve each on a modified
+   registry, under a cap per report. A candidate the cap left untried is a
+   sentence the page did not print, never a false one; the diagnosis
+   records that the cap was hit, and the page says nothing, for the reason
+   the reason walk's cut says nothing.
 
 Costs worth knowing, none load-bearing: finding `k` is a handful of
 bounded solves (`k` is small in practice); enumerating `F_min` is one solve

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -2335,7 +2335,7 @@ qualify. Everything else about `d` is unchanged, and a diagnosis whose
 conflicts have no qualifying pair comes back as it went in.
 
 `deps` is the package data the releases are tried against, as a `DepsProvider`
-or a dict of [`PkgData`](@ref Resolver.PkgData); `prob` is the query `d`
+or a dict of `PkgData`; `prob` is the query `d`
 diagnoses; `by` and `order` are the orderings the witnesses are resolved with,
 as `resolve` takes them. Each candidate costs one resolve on modified data,
 under a budget per report; what the budget leaves untried sets `upstream_cut`
@@ -3245,7 +3245,7 @@ Everything Section 8's checker can decide without asking the solver:
     package is one the query narrows and one of this conflict's own lines says
     so about. Given `prob`, the query, and `data`, the package data the release
     was tried against — a `DepsProvider` or a dict of
-    [`PkgData`](@ref Resolver.PkgData) — the rest of Section 8's check is
+    `PkgData` — the rest of Section 8's check is
     decidable too: the version is really the latest, the bound the sentence
     quotes is really that version's, the witness's version of the bounded
     package really lies outside it (Lemma 32, checked rather than trusted), and

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -28,13 +28,15 @@ module Diagnostics
 using ..Resolver: Resolver, SAT, Problem, PkgInfo, Universe, PicoSAT, Relation,
     nclasses, installed_lit, forbidden_lit, sat_assume_var, sat_solve,
     sat_new_variable, sat_add_var, sat_add, with_classes_relaxed,
-    with_temp_clauses, exclusion_kinds, relax, resolve
+    with_temp_clauses, exclusion_kinds, relax, resolve, DepsProvider, PkgData,
+    is_excluded
 using ..Resolver.Clauses: Clauses, Clause, Lit, literal, clause, packages,
     isbottom, subsumes, absent, present, resolve_raw, resolve_on, clause_phrase,
     range_phrase, selected, unselected, nversions
 using ..Resolver.UnsatCores: sat_mus
 
-export Diagnosis, Conflict, Alternative, Fix, Action, Line, action_phrase
+export Diagnosis, Conflict, Alternative, Fix, Action, Line, Upstream,
+    action_phrase
 
 ## what a report is made of
 
@@ -96,12 +98,46 @@ struct Fix{P,V}
 end
 
 """
-    Conflict(reqs, lines, versions, excluded, fixes, blocks = [])
+    Upstream(pkg, latest, dep, supports, supported, solution)
+
+A release someone else could cut that would settle a conflict: `pkg`'s latest
+version, `latest`, with its compatibility bound on `dep` dropped and nothing
+else changed — the same dependencies, the same bounds on every other package,
+the same version number. `supports` is the version of `dep` that release would
+let the user have, `supported` the versions of `dep` that `latest` does support
+— what the page names as the range the request is about — and `solution` the
+whole of what the resolver answers on that registry, `pkg` at `latest`.
+
+Modelled in place rather than as a new version number: a new number would carry
+every other package's bound on `pkg` along with it, and whether some third
+package admits the next version where it admitted this one is a question about
+version arithmetic no report has any business raising.
+
+One request, and verified. A conflict names such a release only where the bound
+it drops meets one of the user's *own* facts — never another registry package's,
+which would blame two maintainers and judge between them — where the user's own
+constraint admits `latest`, since otherwise a release that helps exists already
+and *relax your compat on «pkg»* is on the menu, and where a resolve on the
+modified registry succeeded, which is `solution`. Nothing prints where any of
+that fails: the sentence is one the reader can send upstream as it stands.
+"""
+struct Upstream{P,V}
+    pkg       :: P          # the package a release of would fix it
+    latest    :: V          # its latest version, what that release is like
+    dep       :: P          # the package the release would support
+    supports  :: V          # the version of it the witness took
+    supported :: Vector{V}  # the versions of it `latest` does support
+    solution  :: Dict{P,V}  # the witness, `pkg` at `latest`
+end
+
+"""
+    Conflict(reqs, lines, versions, excluded, fixes, blocks = [], upstream = [])
 
 One independent thing that is wrong: the requirements it answers for, the lines
 that prove it, the version list each named package is spoken of in, which of
 the query's constraint kinds exclude which of those versions, the menu of fixes
-that settles it, and the verdict on each action the page makes tempting.
+that settles it, the verdict on each action the page makes tempting, and the
+releases someone else could cut instead.
 
 A conflict is one **menu**: choose one entry of `fixes` and this conflict is
 settled. An entry may ask for several actions at once, where the family couples
@@ -124,6 +160,13 @@ page says the repair once rather than mirroring it from every end. Every verdict
 solver's: a bounded search for a minimal repair through the action, shrunk
 in the action's favour so a tie between equal repairs cannot call the same
 action idle in one sentence and a rescue in the next.
+
+Everything above is what the *user* could change. `upstream` is what a
+maintainer could: each entry an [`Upstream`](@ref) — a release of a package
+this conflict speaks of, its bound on a package the query narrowed dropped —
+that a resolve says would settle this conflict. Empty where no pair meets the
+bar, and empty where the diagnosis was made without the package data such a
+release has to be tried against.
 """
 struct Conflict{P,V}
     reqs     :: Vector{P}
@@ -132,11 +175,15 @@ struct Conflict{P,V}
     excluded :: Dict{P,Vector{Vector{Symbol}}}
     fixes    :: Vector{Fix{P,V}}
     blocks   :: Vector{Tuple{Vector{Vector{Action{P}}},Vector{Action{P}}}}
+    upstream :: Vector{Upstream{P,V}}
 end
 
 Conflict{P,V}(reqs, lines, versions, excluded, fixes) where {P,V} =
     Conflict{P,V}(reqs, lines, versions, excluded, fixes,
                   Tuple{Vector{Vector{Action{P}}},Vector{Action{P}}}[])
+Conflict{P,V}(reqs, lines, versions, excluded, fixes, blocks) where {P,V} =
+    Conflict{P,V}(reqs, lines, versions, excluded, fixes, blocks,
+                  Upstream{P,V}[])
 
 """
     selections(c) :: Vector{Vector{Action{P}}}
@@ -203,6 +250,9 @@ short and one further solve found one it never reached. `truncated` records
 that the search for reasons was cut short — a conflict may then argue from a
 reason that is not the shortest it owns — which the report does not announce,
 since nothing on the page is false or missing for the reader on that account.
+`upstream_cut` records the same about the probes behind the conflicts' upstream
+fixes: the budget stopped a candidate being tried, which is a sentence the page
+did not print rather than a false one, and so is not announced either.
 
 `show`ing one prints the report.
 """
@@ -211,6 +261,7 @@ struct Diagnosis{P,V}
     alternatives :: Vector{Alternative{P,V}}
     others       :: Symbol # :none, :larger, :some
     truncated    :: Bool
+    upstream_cut :: Bool
 end
 
 # a diagnosis rebuilt by a caller — renamed, filtered, whatever — is not one
@@ -218,6 +269,8 @@ end
 Diagnosis(conflicts::Vector{Conflict{P,V}},
           alternatives::Vector{Alternative{P,V}}, others::Symbol) where {P,V} =
     Diagnosis{P,V}(conflicts, alternatives, others, false)
+Diagnosis{P,V}(conflicts, alternatives, others, truncated) where {P,V} =
+    Diagnosis{P,V}(conflicts, alternatives, others, truncated, false)
 Diagnosis(conflicts::Vector{Conflict{P,V}}, others::Symbol) where {P,V} =
     Diagnosis(conflicts, Alternative{P,V}[], others)
 
@@ -1961,14 +2014,23 @@ fix_actions(prob::Problem{P}, sat::SAT{P,V}, univ::Universe{P,V},
 # in for it.
 function witness(sat::SAT{P,V}, univ::Universe{P,V}, prob::Problem{P},
                  actions::Vector{Action{P}}; by, order) where {P,V}
+    drop_reqs, drop_constraints = withdrawal(actions)
+    sol = resolve(sat, relax(univ, prob, drop_reqs, drop_constraints; order); by)
+    return sol === nothing ? Dict{P,V}() : sol
+end
+
+# The withdrawal a set of actions asks for: the requirements to stop requiring,
+# and per constraint kind the packages to lift it for. An action names a kind
+# of the query's own, so this is a reading of the actions and not a decision
+# about them.
+function withdrawal(actions::Vector{Action{P}}) where {P}
     drop_reqs = P[a.pkg for a in actions if a.kind === :drop]
     drop_constraints = Dict{Symbol,Set{P}}()
     for a in actions
         a.kind === :drop && continue
         push!(get!(Set{P}, drop_constraints, a.kind), a.pkg)
     end
-    sol = resolve(sat, relax(univ, prob, drop_reqs, drop_constraints; order); by)
-    return sol === nothing ? Dict{P,V}() : sol
+    return drop_reqs, drop_constraints
 end
 
 """
@@ -2136,6 +2198,195 @@ function diagnose(
     end
     return Diagnosis{P,V}(conflicts, alternatives, plan.others, plan.truncated)
 end
+
+## upstream fixes
+#
+# Everything a menu offers is what the user could change. A conflict's chain
+# ends where a registry statement meets one of the user's own facts, and the
+# registry side is something a maintainer could change instead — so the page
+# may say so, under a bar high enough that what it says is a single, sendable
+# request: the sentence a user would put in an issue, and one this has resolved
+# and found would work.
+#
+# The hypothetical is the package's latest version with its bound on the other
+# package dropped and nothing else changed, modelled in place: same version
+# number, same dependencies, same bounds on everything else, so that it behaves
+# as the latest in every clause but one and no third package's bound on it comes
+# into question. What a solve on that registry proves is exactly the sentence
+# printed (Lemma 32 of the theory page): a model taking the release takes the
+# bounded package outside the dropped bound, and the witness names the version.
+#
+# This needs the package data — a release is a different registry, not a
+# different query — so it runs out here rather than inside `diagnose`, which
+# has only the universe the failed resolve was run against.
+
+# how many qualifying releases one conflict may name, and how many solves the
+# whole report may spend looking for them. A candidate the budget leaves untried
+# is a sentence the page did not print, never a false one: it is recorded on the
+# diagnosis and not announced (Section 11 of the theory page).
+const UPSTREAM_PER_CONFLICT = 2
+const UPSTREAM_SOLVES = 8
+
+# The pairs this conflict could ask a release for, in the order it would name
+# them, each with the version a release would be of and the versions of the
+# other package that version supports as it stands. `q` runs over the packages
+# the page states a constraint of the user's own about, in the order it states
+# them — only such a package counts, since a bound contradicted by another
+# registry package's bound would blame two maintainers and judge between them.
+# `p` runs over the packages this conflict's lines speak of, the pair closing
+# the chain first, since that is the bound the reader has just read.
+#
+# Two of the three conditions are decided here, off the data and the query
+# alone: the bound must exclude every version of `q` the user's own constraint
+# leaves — one it admits is not what stops the user — and the query must admit
+# `p`'s latest, since otherwise a release that helps exists already and the menu
+# says so. The third is a solve.
+function upstream_candidates(base, prob::Problem{P}, c::Conflict{P,V}) where {P,V}
+    out = Tuple{P,V,P,Vector{V}}[]
+    isempty(c.lines) && return out
+    _, con, _, _ = given_facts(c, Line{P}[l for l in c.lines if l.given])
+    isempty(con) && return out
+    pkgs = line_packages(c)
+    for q in chain_closers(c)
+        haskey(con, q) || continue
+        ps = P[]
+        for l in c.lines
+            l.given && continue
+            l.pivot == q || continue
+            for p in packages(l.clause)
+                p == q || p in ps || push!(ps, p)
+            end
+        end
+        for p in pkgs
+            p == q || p in ps || push!(ps, p)
+        end
+        qd = base(q)
+        for p in ps
+            pd = base(p)
+            isempty(pd.versions) && continue
+            v = maximum(pd.versions)
+            haskey(pd.compat, v) || continue
+            comp = pd.compat[v]
+            haskey(comp, q) || continue
+            s = comp[q]
+            any(w -> !is_excluded(prob, q, w) && w in s, qd.versions) && continue
+            is_excluded(prob, p, v) && continue
+            # ... and there has to be a range to name. The sentence says what
+            # the bound does support, of the versions the page speaks of `q`
+            # in, so a bound that admits none of them or all of them is one the
+            # page cannot state — and a candidate it cannot state is one it
+            # does not try
+            sel = Bool[w in s for w in c.versions[q]]
+            (any(sel) && !all(sel)) || continue
+            push!(out, (p, v, q, V[w for w in c.versions[q] if w in s]))
+        end
+    end
+    return out
+end
+
+# `p`'s data with its latest version's bound on `q` removed, in place: same
+# version numbers, same dependencies, same bounds on every other package and
+# for every other version. The compat map is rebuilt rather than edited, since
+# a provider's own may be shared between versions and is not ours to change —
+# and rebuilt entry by entry, so that versions that shared one before share one
+# still, which is what keeps the artifact behind the probe the size it was.
+function without_bound(pd::PkgData{P,V,S}, v::V, q::P) where {P,V,S}
+    comp = Dict{V,Dict{P,S}}()
+    seen = IdDict{Any,Dict{P,S}}()
+    for (w, e) in pd.compat
+        comp[w] = w == v ? Dict{P,S}(r => s for (r, s) in e if r != q) :
+                           get!(() -> Dict{P,S}(e), seen, e)
+    end
+    return PkgData(pd.versions, pd.depends, comp)
+end
+
+# One candidate, tried (condition 3): the query with every other conflict
+# settled the first way its menu offers — the convention every witness on the
+# page uses — resolved against the registry that release would make. `nothing`
+# where it does not answer with `p` at its latest and `q` installed, which is
+# what the sentence would have claimed.
+function upstream_probe(deps::DepsProvider{P,D}, base, prob::Problem{P},
+                        p::P, v::V, q::P, supported::Vector{V},
+                        settle::Vector{Action{P}}; by, order) where {P,D,V}
+    over = without_bound(base(p), v, q)
+    release(r::P) = r == p ? over : base(r)
+    # the release's own data is a `PkgData` of its own type — same versions,
+    # same dependencies, a compat map rebuilt — so the provider answers in
+    # whatever both it and the rest of the registry are
+    prov = DepsProvider{P,typejoin(D, typeof(over)),typeof(release)}(
+        deps.packages, release)
+    drop_reqs, drop_constraints = withdrawal(settle)
+    sol = resolve(prov, relax(prob, drop_reqs, drop_constraints);
+                  by, order, diagnose = false, upstream = false)
+    sol === nothing && return nothing
+    get(sol, p, nothing) == v || return nothing
+    w = get(sol, q, nothing)
+    w === nothing && return nothing
+    return Upstream{P,V}(p, v, q, w, supported, sol)
+end
+
+"""
+    upstream_fixes(deps, prob, d; by, order) :: Diagnosis
+
+`d` with each conflict's upstream fixes filled in: for every conflict, up to
+two releases someone else could cut that a resolve says would settle it — see
+[`Upstream`](@ref) for what a release is taken to be and what it takes to
+qualify. Everything else about `d` is unchanged, and a diagnosis whose
+conflicts have no qualifying pair comes back as it went in.
+
+`deps` is the package data the releases are tried against, as a `DepsProvider`
+or a dict of [`PkgData`](@ref Resolver.PkgData); `prob` is the query `d`
+diagnoses; `by` and `order` are the orderings the witnesses are resolved with,
+as `resolve` takes them. Each candidate costs one resolve on modified data,
+under a budget per report; what the budget leaves untried sets `upstream_cut`
+on the answer and is not otherwise announced.
+"""
+function upstream_fixes(deps::DepsProvider{P,D}, prob::Problem{P},
+                        d::Diagnosis{P,V}; by::Function = identity,
+                        order = nothing) where {P,D,V}
+    isempty(d.conflicts) && return d
+    # one call per package for the whole report, however many releases are
+    # tried: the data is the same for every candidate but the one package each
+    # of them edits
+    cache = Dict{P,D}()
+    base(r::P) = get!(() -> deps.provider(r)::D, cache, r)
+    firsts = Vector{Action{P}}[isempty(c.fixes) ? Action{P}[] :
+                               first(c.fixes).actions for c in d.conflicts]
+    ups = Vector{Upstream{P,V}}[Upstream{P,V}[] for _ in d.conflicts]
+    solves = 0
+    cut = false
+    for (i, c) in enumerate(d.conflicts)
+        cands = upstream_candidates(base, prob, c)
+        isempty(cands) && continue
+        settle = Action{P}[]
+        for j in eachindex(firsts), a in (j == i ? Action{P}[] : firsts[j])
+            a in settle || push!(settle, a)
+        end
+        for (p, v, q, supported) in cands
+            length(ups[i]) < UPSTREAM_PER_CONFLICT || break
+            if solves ≥ UPSTREAM_SOLVES
+                cut = true
+                break
+            end
+            solves += 1
+            u = upstream_probe(deps, base, prob, p, v, q, supported, settle;
+                               by, order)
+            u === nothing && continue
+            push!(ups[i], u)
+        end
+    end
+    (cut || any(!isempty, ups)) || return d
+    conflicts = Conflict{P,V}[
+        Conflict{P,V}(c.reqs, c.lines, c.versions, c.excluded, c.fixes,
+                      c.blocks, ups[i]) for (i, c) in enumerate(d.conflicts)]
+    return Diagnosis{P,V}(conflicts, d.alternatives, d.others, d.truncated,
+                          d.upstream_cut | cut)
+end
+
+upstream_fixes(data::AbstractDict{P,<:PkgData{P}}, prob::Problem{P},
+               d::Diagnosis{P,V}; by::Function = identity,
+               order = nothing) where {P,V} =
+    upstream_fixes(DepsProvider(p -> data[p], keys(data)), prob, d; by, order)
 
 ## the report
 #
@@ -2630,13 +2881,17 @@ end
 # witness land where the opened meet says it can, which is what the versions are
 # on the page for. Where the entry is one of several under a bullet, the line
 # says which entry it is for; where the bullet has only the one, it does not.
-function print_allows(io::IO, pkgs, f::Fix{P,V}, indent::String;
+function print_allows(io::IO, pkgs, sol::Dict{P,V}, indent::String;
                       prefix::String = "allows: ") where {P,V}
-    ps = sort!(P[p for p in pkgs if haskey(f.solution, p)])
+    ps = sort!(P[p for p in pkgs if haskey(sol, p)])
     isempty(ps) && return
-    print_wrapped(io, prefix * join(String["$p $(f.solution[p])" for p in ps],
-                                    ", "), indent * "→ ", indent * "  ")
+    print_wrapped(io, prefix * join(String["$p $(sol[p])" for p in ps], ", "),
+                  indent * "→ ", indent * "  ")
 end
+
+print_allows(io::IO, pkgs, f::Fix{P,V}, indent::String;
+             prefix::String = "allows: ") where {P,V} =
+    print_allows(io, pkgs, f.solution, indent; prefix)
 
 # A menu of one has exactly three honest wordings, and which one is the whole of
 # what the reader learns about the gap. Never derived from the length of a
@@ -2750,12 +3005,13 @@ end
     print_conflict(io, c, index = nothing; others = :some)
 
 One conflict's page: its heading (where it is numbered), the lines that prove
-it, what settles it, and the verdict on each action the page makes tempting and
-no fix takes. `others` is what the whole diagnosis knows about the repairs that
-cost more than the ones it offers, which is what a menu of one is entitled to
-say about itself; `alone` says whether this conflict's menu is the whole of
-what settles its block, which an alternative to that block denies. `also` is a
-package to name in the heading beside the requirements, which a page whose
+it, what settles it, the verdict on each action the page makes tempting and no
+fix takes, and the releases someone else could cut instead. `others` is what the
+whole diagnosis knows about the repairs that cost more than the ones it offers,
+which is what a menu of one is entitled to say about itself; `alone` says
+whether this conflict's menu is the whole of what settles its block, which an
+alternative to that block denies. `also` is a package to name in the heading
+beside the requirements, which a page whose
 heading would otherwise repeat another's is given (`heading_extras`).
 """
 function print_conflict(io::IO, c::Conflict{P,V}, index = nothing;
@@ -2780,6 +3036,7 @@ function print_conflict(io::IO, c::Conflict{P,V}, index = nothing;
     end
     print_menu(io, c, others, alone)
     print_blocked(io, c)
+    print_upstream(io, c)
 end
 
 # The actions this page makes tempting and leaves out, one sentence each. The
@@ -2828,6 +3085,42 @@ function print_blocked(io::IO, c::Conflict{P,V}) where {P,V}
             "$tried would not help unless you also $also."
         end
         print_wrapped(io, lead, "    • ", "      ")
+    end
+end
+
+# One request, said as the reader would send it: what release would fix this,
+# what the latest supports instead, and what the release would get them. The
+# range is the versions of the bounded package that latest does support, printed
+# as any range on the page is, and the versions under it are the witness on the
+# packages this conflict speaks of — the release's own package aside, since the
+# sentence has just said which version of it this is about.
+#
+# Printed after the blocked fixes: the menu first, the roads not taken second,
+# and last the road that is not the reader's to take. Nothing prints for a
+# conflict with no qualifying pair, and nothing prints for a candidate the probe
+# budget left untried — a sentence the page did not print, and one it would have
+# had to verify before printing.
+function upstream_phrase(c::Conflict{P,V}, u::Upstream{P,V}) where {P,V}
+    vs = c.versions[u.dep]
+    r = range_phrase(vs, Bool[w in u.supported for w in vs])
+    return "a release of $(u.pkg) supporting $(u.dep) $(u.supports) would fix " *
+           "this; $(u.latest), its latest, supports only $r."
+end
+
+function print_upstream(io::IO, c::Conflict{P,V}) where {P,V}
+    isempty(c.upstream) && return
+    pkgs(u) = P[p for p in keys(c.versions) if p != u.pkg]
+    if length(c.upstream) == 1
+        u = only(c.upstream)
+        print_wrapped(io, "Upstream fix: " * upstream_phrase(c, u), "  ", "    ")
+        print_allows(io, pkgs(u), u.solution, "    "; prefix = "would allow: ")
+    else
+        println(io, "  Upstream fixes:")
+        for u in c.upstream
+            print_wrapped(io, upstream_phrase(c, u), "    • ", "      ")
+            print_allows(io, pkgs(u), u.solution, "      ";
+                         prefix = "would allow: ")
+        end
     end
 end
 
@@ -2922,7 +3215,7 @@ end
 touched(f::Fix{P,V}) where {P,V} = Set{P}(a.pkg for a in f.actions)
 
 """
-    report_problems(d) :: Vector{String}
+    report_problems(d; prob = nothing, data = nothing) :: Vector{String}
 
 Everything Section 8's checker can decide without asking the solver:
 
@@ -2946,6 +3239,18 @@ Everything Section 8's checker can decide without asking the solver:
     a whole repair the page has already printed. Were one inside it, taking
     the completion alone would repair and the action it excuses would be idle,
     so the entry would be exhibiting a costlier fix that is not one.
+  * **(V7) upstream fixes** — each one's witness takes the package it asks a
+    release of at the version the sentence calls its latest, and the package
+    that release would support at the version the sentence names; and that
+    package is one the query narrows and one of this conflict's own lines says
+    so about. Given `prob`, the query, and `data`, the package data the release
+    was tried against — a `DepsProvider` or a dict of
+    [`PkgData`](@ref Resolver.PkgData) — the rest of Section 8's check is
+    decidable too: the version is really the latest, the bound the sentence
+    quotes is really that version's, the witness's version of the bounded
+    package really lies outside it (Lemma 32, checked rather than trusted), and
+    the user's own constraint really admits the latest. Without them those four
+    are left unasked, since nothing on the page can answer them.
 
 Empty when the report is sound. The remaining obligation — that each printed
 line is true of the universe this query left (V1) — is one entailment query per
@@ -2960,7 +3265,8 @@ lines are `S₁ ∪ S₂` and `S₂` alone contradicts, the union stays contradi
 whatever is deleted from `S₁`, so a union-level check would pass a page that
 silently destroyed the whole account of `S₁`.
 """
-function report_problems(d::Diagnosis{P,V}) where {P,V}
+function report_problems(d::Diagnosis{P,V}; prob = nothing,
+                         data = nothing) where {P,V}
     bad = String[]
     # V5 is stated against the *full* withdrawal, never the single entry: an
     # owned reason can hold other conflicts' facts, and the witness respects
@@ -3027,8 +3333,65 @@ function report_problems(d::Diagnosis{P,V}) where {P,V}
               join_and(String[action_phrase(a) for a in unless]) *
               " repairs on its own")
     end
+    # (V7) each printed request is one the page has verified: its witness takes
+    # the release at the version the sentence is about and the bounded package
+    # at the version it names, and the bound it drops is one of the user's own
+    # facts' opposite numbers. What the registry has to answer for — that the
+    # version is the latest, that the bound is what the sentence quotes, and
+    # that the witness lands outside it — is asked where the data is given.
+    for (n, c) in enumerate(d.conflicts)
+        for s in upstream_problems(c, prob, data)
+            push!(bad, "conflict $n: $s")
+        end
+    end
     return bad
 end
+
+# the package data for one package, from whichever shape of it the checker was
+# handed — the same two `resolve` itself takes
+pkg_data_of(data::DepsProvider{P}, p::P) where {P} = data.provider(p)
+pkg_data_of(data::AbstractDict{P,<:PkgData{P}}, p::P) where {P} = data[p]
+
+# (V7), of one conflict's upstream fixes
+function upstream_problems(c::Conflict{P,V}, prob, data) where {P,V}
+    bad = String[]
+    isempty(c.upstream) && return bad
+    _, con, _, _ = given_facts(c, Line{P}[l for l in c.lines if l.given])
+    for u in c.upstream
+        said = "the upstream fix naming $(u.pkg) $(u.latest)"
+        # the witness is what the sentence claims it is
+        get(u.solution, u.pkg, nothing) == u.latest ||
+            push!(bad, "$said: its witness does not take $(u.pkg) $(u.latest)")
+        get(u.solution, u.dep, nothing) == u.supports ||
+            push!(bad, "$said: its witness does not take $(u.dep) $(u.supports)")
+        # the bound it drops meets one of the user's own facts, said by a line
+        # of this conflict — never another registry package's bound
+        haskey(con, u.dep) ||
+            push!(bad, "$said: no line of it says the query narrows $(u.dep)")
+        data === nothing && continue
+        pd = pkg_data_of(data, u.pkg)
+        u.latest == maximum(pd.versions) ||
+            push!(bad, "$said: $(u.latest) is not the latest $(u.pkg)")
+        if !haskey(pd.compat, u.latest) || !haskey(pd.compat[u.latest], u.dep)
+            push!(bad, "$said: $(u.pkg) $(u.latest) has no bound on $(u.dep)")
+        else
+            s = pd.compat[u.latest][u.dep]
+            # (Lemma 32) the release helps by exactly what the sentence says
+            u.supports in s &&
+                push!(bad, "$said: $(u.dep) $(u.supports) is inside the bound " *
+                           "the release drops")
+            u.supported == V[w for w in get(c.versions, u.dep, V[]) if w in s] ||
+                push!(bad, "$said: the range it names is not what " *
+                           "$(u.pkg) $(u.latest) supports")
+        end
+        prob === nothing && continue
+        # the blame is current: a release the user has excluded already exists
+        is_excluded(prob, u.pkg, u.latest) &&
+            push!(bad, "$said: the query does not admit $(u.pkg) $(u.latest)")
+    end
+    return bad
+end
+
 
 function conflict_problems(c::Conflict{P,V}, rest::Set{P} = Set{P}()) where {P,V}
     bad = String[]

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -94,9 +94,9 @@ function resolve_core(
 end
 
 """
-    resolve(data, prob::Problem; by = identity, diagnose = true)
+    resolve(data, prob::Problem; by = identity, diagnose = true, upstream = true)
         -> Union{Dict{P,V}, Diagnosis{P,V}, Nothing}
-    resolve(data, reqs; by = identity, diagnose = true)
+    resolve(data, reqs; by = identity, diagnose = true, upstream = true)
 
 Resolve the requirements `reqs` against the package universe described by
 `data`, returning the optimal solution as a dict mapping each needed package
@@ -109,6 +109,13 @@ user could change to make them; `show`ing it prints the report. Pass
 `diagnose = false` for the bare `nothing` instead, which is what a caller that
 only wants the verdict should do — the diagnosis costs several more solves and
 one resolve per fix on the menus it offers.
+
+Where `data` is a `DepsProvider` or a dict of `PkgData`, a diagnosis also says
+what someone *else* could change: a release of a package on the page, supporting
+a package the query narrowed, that a resolve on the data so modified says would
+settle a conflict — see [`Upstream`](@ref Resolver.Diagnostics.Upstream).
+`upstream = false` skips the search, which costs one such resolve per candidate
+under a budget per report.
 
 A [`Problem`](@ref) additionally constrains the admissible versions with user
 constraints; the answer is the one the same universe with those versions
@@ -129,7 +136,8 @@ constraints to attribute a failure to: it answers `nothing`, and accepts
 are restored before returning so the instance can be reused, and
 `restore = false` is faster for single-use instances.
 
-The other methods accept one more keyword:
+The other methods accept `order` as well, and the `DepsProvider` and `PkgData`
+ones `upstream` besides:
 
   * `order`: the *version* preference ordering, as a callable mapping a package
     to a `lt` comparator over its versions ("is preferred to"). The default,
@@ -317,10 +325,12 @@ function resolve(
     by   :: Function = identity, # package ordering
     order = nothing, # version ordering
     diagnose :: Bool = true,
+    upstream :: Bool = true, # look for releases that would fix each conflict
 ) where {P}
     info = pkg_info(deps, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob;
+    ans = resolve_prepared(prepare_pkg_info(info, prob, info; order), prob;
         by, order, diagnose)
+    return with_upstream(deps, prob, ans, upstream; by, order)
 end
 
 function resolve(
@@ -329,11 +339,22 @@ function resolve(
     by   :: Function = identity, # package ordering
     order = nothing, # version ordering
     diagnose :: Bool = true,
+    upstream :: Bool = true, # look for releases that would fix each conflict
 ) where {P}
     info = pkg_info(data, prob)
-    resolve_prepared(prepare_pkg_info(info, prob, info; order), prob;
+    ans = resolve_prepared(prepare_pkg_info(info, prob, info; order), prob;
         by, order, diagnose)
+    return with_upstream(data, prob, ans, upstream; by, order)
 end
+
+# What the package data adds to a diagnosis, and only it can: for each
+# conflict, whether a release of some package on the page would settle it (see
+# `Diagnostics.upstream_fixes`). A release is a different registry rather than a
+# different query, so this is the resolve's to ask and not the diagnosis's, and
+# `upstream = false` is how a caller that does not want the probes says so.
+with_upstream(data, prob::Problem, ans, upstream::Bool; by, order) =
+    upstream && ans isa Diagnostics.Diagnosis ?
+        Diagnostics.upstream_fixes(data, prob, ans; by, order) : ans
 
 # a caller-supplied info may be a reusable (or cached) T1 artifact, so this
 # method prepares into a dict of its own and leaves the argument alone
@@ -357,7 +378,8 @@ resolve(
     by     :: Function = identity, # package ordering
     order  = nothing, # version ordering
     diagnose :: Bool = true,
-) where {P} = resolve(deps, Problem(reqs); by, order, diagnose)
+    upstream :: Bool = true,
+) where {P} = resolve(deps, Problem(reqs); by, order, diagnose, upstream)
 
 resolve(
     data :: AbstractDict{P,<:PkgData{P}},
@@ -365,7 +387,8 @@ resolve(
     by     :: Function = identity, # package ordering
     order  = nothing, # version ordering
     diagnose :: Bool = true,
-) where {P} = resolve(data, Problem(reqs); by, order, diagnose)
+    upstream :: Bool = true,
+) where {P} = resolve(data, Problem(reqs); by, order, diagnose, upstream)
 
 resolve(
     info :: AbstractDict{P,PkgInfo{P,V}},

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -34,8 +34,9 @@ using Resolver: Problem, PkgData, PkgInfo, SAT, Diagnosis, pkg_info, relax,
     prepare_pkg_info, finalize, sat_solve, installed_lit, forbidden_lit,
     with_classes_relaxed, class_exclusions, exclusion_kinds, nclasses,
     sat_assume_var
-using Resolver.Diagnostics: Diagnostics, Conflict, Fix, Action, Line,
-    clause_versions, clauses_satisfiable, clause_of, project, action_phrase
+using Resolver.Diagnostics: Diagnostics, Conflict, Fix, Action, Line, Upstream,
+    clause_versions, clauses_satisfiable, clause_of, project, action_phrase,
+    report_problems
 using Resolver.Clauses: Clauses, Clause, packages, isbottom, clause_phrase,
     literal, resolve_on, subsumes
 using Resolver.UnsatCores: sat_mcses
@@ -650,6 +651,9 @@ end
             1. relax your compat on P
                → allows: P p2, R r1
             2. drop requirement R
+          Upstream fix: a release of R supporting P p1 would fix this; r1, its latest,
+            supports only p2.
+            → would allow: P p1
         """
 end
 
@@ -674,6 +678,9 @@ end
             1. relax your compat on C
                → allows: A a3, C c3
             2. drop requirement A
+          Upstream fix: a release of A supporting C c1 would fix this; a3, its latest,
+            supports only c3.
+            → would allow: C c1
         """
 end
 
@@ -695,6 +702,9 @@ end
             1. relax your compat on C
                → allows: A a1, C c2
             2. drop requirement A
+          Upstream fix: a release of A supporting C c1 would fix this; a1, its latest,
+            supports only c2.
+            → would allow: C c1
         """
 end
 
@@ -1791,4 +1801,210 @@ end
     for r in (:A, :B, :C)
         @test any(l -> l.clause[r] !== nothing, said)
     end
+end
+
+
+# An upstream fix is the one thing on the page the reader cannot do themselves:
+# a release of some package, supporting a package the query narrowed, that this
+# has resolved and found would settle the conflict. The bar is three conditions
+# (Section 7 of the theory page) and every one of them is checked here on data
+# small enough to read: the bound has to meet one of the user's *own* facts, the
+# query has to admit the releasing package's latest, and the solve has to
+# succeed with that latest taken.
+#
+# `report_problems` is the checker, and it is given the query and the data, so
+# the four questions only the registry can answer -- is that the latest, is that
+# its bound, does the witness land outside it, does the query admit it -- are
+# asked here too.
+
+# :A's only version wants the older :B, and the user wants the newer one: the
+# bound is :A's and lifting it is not the user's to do
+const upstream_pair = Dict(
+    :A => PkgData([:a1], Dict(:a1 => [:B]), Dict(:a1 => Dict(:B => [:b1]))),
+    :B => PkgData([:b2, :b1], DEPS_NONE, COMP_NONE),
+)
+
+@testset "diagnosis: a release someone else could cut" begin
+    prob = Problem([:A, :B]; compat = Dict(:B => [:b2]))
+    d = check_diagnosis(upstream_pair, prob)
+    c = only(d.conflicts)
+    u = only(c.upstream)
+    @test (u.pkg, u.latest, u.dep, u.supports) == (:A, :a1, :B, :b2)
+    @test u.supported == [:b1]
+    # the versions are a resolve's, like every other witness on the page
+    @test u.solution == Dict(:A => :a1, :B => :b2)
+    # ... and the sentence is one the reader could send as it stands (read
+    # here with the wrapping undone, which is the terminal's business)
+    report = sprint(show, MIME("text/plain"), d)
+    unwrapped = replace(report, r"\n\s+" => " ")
+    @test occursin("Upstream fix: a release of A supporting B b2 would fix " *
+                   "this; a1, its latest, supports only b1.", unwrapped)
+    @test occursin("→ would allow: B b2", report)
+    # (V7) everything Section 8 asks of it, the registry's part included
+    @test isempty(report_problems(d; prob, data = upstream_pair))
+    @test isempty(report_problems(d))
+    # ... and the probes are the resolve's to run, so a caller can say no
+    d2 = resolve(upstream_pair, prob; upstream = false)
+    @test all(c -> isempty(c.upstream), d2.conflicts)
+    @test !occursin("Upstream", sprint(show, MIME("text/plain"), d2))
+end
+
+@testset "diagnosis: a checker that reads the registry" begin
+    # V7 is a check and not a formality: a sentence the data does not bear out
+    # is caught, whichever half of it is wrong
+    prob = Problem([:A, :B]; compat = Dict(:B => [:b2]))
+    d = check_diagnosis(upstream_pair, prob)
+    c = only(d.conflicts)
+    u = only(c.upstream)
+    function retold(v::Upstream{Symbol,Symbol})
+        c2 = Conflict{Symbol,Symbol}(c.reqs, c.lines, c.versions, c.excluded,
+                                     c.fixes, c.blocks, [v])
+        return report_problems(Diagnosis([c2], d.others); prob,
+                               data = upstream_pair)
+    end
+    @test isempty(retold(u))
+    # a witness that does not take the release
+    @test !isempty(retold(Upstream(:A, :a1, :B, :b2, [:b1],
+                                   Dict(:B => :b2))))
+    # a version that is not the latest
+    @test !isempty(retold(Upstream(:B, :b1, :A, :a1, Symbol[],
+                                   Dict(:A => :a1, :B => :b1))))
+    # a version of the bounded package the bound admits after all: then the
+    # release drops a bound that was not in the way (Lemma 32)
+    @test !isempty(retold(Upstream(:A, :a1, :B, :b1, [:b1],
+                                   Dict(:A => :a1, :B => :b1))))
+    # a package no line of the conflict says the query narrowed
+    @test !isempty(retold(Upstream(:B, :b2, :A, :a1, Symbol[],
+                                   Dict(:A => :a1, :B => :b2))))
+end
+
+@testset "diagnosis: a bound the user's own facts do not meet" begin
+    # :A wants the old :C, :B wants the new one, and the query says nothing
+    # about :C at all. Two maintainers could each fix this and the page will
+    # not judge between them, so it asks neither
+    data = Dict(
+        :A => PkgData([:a1], Dict(:a1 => [:C]), Dict(:a1 => Dict(:C => [:c1]))),
+        :B => PkgData([:b1], Dict(:b1 => [:C]), Dict(:b1 => Dict(:C => [:c2]))),
+        :C => PkgData([:c2, :c1], DEPS_NONE, COMP_NONE),
+    )
+    d = check_diagnosis(data, Problem([:A, :B]))
+    @test all(c -> isempty(c.upstream), d.conflicts)
+    @test !occursin("Upstream", sprint(show, MIME("text/plain"), d))
+    @test isempty(report_problems(d; prob = Problem([:A, :B]), data))
+end
+
+@testset "diagnosis: a release that exists already is on the menu" begin
+    # :a2 already supports the :B the user wants; what stands in the way is
+    # the user's own compat on :A, and *relax your compat on A* is the fix.
+    # Asking upstream for what has shipped would be asking for nothing
+    data = Dict(
+        :A => PkgData([:a2, :a1], Dict(:a2 => [:B], :a1 => [:B]),
+                      Dict(:a2 => Dict(:B => [:b1, :b2]),
+                           :a1 => Dict(:B => [:b1]))),
+        :B => PkgData([:b2, :b1], DEPS_NONE, COMP_NONE),
+    )
+    prob = Problem([:A]; compat = Dict(:A => [:a1], :B => [:b2]))
+    d = check_diagnosis(data, prob)
+    c = only(d.conflicts)
+    @test Set([Action(:compat, :A)]) in Set(Set(f.actions) for f in c.fixes)
+    @test isempty(c.upstream)
+    @test !occursin("Upstream", sprint(show, MIME("text/plain"), d))
+    @test isempty(report_problems(d; prob, data))
+end
+
+@testset "diagnosis: an upstream witness settles the rest of the page" begin
+    # two conflicts that share nothing: the release asked for is one conflict's
+    # own, and its witness settles the other the first way that menu offers,
+    # which is the convention every witness on the page follows
+    data = Dict(
+        :A => PkgData([:a1], Dict(:a1 => [:C]), Dict(:a1 => Dict(:C => [:c1]))),
+        :C => PkgData([:c2, :c1], DEPS_NONE, COMP_NONE),
+        :E => PkgData([:e1], Dict(:e1 => [:G]), Dict(:e1 => Dict(:G => [:g1]))),
+        :G => PkgData([:g2, :g1], DEPS_NONE, COMP_NONE),
+    )
+    prob = Problem([:A, :E]; compat = Dict(:C => [:c2], :G => [:g2]))
+    d = check_diagnosis(data, prob)
+    @test length(d.conflicts) == 2
+    for (i, c) in enumerate(d.conflicts)
+        u = only(c.upstream)
+        other = d.conflicts[3-i]
+        # the release is this conflict's own ...
+        @test u.pkg in keys(c.versions) && u.dep in keys(c.versions)
+        @test u.solution[u.pkg] == u.latest
+        @test u.solution[u.dep] == u.supports
+        # ... and its witness is what a resolve of that registry answers with
+        # the other conflict settled the first way its menu offers -- read off
+        # here rather than taken from the diagnosis, and resolved from scratch
+        released = Diagnostics.without_bound(data[u.pkg], u.latest, u.dep)
+        mod = merge(data, Dict(u.pkg => released))
+        @test u.solution == fix_resolve(mod, prob, first(other.fixes).actions)
+        @test haskey(u.solution, only(other.reqs))
+    end
+    # ... and what prints under one is the page's own packages, not the other's
+    report = sprint(show, MIME("text/plain"), d)
+    @test occursin("→ would allow: C c2\n", report)
+    @test occursin("→ would allow: G g2\n", report)
+    @test isempty(report_problems(d; prob, data))
+end
+
+@testset "diagnosis: the probe budget is recorded and not announced" begin
+    # nine conflicts of the same shape, each with one candidate: the budget
+    # stops the ninth from being tried, and what the page does not print it
+    # does not talk about either
+    n = Diagnostics.UPSTREAM_SOLVES + 1
+    data = Dict{Symbol,PkgData{Symbol,Symbol,Vector{Symbol},Vector{Symbol},
+                               Dict{Symbol,Vector{Symbol}},
+                               Dict{Symbol,Dict{Symbol,Vector{Symbol}}}}}()
+    reqs = Symbol[]
+    compat = Dict{Symbol,Vector{Symbol}}()
+    for i = 1:n
+        a, b = Symbol("A", i), Symbol("B", i)
+        b1, b2 = Symbol("b", i, "1"), Symbol("b", i, "2")
+        data[a] = PkgData([Symbol("a", i)], Dict(Symbol("a", i) => [b]),
+                          Dict(Symbol("a", i) => Dict(b => [b1])))
+        data[b] = PkgData([b2, b1], DEPS_NONE, COMP_NONE)
+        push!(reqs, a)
+        compat[b] = [b2]
+    end
+    prob = Problem(reqs; compat)
+    d = resolve(data, prob)
+    @test length(d.conflicts) == n
+    @test count(c -> !isempty(c.upstream), d.conflicts) ==
+          Diagnostics.UPSTREAM_SOLVES
+    @test d.upstream_cut
+    report = sprint(show, MIME("text/plain"), d)
+    @test !occursin("cut", report) && !occursin("budget", report)
+    @test count("Upstream fix:", report) == Diagnostics.UPSTREAM_SOLVES
+    @test isempty(report_problems(d; prob, data))
+end
+
+# Two qualifying pairs print as the choice they are: a bulleted list under one
+# heading, each bullet the same sentence and its own witness. Built by hand,
+# since a conflict that one release fixes in two different ways is rare enough
+# that neither corpus holds one -- what is being checked here is the shape of
+# the page, which is this file's business either way.
+@testset "diagnosis: two releases print as two bullets" begin
+    P, V = String, Int
+    VS = Dict("X" => [1], "Q" => [1, 2, 3], "R" => [1, 2])
+    lines = Line{P}[Line{P}(Clauses.clause(["X" => literal(1, [1])]), P[], true)]
+    up(p, v, q, s, sup, sol) = Upstream{P,V}(p, v, q, s, V[sup...], sol)
+    c = Conflict{P,V}(P["X"], lines, VS, Dict{P,Vector{Vector{Symbol}}}(),
+        Fix{P,V}[Fix{P,V}(Action{P}[Action(:drop, "X")], Dict("X" => 1))],
+        Tuple{Vector{Vector{Action{P}}},Vector{Action{P}}}[],
+        Upstream{P,V}[up("A", 5, "Q", 3, [1, 2],
+                         Dict("A" => 5, "Q" => 3, "X" => 1)),
+                      up("B", 2, "R", 2, [1],
+                         Dict("B" => 2, "R" => 2, "X" => 1))])
+    report = sprint(show, MIME("text/plain"), Diagnosis([c], :none))
+    flat = replace(report, r"\n\s+" => " ")
+    @test occursin("  Upstream fixes:\n", report)
+    @test !occursin("Upstream fix:", report)
+    @test occursin("• a release of A supporting Q 3 would fix this; 5, its " *
+                   "latest, supports only ≤2.", flat)
+    @test occursin("• a release of B supporting R 2 would fix this; 2, its " *
+                   "latest, supports only 1.", flat)
+    # each bullet's witness is its own, and says nothing about the package the
+    # sentence above it has just named a version of
+    @test occursin("→ would allow: Q 3, X 1", flat)
+    @test occursin("→ would allow: R 2, X 1", flat)
 end


### PR DESCRIPTION
Brings back upstream fixes: a conflict whose chain ends where a registry bound meets one of the user's own facts may now say what a *maintainer* could change, as one verified, sendable request.

## What an upstream fix is

A **hypothetical release** of `P` is `P`'s latest version with its compat bound on one package `Q` removed and nothing else changed — modelled in place, same version number, so it behaves as the latest in every clause but one and no third package's bound on `P` comes into question. Lemma 32: if the registry so modified has a model taking that release, `Q` sits outside the dropped bound, so the release helps by exactly what the sentence says.

The page offers one only when all three hold:
1. **The bound meets the user's own fact.** `Q` is a package the query narrows and names on this conflict's page. A bound contradicted only by *another registry package's* bound is never offered — that would blame two maintainers and judge between them (the earlier "a release of A or C relaxing their compat on each other" form is deliberately gone).
2. **The blame is current.** The user's constraint on `P` admits `P`'s latest; otherwise a helping release exists already and the menu's "relax your compat on P" says so.
3. **It works.** One provider-level resolve on the modified registry, with the other conflicts settled the first way their menus offer, succeeds with `P` at its latest.

Two releases at once are never asked for; no backports. Candidates are the conflict's own (P, Q) pairs, the chain-closing pair first, under caps of 2 per conflict and 8 solves per report; a cap that cuts a candidate is recorded on the diagnosis and not announced.

## The page

After the blocked fixes:

```
Unsatisfiable — 2 conflicts, pick a fix for each:

Conflict 1: Pluto
  • Pluto requires HTTP ≤0.9.17, 1.0.2–1.11.0
  • your compat leaves HTTP 2.6.7
  Fix it by any one of:
    1. relax your compat on HTTP
       → allows: HTTP 1.11.0, Pluto 1.0.3
    2. drop requirement Pluto
       → allows: HTTP 2.6.7
  Blocked fixes:
    • dropping requirement HTTP does not help.
    • relaxing your compat on Pluto would not help unless you also relaxed
      your compat on HTTP and dropped requirement Configurations.
  Upstream fix: a release of Pluto supporting HTTP 2.6.7 would fix this;
    1.0.3, its latest, supports only 1.10.17–1.11.0.
    → would allow: HTTP 2.6.7

Conflict 2: Configurations
  • Configurations requires OrderedCollections 1.3.0–1.8.2
  • your compat leaves OrderedCollections 2.0.1
  One fix: relax your compat on OrderedCollections
    → allows: Configurations 0.17.6, OrderedCollections 1.8.2
  Blocked fixes:
    • relaxing your compat on Configurations does not help.
    • dropping requirement OrderedCollections does not help.
  Upstream fix: a release of Configurations supporting OrderedCollections
    2.0.1 would fix this; 0.17.6, its latest, supports only 1.3.0–1.8.2.
    → would allow: OrderedCollections 2.0.1

Or, to fix without relaxing your compat on OrderedCollections:
  drop requirement Configurations and drop requirement Pluto
  → allows: HTTP 2.6.7, OrderedCollections 2.0.1
```

The chain line speaks for every version of Pluto together ("≤0.9.17, 1.0.2–1.11.0"); the upstream sentence speaks for the latest alone, which is what a release would be like. Nothing prints where the bar is not met: `Bloqade+big20-upgrade` looks like the clean case ("Bloqade requires ForwardDiff 0.10.13–0.10.39") but stays silent, because with Bloqade's bound dropped BloqadeExpr still holds ForwardDiff to 0.10 — two releases, which the page declines to ask for.

## Data and API

`Upstream{P,V}(pkg, latest, dep, supports, supported, solution)` on `Conflict.upstream`; `Diagnosis.upstream_cut`. `upstream_fixes(deps, prob, d; by, order)` runs at the provider level (it needs the registry) and is called from the provider-level `resolve` methods behind `upstream = true`; `bin/resolve.jl` does the same. V7 in `report_problems` checks each printed fix against the registry data: `P` at latest in the witness, `Q` outside the dropped bound (Lemma 32 checked, not trusted), `Q` named by a given line, the user's constraint admitting `P`'s latest, and the printed range exactly the bound's.

## Evidence

Two corpora, before (theory commit; identical to main's reports) and after, `report_problems` 0 throughout. Every report without a qualifying pair is byte-identical.

| corpus | unsat reports | gained a sentence | distinct requests | cap hit |
|---|---:|---:|---:|---:|
| hard (57, closure pinned at latest) | 42 | 32 | 40 | 2 |
| realistic (115, hub + direct deps) | 115 | 22 | 15 | 0 |

Every distinct realistic request, each a compat bump one maintainer could make: Franklin→HTTP 2.6.7, Knet→JLD2 0.6.6, Bloqade→CairoMakie 0.15.14, Metatheory→TermInterface 2.0.0, Metatheory→TimerOutputs 1.2.1, Pluto→HTTP 2.6.7, DataFrames→InlineStrings 2.0.1, DiffEqFlux→Distributions 0.25.131, Franklin→OrderedCollections 2.0.1, Gadfly→DataStructures 0.19.6, Gen→JSON 1.8.0, Gen→ForwardDiff 1.4.5, Metatheory→DataStructures 0.19.6, Configurations→OrderedCollections 2.0.1, ColorTypes→FixedPointNumbers 0.9.1.

**Cost** (per report, warm registry): realistic median 0.14 s → 0.20 s (1.41×), worst +1.07 s; hard median 1.51 s → 2.02 s. A probe is one resolve of the whole query on modified data, so it costs about what the failed resolve did.

Full suite green (137 testsets). New tests: the qualifying pair and its sentence with V7; four corrupted fixes each caught by V7; the two-sided case (silent); the currency case (menu fix, silent); the multi-conflict witness against an independent resolve; the budget; `upstream = false`; the two-bullet form. Side-by-side review of every changed report: https://claude.ai/code/artifact/1d9fa894-5fac-44d6-85fc-c5be3f7725bd — and every report, before and after, in gists: hard https://gist.github.com/StefanKarpinski/a196a5477ae0a4e3c2aff467830f7e03, realistic https://gist.github.com/StefanKarpinski/f1467ed08199f66c76ba437508442960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hyi2aKkUnkd9HA2hS9YChk
