### PR TITLE
Start the descent from the best class the query admits

### DIFF
--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -6,6 +6,7 @@ function resolve_core(
     reqs :: SetOrVec{P} = keys(sat.info);
     by   :: Function = identity, # priority ordering
     ord  :: O = nothing, # class ranking (the universe's own layout by default)
+    reps :: Dict{P,Vector{Int}} = sat.reps, # the classes the query admits
     restore :: Bool = true, # restore the SAT instance's state before returning
 ) where {P, O}
     # a requirement the instance doesn't know has no installable version —
@@ -19,30 +20,39 @@ function resolve_core(
     # clauses added by the descent invalidate the solver's assignment
     extract_solution!(sat, sol)
 
+    # the best class of `p` the query admits: the first in its ranking that
+    # `reps` gives a member, the emptied ones being forbidden already
+    best_class(p::P) =
+        hinted_class(reps[p], ranking(ord, p, nclasses(sat.info[p])))
+
     # optimize each package in `opts` to its best feasible version wrt quality,
     # pinning each as it goes (in priority order); return the newly-reachable
     # dependencies of the chosen versions that still need optimizing
     function optimize!(opts::Set{P}, seen::Set{P})
         layer = sort!(collect(opts); by)
-        # optimistic joint probe: assume the best class of every
-        # package in the layer that the current model doesn't already
-        # have at its best. when jointly feasible — the common case —
-        # one solve pins the whole layer, and joint feasibility of the
-        # best classes witnesses each of the sequential optimizations
-        # below, so the layered answer is unchanged. a failed probe
-        # tells us nothing and the sequential path proceeds as usual
-        # (skipped for a single package, whose own probe covers it)
-        todo = [p for p in layer
-                if sol[p] != @inbounds ranking(ord, p, nclasses(sat.info[p]))[1]]
+        # optimistic joint probe: assume the best admissible class of every
+        # package in the layer that the current model doesn't already have
+        # there. when jointly feasible — the common case — one solve pins the
+        # whole layer, and joint feasibility of those classes witnesses each
+        # of the sequential optimizations below, so the layered answer is
+        # unchanged. a failed probe tells us nothing and the sequential path
+        # proceeds as usual (skipped for a single package, whose own probe
+        # covers it). a class the query emptied is never assumed: it is
+        # forbidden at level 0, and one such assumption would fail the probe
+        # for the whole layer
+        todo = Pair{P,Int}[]
+        for p in layer
+            c = best_class(p)
+            sol[p] == c || push!(todo, p => c)
+        end
         if length(todo) > 1
-            for p in todo
-                sat_assume(sat, p,
-                    @inbounds ranking(ord, p, nclasses(sat.info[p]))[1])
+            for (p, c) in todo
+                sat_assume(sat, p, c)
             end
             sat_solve(sat) && extract_solution!(sat, sol)
         end
         for p in layer
-            optimize_version!(sat, sol, p, ord)
+            optimize_version!(sat, sol, p, ord, reps)
             # fix optimized class
             sat_add(sat, p, sol[p])
             sat_add(sat)
@@ -272,11 +282,14 @@ function relax(
 end
 
 # Answer a relaxation on the instance built for the query it relaxes: the
-# descent again, in the order `rp` ranks the classes, with `rp`'s deactivations
-# in place of the query's for the duration and the query's put back after. The
-# instance is left exactly as it was found — same clauses, same forbidden
-# classes, same decision phases — so one universe answers as many relaxations as
-# it is asked, in any order.
+# descent again, in the order `rp` ranks the classes and over the classes `rp`
+# admits, with `rp`'s deactivations in place of the query's for the duration
+# and the query's put back after. What is admissible the descent learns from
+# the representatives the frame was built from, not from `sat.reps`, which
+# still names the query's: a class the query emptied may well be admissible
+# here. The instance is left exactly as it was found — same clauses, same
+# forbidden classes, same decision phases — so one universe answers as many
+# relaxations as it is asked, in any order.
 function resolve(
     sat :: SAT{P,V},
     rp  :: RelaxedProblem{P};
@@ -287,7 +300,7 @@ function resolve(
     sol = with_deactivations(sat, deactivated_lits(sat, reps)) do
         rehint_classes!(sat, sat.reps, nothing, reps, ord)
         try
-            resolve_core(sat, rp.prob.reqs; by, ord)
+            resolve_core(sat, rp.prob.reqs; by, ord, reps)
         finally
             rehint_classes!(sat, reps, ord, sat.reps, nothing)
         end

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -42,6 +42,11 @@ mutable struct SAT{P,V}
     # with `sat_pop`, which retracts whatever was pushed last, and getting that
     # wrong retracts someone else's clauses instead of the query's
     depth :: Int
+    # how many times picosat has been asked to solve, over the instance's whole
+    # life. An instrument, and the right one: what a descent costs is a number
+    # of solves, and a wall time can't say which of two changes to it made a
+    # solve go away and which merely made it faster
+    solves :: Int
     # per selector variable, the registry statement it switches on. Empty
     # unless the instance was built to be explained: a selector occurs only
     # negatively, so assuming them all gives back exactly the instance without
@@ -336,7 +341,7 @@ function SAT(
         PicoSAT.reset(pico)
         rethrow()
     end
-    sat = finalizer(finalize, SAT(info, univ.reps, pico, vars, Int[], 0, why))
+    sat = finalizer(finalize, SAT(info, univ.reps, pico, vars, Int[], 0, 0, why))
     try deactivate_classes!(sat)
     catch
         finalize(sat)
@@ -493,8 +498,10 @@ forbidden_lit(sat::SAT{P}, p::P, c::Integer) where {P} = -(sat.vars[p] + c)
 # so a caller asking about *requirements* wants `is_satisfiable(sat, reqs)`:
 # requirements are assumed, not asserted, and an unstaged solve reports them
 # satisfiable however unsatisfiable they are.
-sat_solve(sat::SAT) =
-    PicoSAT.sat(sat.pico) == PicoSAT.SATISFIABLE
+function sat_solve(sat::SAT)
+    sat.solves += 1
+    return PicoSAT.sat(sat.pico) == PicoSAT.SATISFIABLE
+end
 
 # Are `reqs` jointly installable? The complete question, staged and answered.
 function is_satisfiable(sat::SAT{P}, reqs::Union{P,SetOrVec{P}}) where {P}

--- a/src/SAT.jl
+++ b/src/SAT.jl
@@ -625,19 +625,25 @@ function rehint_classes!(
     return sat
 end
 
-# improve package p to its best feasible class: repeatedly demand some
-# strictly better class until that becomes unsatisfiable, keeping the last
-# good model in sol
+# improve package p to its best admissible feasible class: repeatedly demand
+# some strictly better class until that becomes unsatisfiable, keeping the last
+# good model in sol. `reps` says which classes are admissible — a class the
+# query emptied is forbidden by a unit clause, so probing one would be a solve
+# spent learning what the instance already states
 function optimize_version!(
-    sat :: SAT{P},
-    sol :: Dict{P,Int},
-    p   :: P,
-    ord :: O = nothing,
+    sat  :: SAT{P},
+    sol  :: Dict{P,Int},
+    p    :: P,
+    ord  :: O = nothing,
+    reps :: Dict{P,Vector{Int}} = sat.reps, # the classes the query admits
 ) where {P, O}
     ord_p = ranking(ord, p, nclasses(sat.info[p]))
-    best = @inbounds ord_p[1]
-    # cheap first try: after filtering, the best class is feasible more
-    # often than not, and probing it by assumption needs no temp clauses
+    best = hinted_class(reps[p], ord_p)
+    @assert best != 0 """
+        $p admits no class, yet the model installs it: `reps` has to be the
+        representatives whose deactivations are in force."""
+    # cheap first try: after filtering, the best admissible class is feasible
+    # more often than not, and probing it by assumption needs no temp clauses
     # at all — one solve replaces the whole improvement loop
     if sol[p] != best
         sat_assume(sat, p, best)
@@ -651,7 +657,10 @@ function optimize_version!(
     while sol[p] != best
         improved = with_temp_clauses(sat) do
             # some class ranking strictly above the one it has — the ranks the
-            # scan passes on its way to the one it has, which is where it stops
+            # scan passes on its way to the one it has, which is where it stops.
+            # an emptied class among them stays in: its literal is false at
+            # level 0 and costs nothing, and `best` being admissible means the
+            # clause is never made of such literals alone
             for r in eachindex(ord_p)
                 c = @inbounds ord_p[r]
                 c == sol[p] && break

--- a/test/class_space.jl
+++ b/test/class_space.jl
@@ -20,7 +20,7 @@
 using Resolver: PkgData, PkgInfo, Problem, SAT, PicoSAT, pkg_info, nclasses,
     rank_pkg_info, prepare_pkg_info, filter_pkg_info!, deactivations,
     mark_installable!, mark_necessary!, drop_unmarked!, class_ranking,
-    finalize, sat_assume, sat_pop, is_satisfiable, sat_solve
+    finalize, sat_assume, sat_pop, is_satisfiable, sat_solve, relax, relaxations
 
 const NODEPS = Dict{Symbol,Vector{Symbol}}()
 const NOCOMP = Dict{Symbol,Dict{Symbol,Vector{Symbol}}}()
@@ -367,6 +367,77 @@ end
     finally
         finalize(sat)
     end
+end
+
+@testset "fitness: the descent never probes an emptied class" begin
+    # An emptied class is forbidden by a unit clause, so a probe of it can only
+    # come back unsatisfiable, and every such solve is spent learning what the
+    # instance already states. The descent has to work from the best class the
+    # query *admits*: `sat.solves` is what says whether it does.
+    #
+    # :A and :D each have three classes, one per dependency pattern, and the
+    # query below empties the two best of each. Unconstrained, the feasibility
+    # solve lands both at their best class and nothing more is asked — one
+    # solve. Constrained, the phase hint lands both at the best class the query
+    # admits, so the same one solve is the whole of it; a descent that reached
+    # for the emptied classes would pay one solve for the layer's joint probe
+    # and two more per package, six in all.
+    data = Dict(
+        :A => PkgData([:v3, :v2, :v1], Dict(:v3 => [:B], :v2 => [:C]), NOCOMP),
+        :D => PkgData([:v3, :v2, :v1], Dict(:v3 => [:B], :v2 => [:C]), NOCOMP),
+        :B => PkgData([:w1], NODEPS, NOCOMP),
+        :C => PkgData([:w1], NODEPS, NOCOMP),
+    )
+    info = pkg_info(data, [:A, :D])
+    function solves(info, prob)
+        sat = SAT(prepare_pkg_info(info, prob))
+        try
+            sol = resolve(sat, prob.reqs)
+            return sol, sat.solves
+        finally
+            finalize(sat)
+        end
+    end
+    @test solves(info, Problem([:A, :D])) ==
+        (Dict(:A => :v3, :D => :v3, :B => :w1), 1)
+    Q = Problem([:A, :D]; compat = Dict(:A => [:v1], :D => [:v1]))
+    univ = prepare_pkg_info(info, Q)
+    @test univ.reps[:A] == univ.reps[:D] == [0, 0, 3]
+    @test solves(info, Q) == (Dict(:A => :v1, :D => :v1), 1)
+
+    # what is admissible is the relaxation's to say, not the query's: lifting
+    # the bound revives the best classes, and the descent has to reach them —
+    # again in one solve, since the hint moves with the relaxation
+    rp = relax(univ, Q, Symbol[], relaxations(Q))
+    sat = SAT(univ)
+    try
+        n = sat.solves
+        @test resolve(sat, rp) == Dict(:A => :v3, :D => :v3, :B => :w1)
+        @test sat.solves - n == 1
+    finally
+        finalize(sat)
+    end
+
+    # the improvement clause keeps an emptied class in: its literal is false at
+    # level 0 and costs nothing. Here the admissible best class conflicts with
+    # a requirement, so the model lands below it and the loop runs — probe the
+    # best (unsatisfiable), then demand something better than what it has
+    # (unsatisfiable), three solves with the feasibility one — and the universe
+    # with the forbidden version deleted outright takes exactly the same three
+    bounded = Dict(
+        :A => PkgData([:v3, :v2, :v1], Dict(:v3 => [:B]),
+            Dict(:v2 => Dict(:E => Symbol[]))),
+        :B => PkgData([:w1], NODEPS, NOCOMP),
+        :E => PkgData([:e1], NODEPS, NOCOMP),
+    )
+    deleted = Dict(
+        :A => PkgData([:v2, :v1], NODEPS, Dict(:v2 => Dict(:E => Symbol[]))),
+        :E => PkgData([:e1], NODEPS, NOCOMP),
+    )
+    want = (Dict(:A => :v1, :E => :e1), 3)
+    @test solves(pkg_info(bounded, [:A, :E]),
+        Problem([:A, :E]; compat = Dict(:A => [:v2, :v1]))) == want
+    @test solves(pkg_info(deleted, [:A, :E]), Problem([:A, :E])) == want
 end
 
 # the versions a universe can still name but no longer offers


### PR DESCRIPTION
Closes #60.

A user constraint that empties a class reaches the solver as one unit clause forbidding it. The descent then went on probing that class as if it were choosable: `optimize_version!` assumed the top-ranked class, and the layer's joint probe assumed the top-ranked class of every package in the layer, so one emptied class failed the probe for the whole layer and the layer fell back to one solve per package. Every such solve was a guaranteed refutation of something the instance already stated at level 0.

## What changes

- **A solve counter.** `sat.solves` counts every time picosat is asked to solve. This is the instrument the issue's measurements were missing: wall time could not separate a wasted probe from a genuinely harder problem, and a solve count can.
- **The descent starts from the best class the query admits.** Both probes now ask `hinted_class` for the best class the representatives in force admit, which is the same question the phase hints already ask. Which representatives are in force is threaded in as `reps`, alongside `ord`, because `sat.reps` is wrong exactly where it matters: a relaxation answered on the query's instance swaps in its own deactivations, and a class the query emptied is admissible there. The relaxed entry point passes `rp.reps`; everything else defaults to the query's own.
- **The improvement clause is left as it was.** Once `best` is admissible and the package is not there yet, the clause always names an admissible class, and an emptied literal in it is false at level 0 and costs nothing.
- **A test** that a query emptying the two best classes of each required package resolves in exactly the one solve the unconstrained query takes, that the relaxation lifting the bound reaches the revived classes in one solve, and that an improvement loop passing an emptied class costs what the universe with that version deleted costs.

## Measurement

General registry, descent only (one `SAT(univ)` per configuration, `resolve(sat, reqs; restore = true)`, min of 5 after a warmup), six packages of each solution bounded to below the version chosen so that the bounds bind but choice remains. Solves per resolve at steady state.

| query | unconstrained | constrained, before | constrained, after |
|---|---|---|---|
| JuMP | 1 | 3 | **1** |
| Makie | 19 | 28 | **21** |
| DifferentialEquations | 5 | 12 | **5** |
| Flux | 1 | 13 | **5** |
| Plots | 15 | 58 | **54** |

Wall time in the same runs, min of 5 on a warm instance:

| query | unconstrained | constrained, before | constrained, after |
|---|---|---|---|
| JuMP | 0.03 ms | 0.03 ms | 0.02 ms |
| Makie | 2.4 ms | 3.31 ms | 2.53 ms |
| DifferentialEquations | 2.5 ms | 3.28 ms | 2.60 ms |
| Flux | 0.07 ms | 0.84 ms | 0.56 ms |
| Plots | 0.56 ms | 1.77 ms | 1.66 ms |

These absolute times are far smaller than the ones in the issue's last measurement comment, which describes the same method, and I could not reconcile the two. The solve counts do not depend on how the timing was set up, which is why the counter is the instrument this PR adds.

Answers are byte-identical before and after, constrained and unconstrained, for all five queries.

The remaining excess is the descent solving a genuinely different problem, which closes the caveat every measurement on the issue had to leave open. Where the bounds move only the six bounded packages (JuMP, DifferentialEquations), the constrained resolve now costs exactly what the unconstrained one does. Where they move unbounded packages too or change the dependency closure, the extra solves are real questions: Makie's bounds move 7 packages, Flux's move 8 and drop one, and Plots' move 23, add 15 and drop 6.

## Tests

The full suite passes. This branch is stacked on #116, which fixes the two Julia 1.13.0 failures that `main`'s CI has today (the yanked-packages resolve and the prerelease assertion in the bin/ tests); the three commits here touch only `src/` and `test/class_space.jl`. GitHub retargets this PR to `main` when #116 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hyi2aKkUnkd9HA2hS9YChk
