### PR TITLE
Make bin/ resolve on Julia 1.13

### DIFF
--- a/.github/workflows/stdlibs.yml
+++ b/.github/workflows/stdlibs.yml
@@ -40,7 +40,7 @@ jobs:
         # rather than derived: it changes about once a year, and the
         # `manifests` job below fails when a released Julia is missing from
         # bin/, which is the same moment this list needs a new entry.
-        version: ['1.9', '1.10', '1.11', '1.12']
+        version: ['1.9', '1.10', '1.11', '1.12', '1.13']
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/bin/Manifest-v1.13.toml
+++ b/bin/Manifest-v1.13.toml
@@ -1,0 +1,251 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.13.0"
+manifest_format = "2.1"
+project_hash = "1a7459ec991893a00bd614db909bf08acd681ebe"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.5.5+2"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.HistoricalStdlibVersions]]
+deps = ["Pkg", "PrecompileTools"]
+git-tree-sha1 = "e2c444d79d406f80f316b779761eef0cf17fc137"
+registries = "General"
+uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
+version = "2.0.7"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+registries = "General"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "88352712893ec50bee3680605891eaf0e9ed6368"
+registries = "General"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.8.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "1.0.0"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "Zstd_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.18.0+1"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.1+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.103+0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2026.8.13"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.6+0"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.46.0+0"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools"]
+git-tree-sha1 = "663e8b48b789916221e0765393b289ca6c88f24e"
+registries = "General"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "3.0.0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "Zstd_jll", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.13.0"
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+    [deps.Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+registries = "General"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+registries = "General"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.Resolver]]
+deps = ["Serialization", "libpicosat_jll"]
+path = ".."
+uuid = "ecd60e94-5748-11e9-04dc-1fe0f95e4121"
+version = "0.2.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "1.0.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
+registries = "General"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.5"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.Zstd_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.7+1"
+
+[[deps.libpicosat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "cbda9296ecfdf9d9805a512845471d584e5fbb75"
+registries = "General"
+uuid = "6b231c3b-13f8-5ced-86ae-8860c7f75d86"
+version = "965.0.2+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.67.1+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.8.2+0"
+
+[registries.General]
+url = "https://github.com/JuliaRegistries/General.git"
+uuid = "23338594-aafe-5451-b93e-139f81909106"

--- a/bin/Registries.jl
+++ b/bin/Registries.jl
@@ -543,6 +543,24 @@ function registry_provider(
         # The upgradable stdlibs get the same treatment even though no pin makes
         # them conflict: a bundled version must be installable on the Julia that
         # bundles it whether or not that Julia insists on it.
+        #
+        # The same disagreement arises in a registry version's bounds on the
+        # *other* stdlibs. A stdlib's copy in Julia can move on without its
+        # registered version moving, so the registry's entry for a version
+        # number and the copy a Julia ships under that number need not agree:
+        # Julia 1.13.0 bundles Downloads 1.7.0 with `LibCURL = "0.6, 1"` in its
+        # Project.toml, beside the LibCURL 1.0.0 it pins, while General's
+        # Downloads 1.7.0 still says `LibCURL = "0.6"` -- and LibCURL 1.0.0 is
+        # not registered at all. Taken from the registry, that bound makes
+        # Downloads, and Pkg through it, unresolvable on the Julia that ships
+        # them. So a registry version is widened on those bounds too, by the
+        # version of the bounded stdlib that each bundling Julia ships: the
+        # bundled set is installed together by construction, so every pair in
+        # it is compatible whatever the registry says. As with `julia`, this is
+        # widening rather than replacement -- the registry bound still governs
+        # on the Julias that bundle neither. What it admits is a pair of
+        # versions, wherever both are available; for a version that exists only
+        # because a Julia bundles it, that is exactly the Julias that bundle it.
         if uuid in keys(bundlers)
             bundlers_u = bundlers[uuid]
             by_patch_u = by_patch[uuid]
@@ -565,6 +583,21 @@ function registry_provider(
                     comp_v = get!(()->valtype(comp)(), comp, v)
                     comp_v[JULIA_UUID] =
                         get(comp_v, JULIA_UUID, VersionSpec("*")) ∪ julias
+                    # ... and its bounds on the stdlibs those Julias ship by the
+                    # versions they ship (only the bounded ones: a dependency
+                    # with no bound is already unbounded)
+                    bounded = [d for d in keys(comp_v) if d != JULIA_UUID]
+                    isempty(bounded) && continue
+                    for julia_ver in JULIA_VERSIONS
+                        julia_ver in julias || continue
+                        shipped = stdlib_snapshot(julia_ver)
+                        for d in bounded
+                            info = get(shipped, d, nothing)
+                            info === nothing && continue
+                            shipped_ver = something(info.version, julia_ver)
+                            comp_v[d] = comp_v[d] ∪ VersionSpec(shipped_ver)
+                        end
+                    end
                 end
             end
         end

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -667,11 +667,23 @@ end
     # that Julia bundles.
     @testset "the julia universe is the whole universe" begin
         pd = Resolver.pkg_data(reg, [JULIA_UUID])[JULIA_UUID]
-        # every Julia there is, 0.x and the prerelease included -- the admission
-        # kinds and the bound are what narrow it
+        # every Julia there is, 0.x included -- the admission kinds and the
+        # bound are what narrow it
         @test length(pd.versions) == length(Registries.JULIA_VERSIONS)
         @test any(v -> v.major == 0, pd.versions)
-        @test any(v -> !isempty(v.prerelease), pd.versions)
+        # ... prereleases too, under the one rule Registries.jl applies to the
+        # release list: a prerelease is kept only while its release is still
+        # unreleased, and then only the newest prerelease of that patch. Stated
+        # against the raw release list rather than as "some prerelease
+        # survives", since that depends on where the release cycle stands on
+        # the day -- 1.13.0 shipping retired 1.13.0-rc4.
+        raw = VersionNumber.(keys(Registries.julia_versions_data))
+        released = Set(v for v in raw if isempty(v.prerelease))
+        newest_of(v) = maximum(w for w in raw if Base.thispatch(w) == Base.thispatch(v))
+        expected_pre = Set(v for v in raw if !isempty(v.prerelease) &&
+                           Base.thispatch(v) ∉ released && v == newest_of(v))
+        @test Set(v for v in pd.versions if !isempty(v.prerelease)) == expected_pre
+        @test all(v -> v ∈ pd.versions, released)
 
         # ... and each of them still pins the stdlibs it bundles, so the pins are
         # per candidate Julia as before (LinearAlgebra is versioned with Julia)

--- a/bin/test/runtests.jl
+++ b/bin/test/runtests.jl
@@ -47,6 +47,13 @@ const LIBMPDEC_JLL = UUID("7106de7a-f406-5ef1-84f7-3345f7341bd2")
 # MbedTLS_jll is a stdlib of Julia 1.10 but not of 1.11 and later, so it tells
 # the target Julia's stdlib set apart from the host's.
 const MBEDTLS_JLL = UUID("c8ffd9c3-330d-5841-b78e-0817d7145fa1")
+# Julia 1.13.0 bundles Downloads 1.7.0 beside a LibCURL 1.0.0 that is not
+# registered, while General's Downloads 1.7.0 bounds LibCURL at 0.6 -- the copy
+# Julia ships moved on without its registered version moving. Pkg depends on
+# Downloads, so this is what decides whether Pkg resolves on 1.13.
+const DOWNLOADS = UUID("f43a241f-c20a-4ad4-852c-f6b1247861c6")
+const LIBCURL = UUID("b27032c2-a3e7-50c8-80cd-2d36dbcbfd21")
+const PKG = UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f")
 
 # Load packages from the installed registries (mirrors bin/resolve.jl).
 const packages = Dict{UUID,Vector{PkgEntry}}()
@@ -217,6 +224,33 @@ end
         @test resolves([COMPILER_SUPPORT_LIBRARIES_JLL, JULIA_UUID]; julia = VersionSpec("1.10"))
         # Realistic reproducer: LinearAlgebra pulls in the same stack transitively.
         @test resolves([LINEAR_ALGEBRA, JULIA_UUID]; julia = VersionSpec("1.10.8"))
+    end
+
+    # The same disagreement, in a registered version's bound on *another*
+    # stdlib: Julia 1.13.0 bundles Downloads 1.7.0 with `LibCURL = "0.6, 1"` in
+    # its Project.toml, next to the LibCURL 1.0.0 it pins, but General's
+    # Downloads 1.7.0 still says `LibCURL = "0.6"` -- and LibCURL 1.0.0 is not
+    # registered at all. Taken from the registry, that bound makes Downloads,
+    # and Pkg through it, unresolvable on the Julia that ships them. The
+    # provider must widen the bound by the version the bundling Julia ships,
+    # and only by that: the registry bound still governs everything else. Julia
+    # 1.13.0 is a frozen release, so what it bundles never changes; the registry
+    # entry may yet be corrected, which only makes the widening a no-op.
+    @testset "stdlib compat on other stdlibs is widened, not cleared" begin
+        pd = Resolver.pkg_data(reg, [DOWNLOADS])[DOWNLOADS]
+        spec = pd.compat[v"1.7.0"][LIBCURL]
+        @test v"1.0.0" ∈ spec # what 1.13.0 ships (this is the fix)
+        @test v"0.6.4" ∈ spec # the registry bound is kept ...
+        @test v"0.5.2" ∉ spec # ... and still excludes what it excluded
+        # a version nothing ships beside LibCURL 1.0.0 keeps the registry bound
+        # as is: Downloads 1.6.0 ships with 1.11 and early 1.12, LibCURL 0.6.x
+        @test v"1.0.0" ∉ pd.compat[v"1.6.0"][LIBCURL]
+    end
+
+    # End-to-end: Pkg, and so anything at all, must resolve on Julia 1.13.
+    @testset "Pkg resolves on Julia 1.13" begin
+        @test resolves([PKG, JULIA_UUID]; julia = VersionSpec("1.13.0"))
+        @test resolves([PKG, JULIA_UUID]; julia = VersionSpec("1.13"))
     end
 
     # Issue #54: a registry compat entry may name a package that is not a


### PR DESCRIPTION
Julia 1.13.0 shipped, and CI's "Julia 1" jobs now run it. Two pre-existing failures surfaced on #115's CI; both are `main`'s, and this fixes them so that PR and every later one can go green.

## The resolver could not resolve Pkg on Julia 1.13

The yanked-packages test resolves a project with `--julia=1.13` and got:

```
Conflict 1: Pkg
  • Pkg requires julia ≤1.12.7 (through LibCURL and Downloads)
  • your compat leaves julia 1.13.0
```

Julia 1.13.0 bundles Downloads 1.7.0 with `LibCURL = "0.6, 1"` in its own Project.toml, beside the LibCURL 1.0.0 it pins. The General registry's Downloads 1.7.0 entry predates that and still says `LibCURL = "0.6"`, and LibCURL 1.0.0 is not registered at all, so it exists in the universe only as a bundled version admitted on exactly Julia 1.13.0. The provider prefers registry data for a version the registry has, so Downloads 1.7.0 carried the stale bound, and with 1.13.0 pinning LibCURL to 1.0.0, Downloads, and Pkg through it, and so everything, was unresolvable there. The 1.13.0 stanza of HistoricalStdlibVersions is right; the registry entry is what is behind.

This is the same disagreement the `julia`-compat widening already handles (CompilerSupportLibraries_jll 1.1.1 on 1.10.8), showing up in a registered version's bound on another stdlib. The widening now applies to those bounds too: a registry version bundled by some Julias has each bound that names a stdlib widened by the version of that stdlib each of those Julias ships. The bundled set is installed together by construction, so every pair in it is compatible whatever the registry says. As before it widens rather than replaces, so the registry bound still governs on Julias that bundle neither, and only bounds that exist are touched.

Regression tests pin the shape of it on Downloads 1.7.0: its bound admits the LibCURL 1.0.0 that 1.13.0 ships, keeps 0.6.4, still excludes 0.5.2, and Downloads 1.6.0 is left alone; and Pkg resolves on Julia 1.13.

## The "julia universe" test asserted a fact about the day

It required some prerelease Julia to survive the release-list filter. The filter keeps a prerelease only while its release is unreleased, so 1.13.0 shipping retired 1.13.0-rc4 and nothing survived. The test now states the rule: from the raw release list, the surviving prereleases are exactly those whose patch has no release and that are the newest of their patch, and every release is present.

## Housekeeping

`bin/Manifest-v1.13.toml` is added, written by Julia 1.13.0 itself with the Resolver path made relative like the others', and `'1.13'` joins the stdlib snapshot matrix in stdlibs.yml. `bin/update_manifests.jl --check` now reports every supported minor covered. Without the manifest 1.13 fell back through the symlink to 1.9's pins, which happened to work only because every manifest pins the same snapshot release.

## Verification

- The yanked-packages resolve with `--julia=1.13` succeeds under Julia 1.12.6 and under 1.13.0, writing a manifest with Downloads 1.7.0 and LibCURL 1.0.0.
- bin/ suite under Julia 1.12.6: 192 of 192 pass. Under Julia 1.13.0, with the new manifest: 192 of 192 pass.
- Full package suite under Julia 1.12.6: passes, including the yanked-packages and bin/ tooling regression testsets that fail on `main`.
- `bin/check_stdlibs.jl` under 1.13.0: the pinned snapshot describes the running Julia.
- `bin/update_manifests.jl --check`: every supported Julia minor has a manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hyi2aKkUnkd9HA2hS9YChk
